### PR TITLE
fix: rename duplicate store_data_enhanced function to store_data

### DIFF
--- a/python_backend/main.py
+++ b/python_backend/main.py
@@ -329,9 +329,9 @@ async def anonymize_image_presidio_only(file: UploadFile = File(...)):
 
 
 @app.post("/store")
-async def store_data_enhanced(request: StoreWithContentRequest):
+async def store_data(request: StoreWithContentRequest):
     """
-    Enhanced storage with both metadata and content vectors
+    Store document data with metadata and content vectors
     """
     try:
         print(f"Received enhanced storage request: {request.dataset_title}")


### PR DESCRIPTION
The /store and /store_enhanced route handlers both had the same function name 'store_data_enhanced'. In Python, the second definition silently overwrites the first, causing /store to use the wrong function body.

Renamed the /store handler from store_data_enhanced to store_data so each route has a unique handler name.

Closes #141 