### PR TITLE
fix(anonymize): remove unreachable dead code referencing undeclared part

### DIFF
--- a/javascript_backend/controllers/anonymizeController.js
+++ b/javascript_backend/controllers/anonymizeController.js
@@ -297,33 +297,6 @@ const anonymizeFile = async (req, res) => {
       type: "buffer",
     });
 
-             const extractedContent = await extractFileContent(
-                cleanedWorkbook,
-                req.file.originalname,
-                req.body.datasetTitle || ''
-            );
-
-            // Return both files as JSON response
-            const timestamp = Date.now();
-            return res.json({
-                success: true,
-                message: 'File anonymized successfully with preview',
-                files: {
-                    main: {
-                        data: outputBuffer.toString('base64'),
-                        filename: `anonymized_${originalFileName}`,
-                        contentType: outputMimeType
-                    },
-                    preview: {
-                        data: previewBuffer.toString('base64'),
-                        filename: `preview_${originalFileName}`,
-                        contentType: outputMimeType
-                    }
-                },
-                extractedContent: extractedContent,  // Add this line
-                extractionStatus: "success"
-            });
-        }
     // Generate preview if requested
     if (generatePreview) {
       const previewWorkbook = XLSX.utils.book_new();
@@ -398,21 +371,21 @@ const anonymizeFile = async (req, res) => {
 };
 
 const extractFileContent = async (workbook, originalFileName, datasetTitle = "") => {
-    /**
-     * Extract content from anonymized file for enhanced search
-     * Returns extracted content as text
-     */
-    try {
-        const ContentExtractor = require('./contentExtractorController');
-        const extractedContent = ContentExtractor.extractSpreadsheetContent(
-            workbook,
-            datasetTitle
-        );
-        return extractedContent;
-    } catch (error) {
-        console.error('Error extracting content:', error);
-        return ""; // Return empty string on error, don't fail the upload
-    }
+  /**
+   * Extract content from anonymized file for enhanced search
+   * Returns extracted content as text
+   */
+  try {
+    const ContentExtractor = require('./contentExtractorController');
+    const extractedContent = ContentExtractor.extractSpreadsheetContent(
+      workbook,
+      datasetTitle
+    );
+    return extractedContent;
+  } catch (error) {
+    console.error('Error extracting content:', error);
+    return ""; // Return empty string on error, don't fail the upload
+  }
 };
 
 module.exports = {


### PR DESCRIPTION
## Description
Removes an unreachable dead code block (lines 300–326) in `anonymizeController.js` that references `previewBuffer` before it is declared on line 351. If this block were ever reached, it would throw a `ReferenceError` at runtime.
The block appears to be a leftover from an earlier refactor that added `extractFileContent()` support. The working preview logic already exists in the `if (generatePreview)` branch below it.

### Changes
- Removed 27 lines of dead code from `anonymizeController.js`
- No functional behavior changes — existing preview and anonymization logic is untouched


Closes #162 
