### PR TITLE
fix: switch multer to disk storage to prevent OOM on file uploads (#119)

### DIFF
--- a/javascript_backend/controllers/anonymizeController.js
+++ b/javascript_backend/controllers/anonymizeController.js
@@ -1,12 +1,22 @@
 const multer = require("multer");
 const { Worker } = require("worker_threads");
 const path = require("path");
+const fs = require("fs");
+const os = require("os");
+const crypto = require("crypto");
 
-const storage = multer.memoryStorage();
+const storage = multer.diskStorage({
+  destination: (req, file, cb) => {
+    cb(null, os.tmpdir());
+  },
+  filename: (req, file, cb) => {
+    const uniqueName = `upload-${crypto.randomUUID()}-${file.originalname}`;
+    cb(null, uniqueName);
+  },
+});
 const upload = multer({
   storage: storage,
   fileFilter: (req, file, cb) => {
-    // Accept Excel files, CSV, ODS, TSV and other spreadsheet formats
     const allowedMimeTypes = [
       "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", // .xlsx
       "application/vnd.ms-excel", // .xls
@@ -18,7 +28,6 @@ const upload = multer({
       "application/vnd.ms-excel.sheet.binary.macroEnabled.12", // .xlsb
     ];
 
-    // Also check file extension as a fallback
     const allowedExtensions = /\.(xlsx|xls|csv|ods|tsv|xlsm|xlsb)$/i;
 
     if (allowedMimeTypes.includes(file.mimetype) || allowedExtensions.test(file.originalname)) {
@@ -33,11 +42,21 @@ const upload = multer({
     }
   },
   limits: {
-    fileSize: 10 * 1024 * 1024 * 1024, // 10GB limit
+    fileSize: 500 * 1024 * 1024, // 500MB
   },
 });
 
 const anonymizeFile = async (req, res) => {
+  const cleanupTempFile = () => {
+    if (req.file && req.file.path) {
+      fs.unlink(req.file.path, (err) => {
+        if (err && err.code !== "ENOENT") {
+          console.error("Failed to clean up temp file:", err);
+        }
+      });
+    }
+  };
+
   try {
     if (!req.file) {
       return res.status(400).json({
@@ -58,16 +77,21 @@ const anonymizeFile = async (req, res) => {
       walletAddress: walletAddress ? `${walletAddress.substring(0, 6)}...` : "N/A",
     });
 
-    // Offload heavy processing to a Worker Thread
+    const diskBuffer = fs.readFileSync(req.file.path);
+
+    const arrayBuffer = new ArrayBuffer(diskBuffer.length);
+    const fileBuffer = Buffer.from(arrayBuffer);
+    diskBuffer.copy(fileBuffer);
+
     const workerPath = path.join(__dirname, "../workers/anonymizeWorker.js");
 
     const worker = new Worker(workerPath);
 
-    const transferList = [req.file.buffer.buffer];
+    const transferList = [arrayBuffer];
 
     worker.postMessage(
       {
-        fileBuffer: req.file.buffer,
+        fileBuffer: fileBuffer,
         walletAddress,
         generatePreview,
         originalFileName: req.file.originalname,
@@ -76,6 +100,8 @@ const anonymizeFile = async (req, res) => {
     );
 
     worker.on("message", (result) => {
+      cleanupTempFile();
+
       if (!result.success) {
         console.error("Worker error:", result.error);
         return res.status(400).json({
@@ -86,7 +112,6 @@ const anonymizeFile = async (req, res) => {
       const { outputBuffer, previewBuffer, outputMimeType, originalFileName } = result;
 
       if (generatePreview && previewBuffer) {
-        // Return both files as JSON response
         return res.json({
           success: true,
           message: "File anonymized successfully with preview",
@@ -105,7 +130,6 @@ const anonymizeFile = async (req, res) => {
         });
       }
 
-      // Standard response for normal anonymization without preview
       const filename = `phi_anonymized_${originalFileName}`;
       const buffer = Buffer.from(outputBuffer);
 
@@ -117,6 +141,7 @@ const anonymizeFile = async (req, res) => {
     });
 
     worker.on("error", (err) => {
+      cleanupTempFile();
       console.error("Worker thread error:", err);
       res.status(500).json({
         error: "Internal server error occurred while processing the file.",
@@ -129,6 +154,7 @@ const anonymizeFile = async (req, res) => {
       }
     });
   } catch (error) {
+    cleanupTempFile();
     console.error("Error processing file:", error);
 
     if (error.message.includes("Only")) {

--- a/javascript_backend/controllers/ipfsController.js
+++ b/javascript_backend/controllers/ipfsController.js
@@ -1,17 +1,37 @@
 const multer = require("multer");
 const axios = require("axios");
 const FormData = require("form-data");
+const fs = require("fs");
+const os = require("os");
+const crypto = require("crypto");
 
-// Configure multer for memory storage
-const storage = multer.memoryStorage();
+const storage = multer.diskStorage({
+  destination: (req, file, cb) => {
+    cb(null, os.tmpdir());
+  },
+  filename: (req, file, cb) => {
+    const uniqueName = `upload-${crypto.randomUUID()}-${file.originalname}`;
+    cb(null, uniqueName);
+  },
+});
 const upload = multer({
   storage: storage,
   limits: {
-    fileSize: 10 * 1024 * 1024 * 1024, // 10GB limit
+    fileSize: 2 * 1024 * 1024 * 1024, // 2GB
   },
 });
 
 const uploadToIPFS = async (req, res) => {
+  const cleanupTempFile = () => {
+    if (req.file && req.file.path) {
+      fs.unlink(req.file.path, (err) => {
+        if (err && err.code !== "ENOENT") {
+          console.error("Failed to clean up temp file:", err);
+        }
+      });
+    }
+  };
+
   try {
     if (!req.file) {
       return res.status(400).json({
@@ -20,21 +40,20 @@ const uploadToIPFS = async (req, res) => {
     }
 
     const { fileName } = req.body;
-    const encryptedBuffer = req.file.buffer;
 
     console.log("Uploading to IPFS:", {
       fileName,
-      fileSize: encryptedBuffer.length,
+      fileSize: req.file.size,
     });
 
-    // Create form data for Pinata
+    const fileStream = fs.createReadStream(req.file.path);
+
     const formData = new FormData();
-    formData.append("file", encryptedBuffer, {
+    formData.append("file", fileStream, {
       filename: fileName || "encrypted_file",
       contentType: "application/octet-stream",
     });
 
-    // Pinata metadata
     const pinataMetadata = JSON.stringify({
       name: fileName || "Encrypted Document",
       keyvalues: {
@@ -44,13 +63,11 @@ const uploadToIPFS = async (req, res) => {
     });
     formData.append("pinataMetadata", pinataMetadata);
 
-    // Pinata options
     const pinataOptions = JSON.stringify({
       cidVersion: 0,
     });
     formData.append("pinataOptions", pinataOptions);
 
-    // Upload to Pinata
     const pinataResponse = await axios.post(
       "https://api.pinata.cloud/pinning/pinFileToIPFS",
       formData,
@@ -68,13 +85,16 @@ const uploadToIPFS = async (req, res) => {
 
     console.log("IPFS upload successful:", { ipfsHash, fileName });
 
+    cleanupTempFile();
+
     res.json({
       success: true,
       ipfsHash: ipfsHash,
       fileName: fileName,
-      fileSize: encryptedBuffer.length,
+      fileSize: req.file.size,
     });
   } catch (error) {
+    cleanupTempFile();
     console.error("IPFS upload error:", error.response?.data || error.message);
 
     if (error.response?.status === 401) {

--- a/javascript_backend/routes/anonymize.js
+++ b/javascript_backend/routes/anonymize.js
@@ -9,7 +9,7 @@ router.post("/", upload.single("file"), anonymizeFile);
 router.use((error, req, res, next) => {
   if (error.code === "LIMIT_FILE_SIZE") {
     return res.status(400).json({
-      error: "File too large. Maximum size is 10GB.",
+      error: "File too large. Maximum size is 500MB.",
     });
   }
   next(error);

--- a/javascript_backend/routes/ipfs.js
+++ b/javascript_backend/routes/ipfs.js
@@ -9,7 +9,7 @@ router.post("/upload", upload.single("encryptedFile"), uploadToIPFS);
 router.use((error, req, res, next) => {
   if (error.code === "LIMIT_FILE_SIZE") {
     return res.status(400).json({
-      error: "File too large. Maximum size is 10GB.",
+      error: "File too large. Maximum size is 2GB.",
     });
   }
   next(error);


### PR DESCRIPTION
## Summary
Hey @pradeeban @karthiksathishjeemain @avinxshKD 👋 this PR fixes the critical OOM crash risk reported in #119 by switching multer from `memoryStorage()` to `diskStorage()` in both [anonymizeController.js](cci:7://file:///Users/santhil/bio-block/javascript_backend/controllers/anonymizeController.js:0:0-0:0) and [ipfsController.js](cci:7://file:///Users/santhil/bio-block/javascript_backend/controllers/ipfsController.js:0:0-0:0).
## Problem
Both controllers were using `multer.memoryStorage()` with a configured **10GB file size limit**:
```js
const storage = multer.memoryStorage();
const upload = multer({
  storage: storage,
  limits: { fileSize: 10 * 1024 * 1024 * 1024 } // 10GB
});
```
### The Problem

This is a critical stability risk:

- V8 cannot handle single Buffers of this size in the main heap
- Even a few concurrent 500MB uploads would exhaust system RAM
- The Node.js process would crash with an OOM error, taking down the entire backend
- No temp file cleanup existed — if anything went wrong mid-upload, resources leaked silently

---

### What I Changed

**`anonymizeController.js`**
- **Storage:** Switched from `multer.memoryStorage()` → `multer.diskStorage()` with `os.tmpdir()` as destination
- **Unique filenames:** Uses `crypto.randomUUID()` to prevent collisions on concurrent uploads
- **File reading:** Reads from disk via `fs.readFileSync(req.file.path)` instead of `req.file.buffer`
- **Worker thread transfer:** Creates a fresh `ArrayBuffer` copy before transferring to the worker (fixes a `DataCloneError` that occurs because `fs.readFileSync` buffers aren't always transferable in newer Node.js versions)
- **Temp cleanup:** `fs.unlink()` in all exit paths — worker success, worker error, and try/catch
- **Limit:** 10GB → 500MB (healthcare spreadsheets should never be anywhere near 10GB)

**`ipfsController.js`**
- **Storage:** Same `diskStorage` migration as above
- **Streaming to Pinata:** Uses `fs.createReadStream(req.file.path)` instead of passing `req.file.buffer` to FormData — even a 2GB file only uses a small stream buffer in memory, never the full file
- **Temp cleanup:** Same cleanup pattern as anonymize controller
- **Limit:** 10GB → 2GB (encrypted files can be larger, but 10GB in memory is reckless)

**Route files**
- Updated `routes/anonymize.js` error message: `"Maximum size is 10GB"` → `"Maximum size is 500MB"`
- Updated `routes/ipfs.js` error message: `"Maximum size is 10GB"` → `"Maximum size is 2GB"`

---

### Why This Doesn't Break Anything

- API contract is identical — same endpoints, same request/response formats, same field names
- Worker thread receives the same data — still gets a `Buffer`, `anonymizeWorker.js` needed zero changes
- `req.file` metadata unchanged — `originalname`, `size`, `mimetype` are populated by multer regardless of storage type
- No other code references `req.file.buffer` — verified across the entire codebase

---

### Tests

All existing tests pass with zero regressions:

-  57/57 anonymize controller tests (PHI detection, case-insensitive matching, multi-sheet, CSV, edge cases)
-  18/18 IPFS controller tests (upload flow, Pinata error handling, binary content, filenames)
-  4/4 API endpoint tests
```
57 passing (5s)
18 passing (38ms)
4 passing (232ms)
```

Closes #119 