### PR TITLE
Upgrade: nextjs 16 (phase 2) 

### DIFF
--- a/nextjs-frontend/app/actions.ts
+++ b/nextjs-frontend/app/actions.ts
@@ -29,11 +29,17 @@ interface SearchResponse {
 export async function searchDocuments(params: SearchParams): Promise<SearchResponse> {
   const PYTHON_BACKEND_URL = process.env.NEXT_PUBLIC_PYTHON_BACKEND_URL || 'http://localhost:3002';
 
+  // Input validation: query must be a non-empty string
+  if (!params.query || typeof params.query !== 'string' || params.query.trim().length === 0) {
+    return { success: false, error: 'A valid search query is required' };
+  }
+
   try {
     const response = await fetch(`${PYTHON_BACKEND_URL}/search`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(params),
+      cache: 'no-store', // Prevent caching of PHI search results
     });
 
     if (!response.ok) {
@@ -64,11 +70,17 @@ interface StoreResponse {
 export async function storeMetadata(params: StoreParams): Promise<StoreResponse> {
   const PYTHON_BACKEND_URL = process.env.NEXT_PUBLIC_PYTHON_BACKEND_URL || 'http://localhost:3002';
 
+  // Input validation: required fields must be present
+  if (!params.cid || !params.dataset_title || !params.summary) {
+    return { success: false, error: 'Missing required fields: cid, dataset_title, and summary are required' };
+  }
+
   try {
     const response = await fetch(`${PYTHON_BACKEND_URL}/store`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(params),
+      cache: 'no-store', // Prevent caching of PHI metadata
     });
 
     if (!response.ok) {
@@ -96,6 +108,7 @@ export async function checkHealth(): Promise<HealthResponse> {
     const response = await fetch(`${JS_BACKEND_URL}/api/health`, {
       method: 'GET',
       headers: { 'Content-Type': 'application/json' },
+      cache: 'no-store', // Always fetch fresh health status
     });
 
     if (!response.ok) {

--- a/nextjs-frontend/app/api/proxy/route.ts
+++ b/nextjs-frontend/app/api/proxy/route.ts
@@ -11,11 +11,20 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'URL is required' }, { status: 400 });
     }
 
-    // Determine full URL
-    let fullUrl = url;
+    // SECURITY: Only allow proxying to known internal backends
+    // Reject arbitrary URLs to prevent SSRF attacks
+    if (!url.startsWith('/js/') && !url.startsWith('/py/')) {
+      return NextResponse.json(
+        { error: 'Invalid proxy target. Only /js/ and /py/ prefixes are allowed.' },
+        { status: 403 }
+      );
+    }
+
+    // Determine full URL from allowed prefixes
+    let fullUrl: string;
     if (url.startsWith('/js/')) {
       fullUrl = `${JS_BACKEND_URL}${url.replace('/js', '')}`;
-    } else if (url.startsWith('/py/')) {
+    } else {
       fullUrl = `${PYTHON_BACKEND_URL}${url.replace('/py', '')}`;
     }
 


### PR DESCRIPTION
### Changes

**`app/actions.ts`**
- Added `cache: 'no-store'` to all `fetch` calls to prevent caching of PHI data (search results, metadata, health checks).
- Added input validation:
  - `searchDocuments` rejects empty queries.
  - `storeMetadata` requires `cid`, `dataset_title`, and `summary`.

**`app/api/proxy/route.ts`**
- Fixed SSRF vulnerability.
- Proxy now only allows URLs starting with `/js/` or `/py/`.
- Blocks arbitrary external URL fetching (mitigates internal service enumeration risk).

### Why
- Prevent CDN/server caching of sensitive PHI data.
- Eliminate open proxy attack vector.

### Verification
- `npm run build` passes (12/12 pages, zero errors).
<img width="714" height="173" alt="Screenshot 2026-02-26 105041" src="https://github.com/user-attachments/assets/393aca71-3ab3-4e86-b7b2-02a34e2610fa" />

Note to maintainers: @pradeeban @karthiksathishjeemain This completes the phase 2 of #133 and strengthens against any vulnerabilities with the latest stable patch. The next(last) phase would be just testing in real time on dev and little documentation upgrade in `Migration.md`