### PR TITLE
fix(api): add input validation to SearchRequest and FilterRequest

### DIFF
--- a/python_backend/main.py
+++ b/python_backend/main.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI, HTTPException, File, UploadFile
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import StreamingResponse
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from typing import Optional, Dict, Any, List
 import chromadb
 import time
@@ -119,12 +119,12 @@ class StoreRequest(BaseModel):
     metadata: Optional[Dict[str, Any]] = {}
 
 class SearchRequest(BaseModel):
-    query: str
-    n_results: Optional[int] = 5
+    query: str = Field(..., min_length=1)
+    n_results: Optional[int] = Field(default=5, ge=1, le=100)
 
 class FilterRequest(BaseModel):
-    filters: Dict[str, Any]
-    n_results: Optional[int] = 10
+    filters: Dict[str, Any] = Field(..., min_length=1)
+    n_results: Optional[int] = Field(default=10, ge=1, le=100)
     
 # Add new request model for enhanced storage
 class StoreWithContentRequest(BaseModel):


### PR DESCRIPTION
## Summary

- Added Pydantic `Field` validators to `SearchRequest` and `FilterRequest` models
- `query`: rejects empty strings (`min_length=1`)
- `n_results`: enforces sane range (`ge=1, le=100`)
- `filters`: rejects empty dicts (`min_length=1`)
- Default values preserved for backwards compatibility

Fixes #165

## Context

Follow-up to PR #161 which added `n_results` to `SearchRequest` without validation. This patch also addresses the pre-existing lack of constraints on `FilterRequest`.

## How to test

```bash
cd python_backend
pip install -r requirements.txt
python -m pytest tests/ -q
```

Manual verification:

```bash
# Should return 422 (empty query)
curl -X POST http://localhost:3002/search \
  -H "Content-Type: application/json" \
  -d '{"query": ""}'

# Should return 422 (n_results out of range)
curl -X POST http://localhost:3002/search \
  -H "Content-Type: application/json" \
  -d '{"query": "test", "n_results": -1}'

# Should return 422 (empty filters)
curl -X POST http://localhost:3002/filter \
  -H "Content-Type: application/json" \
  -d '{"filters": {}}'
```

## Checklist

- [x] PR targets the `dev` branch
- [x] Linked issue: Fixes #165
- [x] Clear description of what changed and why
- [x] How to test locally
- [x] Code formatted and linted