### PR TITLE
docs: add Pull Request template for contributors

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,41 @@
+## ✅ Summary
+Please provide a concise summary of the changes introduced by this Pull Request.
+
+---
+
+## 🔗 Linked Issue
+Use a GitHub keyword to auto-close the issue:
+
+
+Replace `<issue_number>` with the correct issue ID.
+
+---
+
+## 🖼️ Screenshots (if applicable)
+If this PR includes UI changes, attach screenshots or screen recordings here.
+
+---
+
+## 🧪 Testing Instructions
+Describe how reviewers can test the changes:
+
+- [ ] Step 1
+- [ ] Step 2
+- [ ] Step 3
+
+---
+
+## ✅ Checklist
+Make sure you’ve completed all of the following before submitting:
+
+- [ ] Code follows repository guidelines  
+- [ ] Prettier formatting applied  
+- [ ] Lint checks pass  
+- [ ] All tests pass successfully  
+- [ ] Documentation updated (if needed)  
+- [ ] Linked the correct issue number  
+
+---
+
+## 📘 Additional Notes
+Add any extra notes or context for reviewers here (optional).


### PR DESCRIPTION
Resolves #57

This Pull Request adds a standardized Pull Request template to improve the quality and consistency of contributions across the repository.

### What’s Included
- A new `PULL_REQUEST_TEMPLATE.md` file placed under `.github/`
- Sections for summary, linked issues, screenshots, testing steps, a checklist, and additional notes
- Auto-closing issue integration using GitHub keywords

### Why This Matters
Having a PR template ensures contributors follow a clear structure, making reviews faster, cleaner, and more consistent.

### Testing
- Verified that GitHub automatically applies this template on new pull requests.
