### PR TITLE
chore: add CI workflow for Python backend (FastAPI)

### DIFF
--- a/.github/workflows/python-backend-ci.yml
+++ b/.github/workflows/python-backend-ci.yml
@@ -1,0 +1,38 @@
+name: Python Backend CI
+
+on:
+  push:
+    paths:
+      - "python_backend/**"
+  pull_request:
+    paths:
+      - "python_backend/**"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install dependencies
+        working-directory: python_backend
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Download spaCy model
+        working-directory: python_backend
+        run: |
+          python -m spacy download en_core_web_lg
+
+      - name: Run tests
+        working-directory: python_backend
+        run: |
+          pytest -q


### PR DESCRIPTION
Resolves #53

Adds a GitHub Actions CI workflow for the Python backend.

This workflow:
- Installs Python dependencies from requirements.txt
- Downloads the spaCy `en_core_web_lg` model
- Runs the Python test suite using pytest
- Fails the CI if any test fails
- Runs only when files under `python_backend/**` are modified
