### PR TITLE
fix(contract): prevent ownership hijacking in storeDocument

### DIFF
--- a/prototype/src/DocumentStorage.sol
+++ b/prototype/src/DocumentStorage.sol
@@ -16,6 +16,7 @@ contract DocumentStorage {
     mapping(address => uint256) public earnings;
     
     function storeDocument(string memory ipfsHash, uint256 price, string memory metadata) public {
+        require(documentOwners[ipfsHash] == address(0), "Document already exists");
         userDocuments[msg.sender].push(ipfsHash);
         documentPrices[ipfsHash] = price;
         documentOwners[ipfsHash] = msg.sender;


### PR DESCRIPTION
## Summary

- Added a `require(documentOwners[ipfsHash] == address(0), "Document already exists")` guard at the top of `storeDocument`
- Prevents any caller from overwriting ownership of an already-registered IPFS hash
- Existing documents can no longer be silently hijacked

Fixes #155

## The vulnerability

`storeDocument` unconditionally overwrites `documentOwners[ipfsHash]` with `msg.sender`. An attacker who knows the `ipfsHash` of a high-value dataset can call `storeDocument` with the same hash, redirecting all future `purchaseDocument` earnings to themselves.

```solidity
// Before: no ownership check
function storeDocument(string memory ipfsHash, uint256 price, string memory metadata) public {
    userDocuments[msg.sender].push(ipfsHash);
    documentPrices[ipfsHash] = price;
    documentOwners[ipfsHash] = msg.sender;  // overwrites existing owner
    ...
}
```

## The fix

```solidity
function storeDocument(string memory ipfsHash, uint256 price, string memory metadata) public {
    require(documentOwners[ipfsHash] == address(0), "Document already exists");
    ...
}
```

The `require` reverts the transaction if `documentOwners[ipfsHash]` is already set to a non-zero address, meaning the hash was previously registered. This is consistent with how `updateMetadata` and `deleteDocument` already use `require` for ownership checks.

## How to test

Deploy the contract on a local testnet (Hardhat/Foundry) and verify:

1. **Store a document** as `userA` — should succeed
2. **Store the same hash** as `userB` — should revert with `"Document already exists"`
3. **Store a different hash** as `userB` — should succeed
4. **Delete a document** as `userA`, then **re-store the same hash** as `userB` — should succeed (owner was reset to `address(0)`)

## Checklist

- [x] PR targets the `dev` branch
- [x] Linked issue: Fixes #155
- [x] Clear description of what changed and why
- [x] How to test locally