### PR TITLE
Add n_results parameter to /search endpoint

### DIFF
--- a/python_backend/main.py
+++ b/python_backend/main.py
@@ -85,6 +85,7 @@ class StoreRequest(BaseModel):
 
 class SearchRequest(BaseModel):
     query: str
+    n_results: Optional[int] = 5
 
 class FilterRequest(BaseModel):
     filters: Dict[str, Any]
@@ -312,7 +313,7 @@ async def search_data(request: SearchRequest):
     try:
         search_results = collection.query(
             query_texts=[request.query],
-            n_results=5,
+            n_results=request.n_results,
             include=["documents", "metadatas", "distances"]
         )
         


### PR DESCRIPTION
## Summary

The `POST /search` endpoint hardcodes `n_results=5`, giving callers no way to control the number of returned results. This is inconsistent with the `/filter` and `/search_with_filter` endpoints, which both accept `n_results`.

## Changes

1. Added `n_results: Optional[int] = 5` to the `SearchRequest` Pydantic model
2. Updated the `/search` endpoint to use `request.n_results` instead of the hardcoded value

The default value of 5 preserves backwards compatibility — existing clients that don't send `n_results` get the same behavior as before.

## Before / After

**Before:**
```python
class SearchRequest(BaseModel):
    query: str

# In endpoint:
n_results=5,  # hardcoded
```

**After:**
```python
class SearchRequest(BaseModel):
    query: str
    n_results: Optional[int] = 5

# In endpoint:
n_results=request.n_results,  # from request
```

Fixes #160