### PR TITLE
feat: add immutable audit logger for HIPAA compliance (#164)

### DIFF
--- a/python_backend/main.py
+++ b/python_backend/main.py
@@ -23,6 +23,7 @@ from eth_account import Account
 
 # Preview factory imports
 from services.preview.factory import PreviewFactory
+from services.audit_logger import AuditLogger
 
 # DICOM imports
 try:
@@ -59,6 +60,7 @@ app.add_middleware(
 
 chroma_client = chromadb.PersistentClient(path="./chroma_db")
 collection = chroma_client.get_or_create_collection(name="new_user_data")
+audit_logger = AuditLogger(chroma_client)
 
 # 1. Cross-platform Tesseract detection
 tesseract_cmd = os.getenv('TESSERACT_CMD') or shutil.which('tesseract')
@@ -281,6 +283,11 @@ async def anonymize_image(file: UploadFile = File(...)):
                 redacted_image_pil.save(img_buffer, format='JPEG', quality=95)
                 img_buffer.seek(0)
                 
+                audit_logger.log_operation(
+                    operation="ANONYMIZE",
+                    details=f"file: {file.filename}, method: presidio",
+                )
+
                 return StreamingResponse(
                     io.BytesIO(img_buffer.read()),
                     media_type="image/jpeg",
@@ -302,6 +309,11 @@ async def anonymize_image(file: UploadFile = File(...)):
         img_buffer = io.BytesIO()
         masked_pil.save(img_buffer, format='JPEG', quality=95)
         img_buffer.seek(0)
+
+        audit_logger.log_operation(
+            operation="ANONYMIZE",
+            details=f"file: {file.filename}, method: legacy",
+        )
 
         return StreamingResponse(
             io.BytesIO(img_buffer.read()),
@@ -416,6 +428,13 @@ async def store_data(request: StoreWithContentRequest):
             
             print(f"Stored {len(content_chunks)} content chunks for document {doc_id}")
         
+        audit_logger.log_operation(
+            operation="STORE",
+            wallet_address=request.metadata.get("owner_address", ""),
+            document_id=doc_id,
+            details=f"CID: {request.cid}, title: {request.dataset_title}",
+        )
+
         return {
             "message": "Stored successfully with enhanced content indexing",
             "cid": request.cid,
@@ -487,6 +506,13 @@ async def store_data_enhanced(request: StoreWithContentRequest):
             
             print(f"Stored {len(content_chunks)} content chunks for document {doc_id}")
         
+        audit_logger.log_operation(
+            operation="STORE",
+            wallet_address=request.metadata.get("owner_address", ""),
+            document_id=doc_id,
+            details=f"CID: {request.cid}, title: {request.dataset_title} (enhanced)",
+        )
+
         return {
             "message": "Stored successfully with enhanced content indexing",
             "cid": request.cid,
@@ -526,6 +552,11 @@ async def search_data(request: SearchRequest):
                     "metadata": metadata
                 })
         
+        audit_logger.log_operation(
+            operation="SEARCH",
+            details=f"query: {request.query}, results: {len(results)}",
+        )
+
         return {"results": results}
         
     except Exception as e:
@@ -697,6 +728,12 @@ async def update_document(doc_id: str, request: UpdateRequest):
         )
         
         print(f"Document updated in-place: {doc_id}")
+
+        audit_logger.log_operation(
+            operation="UPDATE",
+            wallet_address=request.owner_address,
+            document_id=doc_id,
+        )
         
         return {"message": "Document updated", "id": doc_id}
     
@@ -727,6 +764,12 @@ async def delete_document(doc_id: str, request: DeleteRequest):
         metadata_collection.delete(ids=[doc_id])
         
         print(f"Document {doc_id} deleted")
+
+        audit_logger.log_operation(
+            operation="DELETE",
+            wallet_address=request.owner_address,
+            document_id=doc_id,
+        )
         
         return {"message": "Document deleted", "deleted_id": doc_id}
     
@@ -1062,7 +1105,42 @@ class ContentExtractor:
         
         return chunks if chunks else [content]
     
+
+@app.get("/audit/logs")
+async def get_audit_logs(
+    wallet_address: Optional[str] = None,
+    operation: Optional[str] = None,
+    document_id: Optional[str] = None,
+    limit: int = 50,
+):
+    try:
+        logs = audit_logger.query_logs(
+            wallet_address=wallet_address,
+            operation=operation,
+            document_id=document_id,
+            limit=limit,
+        )
+        return {"logs": logs, "total": len(logs)}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Failed to query audit logs: {str(e)}")
+
+
+@app.get("/audit/logs/{entry_id}")
+async def get_audit_entry(entry_id: str):
+    try:
+        entry = audit_logger.get_entry(entry_id)
+        if not entry:
+            raise HTTPException(status_code=404, detail="Audit log entry not found")
+
+        verified = audit_logger.verify_integrity(entry_id)
+        entry["integrity_verified"] = verified
+        return entry
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Failed to get audit entry: {str(e)}")
+
+
 if __name__ == "__main__":
     import uvicorn
     uvicorn.run(app, host="0.0.0.0", port=3002)
-

--- a/python_backend/services/audit_logger.py
+++ b/python_backend/services/audit_logger.py
@@ -1,0 +1,159 @@
+import chromadb
+import hashlib
+import uuid
+import time
+from datetime import datetime, timezone
+from typing import Optional, List, Dict, Any
+
+
+class AuditLogger:
+    def __init__(self, chroma_client: chromadb.ClientAPI):
+        self.collection = chroma_client.get_or_create_collection(
+            name="audit_logs"
+        )
+
+    @staticmethod
+    def _generate_integrity_hash(
+        entry_id: str,
+        timestamp: str,
+        operation: str,
+        wallet_address: str,
+        document_id: str,
+        status: str,
+        details: str,
+    ) -> str:
+        payload = f"{entry_id}|{timestamp}|{operation}|{wallet_address}|{document_id}|{status}|{details}"
+        return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+    def log_operation(
+        self,
+        operation: str,
+        status: str = "SUCCESS",
+        wallet_address: Optional[str] = None,
+        document_id: Optional[str] = None,
+        details: Optional[str] = None,
+    ) -> str:
+        entry_id = str(uuid.uuid4())
+        timestamp = datetime.now(timezone.utc).isoformat()
+
+        integrity_hash = self._generate_integrity_hash(
+            entry_id,
+            timestamp,
+            operation,
+            wallet_address or "",
+            document_id or "",
+            status,
+            details or "",
+        )
+
+        document_text = (
+            f"{operation} by {wallet_address or 'anonymous'} "
+            f"on {document_id or 'N/A'} at {timestamp} — {status}"
+        )
+
+        metadata = {
+            "timestamp": timestamp,
+            "operation": operation,
+            "wallet_address": wallet_address or "",
+            "document_id": document_id or "",
+            "status": status,
+            "details": details or "",
+            "integrity_hash": integrity_hash,
+        }
+
+        self.collection.add(
+            ids=[entry_id],
+            documents=[document_text],
+            metadatas=[metadata],
+        )
+
+        return entry_id
+
+    def verify_integrity(self, entry_id: str) -> bool:
+        result = self.collection.get(
+            ids=[entry_id], include=["metadatas"]
+        )
+
+        if not result["ids"]:
+            return False
+
+        meta = result["metadatas"][0]
+        expected = self._generate_integrity_hash(
+            entry_id,
+            meta["timestamp"],
+            meta["operation"],
+            meta["wallet_address"],
+            meta["document_id"],
+            meta["status"],
+            meta["details"],
+        )
+        return expected == meta["integrity_hash"]
+
+    def query_logs(
+        self,
+        wallet_address: Optional[str] = None,
+        operation: Optional[str] = None,
+        document_id: Optional[str] = None,
+        limit: int = 50,
+    ) -> List[Dict[str, Any]]:
+        filters = []
+        if wallet_address:
+            filters.append({"wallet_address": wallet_address})
+        if operation:
+            filters.append({"operation": operation})
+        if document_id:
+            filters.append({"document_id": document_id})
+
+        where_clause = None
+        if len(filters) > 1:
+            where_clause = {"$and": filters}
+        elif len(filters) == 1:
+            where_clause = filters[0]
+
+        if where_clause:
+            result = self.collection.get(
+                where=where_clause,
+                include=["metadatas", "documents"],
+            )
+        else:
+            result = self.collection.get(
+                include=["metadatas", "documents"],
+            )
+
+        logs = []
+        if result["ids"]:
+            for i, entry_id in enumerate(result["ids"]):
+                meta = result["metadatas"][i]
+                logs.append({
+                    "id": entry_id,
+                    "timestamp": meta["timestamp"],
+                    "operation": meta["operation"],
+                    "wallet_address": meta["wallet_address"],
+                    "document_id": meta["document_id"],
+                    "status": meta["status"],
+                    "details": meta["details"],
+                    "integrity_hash": meta["integrity_hash"],
+                })
+
+        logs.sort(key=lambda x: x["timestamp"], reverse=True)
+        return logs[:limit]
+
+    def get_entry(self, entry_id: str) -> Optional[Dict[str, Any]]:
+        result = self.collection.get(
+            ids=[entry_id], include=["metadatas", "documents"]
+        )
+
+        if not result["ids"]:
+            return None
+
+        meta = result["metadatas"][0]
+        return {
+            "id": entry_id,
+            "timestamp": meta["timestamp"],
+            "operation": meta["operation"],
+            "wallet_address": meta["wallet_address"],
+            "document_id": meta["document_id"],
+            "status": meta["status"],
+            "details": meta["details"],
+            "integrity_hash": meta["integrity_hash"],
+        }

--- a/python_backend/services/audit_models.py
+++ b/python_backend/services/audit_models.py
@@ -1,0 +1,19 @@
+from pydantic import BaseModel, Field
+from typing import Optional, List
+from datetime import datetime
+
+
+class AuditLogEntry(BaseModel):
+    id: str
+    timestamp: str
+    operation: str
+    wallet_address: Optional[str] = None
+    document_id: Optional[str] = None
+    status: str
+    details: Optional[str] = None
+    integrity_hash: str
+
+
+class AuditQueryResponse(BaseModel):
+    logs: List[AuditLogEntry]
+    total: int

--- a/python_backend/tests/test_audit_logger.py
+++ b/python_backend/tests/test_audit_logger.py
@@ -1,0 +1,166 @@
+import pytest
+import uuid
+import chromadb
+from services.audit_logger import AuditLogger
+
+
+@pytest.fixture
+def audit_logger():
+    client = chromadb.Client()
+    logger = AuditLogger(client)
+    logger.collection = client.get_or_create_collection(
+        name=f"audit_test_{uuid.uuid4().hex[:8]}"
+    )
+    return logger
+
+
+class TestLogOperation:
+    def test_creates_entry_and_returns_id(self, audit_logger):
+        entry_id = audit_logger.log_operation(
+            operation="STORE",
+            wallet_address="0xabc123",
+            document_id="doc_001",
+            details="test store",
+        )
+        assert entry_id is not None
+        assert len(entry_id) > 0
+
+    def test_entry_is_retrievable(self, audit_logger):
+        entry_id = audit_logger.log_operation(
+            operation="DELETE",
+            wallet_address="0xdef456",
+            document_id="doc_002",
+        )
+        entry = audit_logger.get_entry(entry_id)
+        assert entry is not None
+        assert entry["operation"] == "DELETE"
+        assert entry["wallet_address"] == "0xdef456"
+        assert entry["document_id"] == "doc_002"
+        assert entry["status"] == "SUCCESS"
+
+    def test_anonymous_operation(self, audit_logger):
+        entry_id = audit_logger.log_operation(
+            operation="SEARCH",
+            details="query: cancer dataset",
+        )
+        entry = audit_logger.get_entry(entry_id)
+        assert entry["wallet_address"] == ""
+        assert entry["operation"] == "SEARCH"
+
+    def test_custom_status(self, audit_logger):
+        entry_id = audit_logger.log_operation(
+            operation="STORE",
+            status="FAILED",
+            wallet_address="0x111",
+            details="disk full",
+        )
+        entry = audit_logger.get_entry(entry_id)
+        assert entry["status"] == "FAILED"
+
+
+class TestIntegrityVerification:
+    def test_valid_entry_passes_verification(self, audit_logger):
+        entry_id = audit_logger.log_operation(
+            operation="STORE",
+            wallet_address="0xabc",
+            document_id="doc_100",
+        )
+        assert audit_logger.verify_integrity(entry_id) is True
+
+    def test_nonexistent_entry_fails_verification(self, audit_logger):
+        assert audit_logger.verify_integrity("nonexistent-id") is False
+
+    def test_tampered_entry_fails_verification(self, audit_logger):
+        entry_id = audit_logger.log_operation(
+            operation="STORE",
+            wallet_address="0xabc",
+            document_id="doc_tamper",
+        )
+
+        audit_logger.collection.update(
+            ids=[entry_id],
+            metadatas=[{
+                "timestamp": "tampered",
+                "operation": "STORE",
+                "wallet_address": "0xabc",
+                "document_id": "doc_tamper",
+                "status": "SUCCESS",
+                "details": "",
+                "integrity_hash": "fake_hash",
+            }],
+        )
+
+        assert audit_logger.verify_integrity(entry_id) is False
+
+
+class TestQueryLogs:
+    def test_query_all_logs(self, audit_logger):
+        audit_logger.log_operation(operation="STORE", wallet_address="0xa")
+        audit_logger.log_operation(operation="DELETE", wallet_address="0xb")
+
+        logs = audit_logger.query_logs()
+        assert len(logs) == 2
+
+    def test_filter_by_wallet(self, audit_logger):
+        audit_logger.log_operation(operation="STORE", wallet_address="0xAAA")
+        audit_logger.log_operation(operation="DELETE", wallet_address="0xBBB")
+
+        logs = audit_logger.query_logs(wallet_address="0xAAA")
+        assert len(logs) == 1
+        assert logs[0]["wallet_address"] == "0xAAA"
+
+    def test_filter_by_operation(self, audit_logger):
+        audit_logger.log_operation(operation="STORE", wallet_address="0x1")
+        audit_logger.log_operation(operation="DELETE", wallet_address="0x2")
+        audit_logger.log_operation(operation="STORE", wallet_address="0x3")
+
+        logs = audit_logger.query_logs(operation="STORE")
+        assert len(logs) == 2
+        assert all(log["operation"] == "STORE" for log in logs)
+
+    def test_filter_by_document_id(self, audit_logger):
+        audit_logger.log_operation(operation="STORE", document_id="doc_X")
+        audit_logger.log_operation(operation="UPDATE", document_id="doc_Y")
+
+        logs = audit_logger.query_logs(document_id="doc_X")
+        assert len(logs) == 1
+        assert logs[0]["document_id"] == "doc_X"
+
+    def test_limit_results(self, audit_logger):
+        for i in range(10):
+            audit_logger.log_operation(operation="SEARCH", details=f"q{i}")
+
+        logs = audit_logger.query_logs(limit=3)
+        assert len(logs) == 3
+
+    def test_empty_collection_returns_empty(self, audit_logger):
+        logs = audit_logger.query_logs()
+        assert logs == []
+
+
+class TestGetEntry:
+    def test_existing_entry(self, audit_logger):
+        entry_id = audit_logger.log_operation(
+            operation="UPDATE",
+            wallet_address="0xget",
+            document_id="doc_get",
+        )
+        entry = audit_logger.get_entry(entry_id)
+        assert entry is not None
+        assert entry["id"] == entry_id
+
+    def test_nonexistent_entry_returns_none(self, audit_logger):
+        result = audit_logger.get_entry("does-not-exist")
+        assert result is None
+
+
+class TestAppendOnly:
+    def test_entries_accumulate(self, audit_logger):
+        audit_logger.log_operation(operation="STORE")
+        assert len(audit_logger.query_logs()) == 1
+
+        audit_logger.log_operation(operation="DELETE")
+        assert len(audit_logger.query_logs()) == 2
+
+        audit_logger.log_operation(operation="SEARCH")
+        assert len(audit_logger.query_logs()) == 3


### PR DESCRIPTION
## Summary

Hey @pradeeban @Chali-healthy @karthiksathishjeemain 👋 this is the Phase 1 prototype from Discussion #164 — a lightweight immutable audit logger for HIPAA §164.312 compliance.

## What This Adds

### New: `AuditLogger` service (`services/audit_logger.py`)
- Append-only audit log using a dedicated ChromaDB collection (`audit_logs`)
- Every entry gets a **SHA-256 integrity hash** computed from all fields — if any field is tampered with, the hash won't match
- Supports filtered queries by wallet address, operation type, and document ID
- Tracks: timestamp (UTC ISO), operation, wallet address, document ID, status, details

### Endpoints instrumented with audit logging

| Endpoint | Operation logged |
|----------|-----------------|
| `POST /store` | `STORE` |
| `POST /store_enhanced` | `STORE` |
| `PUT /documents/{doc_id}` | `UPDATE` |
| `DELETE /documents/{doc_id}` | `DELETE` |
| `POST /search` | `SEARCH` |
| `POST /anonymize_image` | `ANONYMIZE` |

### New query endpoints
- `GET /audit/logs?wallet_address=&operation=&document_id=&limit=` — query the audit trail with filters
- `GET /audit/logs/{entry_id}` — get single entry with integrity verification (`integrity_verified: true/false`)

## Tests

✅ **16/16** unit tests passing, covering:
- Log creation and retrieval
- Integrity hash verification
- **Tamper detection** (modifying an entry invalidates the hash)
- Filtered queries (by wallet, operation, document_id)
- Result limiting
- Append-only behavior

## What's Next (Phase 2)
- On-chain anchoring of critical events (deletions, bulk exports) via `AuditAnchored` event in `DocumentStorage.sol`
- Periodic Merkle root anchoring for off-chain log verifiability

Phase 1 of Discussion #164
