### PR TITLE
fix github auto-labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,6 +1,7 @@
 frontend:
   - changed-files:
       - any-glob-to-any-file:
+          - "nextjs-frontend/**"
           - "prototype/**"
 
 backend-js:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,7 +1,12 @@
 name: Auto Labeler
 
 on:
-  pull_request:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
 
 jobs:
   label:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -15,6 +15,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      issues: write
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
### Summary
Hey @pradeeban @karthiksathishjeemain this fixes GitHub auto-labeling failures on PRs one section of issue #107  by updating the labeler config to the schema required by `actions/labeler@v5`.

### Problem
`Auto Labeler` was failing with:
`found unexpected type for label '<label>' (should be array of config options)`

This happened because `.github/labeler.yml` used the old format (plain glob arrays), which is incompatible with v5 config parsing.
### Also Updated  
  - `.github/workflows/labeler.yml` trigger with respect to gitHub’s official labeler action
  - from `pull_request` to `pull_request_target`
  - explicit PR event types: `opened`, `synchronize`, `reopened`, `ready_for_review`