### PR TITLE
fix/purchase-test

### DIFF
--- a/prototype/test/DocumentStorage.test.js
+++ b/prototype/test/DocumentStorage.test.js
@@ -135,7 +135,7 @@ describe("DocumentStorage", function () {
         documentStorage
           .connect(buyer)
           .purchaseDocument(ipfsHash, { value: ethers.utils.parseEther("0.5") })
-      ).to.be.revertedWith("Insufficient payment");
+      ).to.be.revertedWith("Exact price required");
     });
 
     it("Should reject purchase of deleted document", async function () {


### PR DESCRIPTION
Hey @pradeeban @karthiksathishjeemain , recent contract changes caused the contracts tests to fail as the test was never updated to match the contracts's error message
<img width="1226" height="168" alt="image" src="https://github.com/user-attachments/assets/b85b03e2-842b-4178-b68b-22a0f6ae04f6" />
Fixes the stale revert message from "Insufficient payment" to "Exact price required" in test assertion