### PR TITLE
feat: Enable Data Previews for Neuroimaging NIfTI Files (Phase 3)

### DIFF
--- a/python_backend/requirements.txt
+++ b/python_backend/requirements.txt
@@ -33,3 +33,6 @@ flake8
 # This installs both the native libopenslide library and Python bindings
 openslide-python
 httpx
+
+# Neuroimaging support for NIfTI files
+nibabel

--- a/python_backend/services/preview/factory.py
+++ b/python_backend/services/preview/factory.py
@@ -20,6 +20,18 @@ except Exception:
     wsi_available = False
     WsiPreviewGenerator = None
 
+# Try to import NIfTI generator (may fail if NiBabel not available)
+try:
+    from .nifti_generator import NiftiPreviewGenerator
+    nifti_available = True
+except ImportError:
+    nifti_available = False
+    NiftiPreviewGenerator = None
+except Exception:
+    # Handle other import errors
+    nifti_available = False
+    NiftiPreviewGenerator = None
+
 
 class PreviewFactory:
     """
@@ -31,7 +43,7 @@ class PreviewFactory:
     
     # Registry of available generators (ordered by priority)
     # WSI generator checked first for specific extensions (.svs, .ndpi, etc.)
-    # Then DICOM, then standard images
+    # Then NIfTI, then DICOM, then standard images
     _generators: List[Type[PreviewGenerator]] = [
         DicomPreviewGenerator,
         ImagePreviewGenerator,
@@ -43,6 +55,12 @@ class PreviewFactory:
         # This ensures .svs, .ndpi, etc. are handled by WSI generator
         # before falling back to other generators
         _generators.insert(0, WsiPreviewGenerator)
+    
+    # Add NIfTI generator if available (after WSI, before DICOM)
+    if nifti_available and NiftiPreviewGenerator is not None:
+        # Insert after WSI (index 1 if WSI present, index 0 otherwise)
+        _nifti_idx = 1 if wsi_available else 0
+        _generators.insert(_nifti_idx, NiftiPreviewGenerator)
     
     @classmethod
     def create_generator(cls, filename: str = None, content_type: str = None) -> PreviewGenerator:

--- a/python_backend/services/preview/nifti_generator.py
+++ b/python_backend/services/preview/nifti_generator.py
@@ -1,0 +1,191 @@
+"""
+NIfTI (Neuroimaging) preview generator for brain scan files.
+Supports formats like .nii and .nii.gz using the NiBabel library.
+"""
+import os
+import io
+import tempfile
+import numpy as np
+from typing import Tuple
+from fastapi import HTTPException
+from fastapi.responses import StreamingResponse
+from PIL import Image
+
+# Try to import nibabel
+nibabel_available = False
+nib = None
+
+
+def _try_import_nibabel():
+    """
+    Try to import nibabel. This works if:
+    - Installed via pip: pip install nibabel
+    - Installed via conda: conda install -c conda-forge nibabel
+    """
+    global nib, nibabel_available
+    try:
+        import nibabel
+        nib = nibabel
+        nibabel_available = True
+        return True
+    except ImportError:
+        return False
+    except Exception as e:
+        print(f"Warning: nibabel import failed: {str(e)}")
+        return False
+
+
+# Try to import nibabel at module load time
+if not _try_import_nibabel():
+    print("Warning: NiBabel not available. NIfTI preview will not work.")
+    print("Install with: pip install nibabel")
+
+from .base import PreviewGenerator
+
+
+class NiftiPreviewGenerator(PreviewGenerator):
+    """
+    Generator for NIfTI neuroimaging files (MRI/fMRI brain scans).
+    Supports formats: .nii, .nii.gz
+    
+    Extracts the middle axial slice from the 3D volume and returns
+    it as a PNG image for preview.
+    """
+
+    # Supported NIfTI extensions
+    SUPPORTED_EXTENSIONS = {'nii', 'nii.gz'}
+
+    def __init__(self):
+        """Initialize the NIfTI generator."""
+        if not nibabel_available:
+            print("Warning: NiBabel not available. NIfTI preview will not work.")
+            print("Install with: pip install nibabel")
+
+    def can_handle(self, filename: str = None, content_type: str = None) -> bool:
+        """
+        Check if this is a NIfTI file.
+        """
+        if not nibabel_available:
+            return False
+
+        # Check by filename extension (most reliable for NIfTI)
+        if filename:
+            lower_name = filename.lower()
+            # Check for .nii.gz first (compound extension)
+            if lower_name.endswith('.nii.gz'):
+                return True
+            # Then check for .nii
+            ext = lower_name.split('.')[-1] if '.' in lower_name else ''
+            if ext == 'nii':
+                return True
+
+        return False
+
+    def generate_preview(self, file_contents: bytes, filename: str = None, content_type: str = None) -> Tuple[StreamingResponse, str]:
+        """
+        Generate preview image from NIfTI file.
+        
+        Extracts the middle axial slice from the 3D volume, normalizes
+        pixel values to 0-255, and returns a PNG image.
+        
+        NiBabel requires a file path, so we save to a temporary file first.
+        """
+        if not nibabel_available or nib is None:
+            raise HTTPException(
+                status_code=503,
+                detail="NiBabel not available. Install via: pip install nibabel"
+            )
+
+        # Create temporary file to store the NIfTI file
+        # NiBabel needs a file path, not bytes
+        temp_file = None
+        try:
+            # Determine file suffix for temp file
+            if filename and filename.lower().endswith('.nii.gz'):
+                suffix = '.nii.gz'
+            else:
+                suffix = '.nii'
+
+            # Create temporary file with appropriate extension
+            temp_fd, temp_path = tempfile.mkstemp(suffix=suffix, prefix='nifti_preview_')
+            temp_file = temp_path
+
+            # Write file contents to temporary file
+            with os.fdopen(temp_fd, 'wb') as f:
+                f.write(file_contents)
+
+            # Load the NIfTI file using NiBabel
+            try:
+                img = nib.load(temp_path)
+            except Exception as e:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Could not open NIfTI file with NiBabel: {str(e)}. File may be corrupted or unsupported."
+                )
+
+            try:
+                # Get image data as a numpy array
+                data = img.get_fdata()
+
+                # Handle 4D data (e.g., fMRI time series) by taking the first volume
+                if data.ndim == 4:
+                    data = data[..., 0]
+                elif data.ndim < 3:
+                    raise HTTPException(
+                        status_code=400,
+                        detail=f"NIfTI file has unexpected dimensions: {data.ndim}D. Expected 3D or 4D data."
+                    )
+
+                # Extract the middle axial slice (z-axis)
+                middle_idx = data.shape[2] // 2
+                middle_slice = data[:, :, middle_idx]
+
+                # Rotate 90 degrees for correct anatomical orientation
+                middle_slice = np.rot90(middle_slice)
+
+                # Normalize pixel values to 0-255
+                slice_min = np.min(middle_slice)
+                slice_max = np.max(middle_slice)
+
+                if slice_max == slice_min:
+                    # Constant image - produce a blank (black) preview
+                    normalized = np.zeros_like(middle_slice, dtype=np.uint8)
+                else:
+                    normalized = ((middle_slice - slice_min) / (slice_max - slice_min) * 255.0).astype(np.uint8)
+
+                # Convert to PIL Image (grayscale)
+                preview_image = Image.fromarray(normalized, mode='L')
+
+                # Convert to RGB for consistency with other generators
+                preview_image = preview_image.convert('RGB')
+
+                # Save to PNG buffer
+                img_buffer = io.BytesIO()
+                preview_image.save(img_buffer, format='PNG')
+                img_buffer.seek(0)
+
+                # Return streaming response
+                return StreamingResponse(
+                    io.BytesIO(img_buffer.read()),
+                    media_type="image/png"
+                ), "image/png"
+
+            finally:
+                # NiBabel may keep file handles; ensure cleanup
+                del img
+
+        except HTTPException:
+            raise
+        except Exception as e:
+            raise HTTPException(
+                status_code=500,
+                detail=f"Error processing NIfTI file: {str(e)}"
+            )
+        finally:
+            # Clean up temporary file
+            if temp_file and os.path.exists(temp_file):
+                try:
+                    os.unlink(temp_file)
+                except Exception as e:
+                    # Log but don't fail if cleanup fails
+                    print(f"Warning: Could not delete temporary file {temp_file}: {str(e)}")


### PR DESCRIPTION
@pradeeban @karthiksathishjeemain So this PR implements Phase 3 (the final phase) of our ongoing effort to support previews for diverse healthcare data types in issue #40. Following the success of Phase 1 (DICOM refactor) and Phase 2 (Pathology WSI), this update brings support for **Neuroimaging data**!

### What does this PR do?

It allows users to preview \`.nii\` and \`.nii.gz\` (NIfTI) brain scan files directly on the platform before purchase. To do this, I've added a new \`NiftiPreviewGenerator\` that seamlessly plugs into our existing \`PreviewFactory\` pattern.

Here’s how it works :
1. It safely loads the 3D or 4D NIfTI volume using the \`nibabel\` library.
2. It automatically extracts the **middle axial slice** from the brain scan (so you actually see the brain structure rather than just the top of the skull).
3. It rotates the image 90 degrees so the anatomical orientation looks completely natural to the viewer.
4. It normalizes the scan's raw pixel values to standard 8-bit image data (0-255) and returns a clean, grayscale PNG streaming response.

### Technical Implementation Details

- **Added \`nifti_generator.py\`**: A brand new generator class containing the logic to parse and extract slices from NIfTI files. It follows the exact same safe, dynamic-import structure as our \`wsi_generator\`.
- **Updated \`factory.py\`**: Registered the new NIfTI generator. It now sits gracefully in the priority list: \`WSI -> NIfTI -> DICOM -> Image\`.
- **Updated \`requirements.txt\`**: Added \`nibabel\` as a required dependency. 

### Safety & Compatibility

- **No changes to \`main.py\`!** Because our factory pattern was designed well in Phase 1, the existing \`/simple_preview\` and \`/preview_dicom\` endpoints automatically inherit this new functionality without needing to be touched.
- I've included graceful error handling. If \`nibabel\` fails to install or a file is corrupted, it safely catches the error and returns appropriate fallback responses without crashing the backend.

### How to test this:

1. Check out this branch and run \`pip install -r requirements.txt\` (or just \`pip install nibabel\`).
2. Start the backend.
3. Upload any \`.nii\` or \`.nii.gz\` file via the frontend to test the preview functionality. It should immediately return a PNG image of the middle brain slice!

Looking forward to your feedback on this! Let me know if you need me to adjust the slice extraction logic. And if you want any other ideas or suggestion to include more file types or anything please let me know. I'll be glad to implement those. Thankyou so much. 