### PR TITLE
fix(backend): replace hardcoded Tesseract path with cross-platform detection

### DIFF
--- a/python_backend/main.py
+++ b/python_backend/main.py
@@ -13,6 +13,8 @@ from pytesseract import Output
 import numpy as np
 from PIL import Image
 import io
+import shutil
+import os
 
 # Presidio imports for advanced image anonymization
 try:
@@ -39,8 +41,32 @@ app.add_middleware(
 chroma_client = chromadb.PersistentClient(path="./chroma_db")
 collection = chroma_client.get_or_create_collection(name="new_user_data")
 
-# Tesseract path for macOS (installed via Homebrew)
-pytesseract.pytesseract.tesseract_cmd = '/opt/homebrew/bin/tesseract'
+# 1. Cross-platform Tesseract detection
+tesseract_cmd = os.getenv('TESSERACT_CMD') or shutil.which('tesseract')
+
+if not tesseract_cmd:
+    common_paths = [
+        '/opt/homebrew/bin/tesseract',
+        '/usr/local/bin/tesseract',
+        '/usr/bin/tesseract',
+        r'C:\Program Files\Tesseract-OCR\tesseract.exe',
+    ]
+    for path in common_paths:
+        if os.path.isfile(path):
+            tesseract_cmd = path
+            break
+
+tesseract_available = False
+if tesseract_cmd:
+    try:
+        pytesseract.pytesseract.tesseract_cmd = tesseract_cmd
+        pytesseract.get_tesseract_version()
+        tesseract_available = True
+        print(f"Tesseract verified: {tesseract_cmd}")
+    except Exception:
+        print(f"Tesseract found at {tesseract_cmd} but failed to execute.")
+else:
+    print("Tesseract not found. Image anonymization will not work.")
 
 try:
     nlp = spacy.load("en_core_web_lg")  # Updated to use large model for better accuracy
@@ -66,14 +92,6 @@ if presidio_available:
     except Exception as e:
         print(f"Warning: Failed to initialize Presidio engines: {str(e)}")
         presidio_available = False
-
-
-try:
-    pytesseract.get_tesseract_version()
-    tesseract_available = True
-except Exception:
-    print("Warning: Tesseract OCR not found. Image anonymization will not work.")
-    tesseract_available = False
 
 PHI_LABELS = {"PERSON", "ORG", "GPE", "DATE", "LOC", "FAC", "NORP"}
 


### PR DESCRIPTION
## Description
Replaced the hardcoded macOS-specific Tesseract path in the Python backend with a cross-platform detection system.  
The app now checks for:
- `TESSERACT_CMD` environment variable
- System PATH for `tesseract`
- Common installation directories on Linux, macOS, and Windows

## Linked Issue
Fixes #95  

## How to Test Locally
1. Ensure Tesseract is installed on your machine.
2. Run `python python_backend/main.py`.
3. Check the logs to see if "Tesseract verified" appears with the correct path for your OS.

## PR Checklist
- [x] PR targets the main branch
- [x] Linked issue: Closes #95
- [x] Clear description of what changed and why
- [x] How to test locally (steps) and expected behavior
- [x] Code formatted and linted