### PR TITLE
feat: add on-chain purchase access tracking

### DIFF
--- a/prototype/src/DocumentStorage.sol
+++ b/prototype/src/DocumentStorage.sol
@@ -14,6 +14,7 @@ contract DocumentStorage {
     mapping(string => string) public documentMetadata;
     mapping(string => address) public documentOwners;
     mapping(address => uint256) public earnings;
+    mapping(string => mapping(address => bool)) public hasPurchased;
     
     function storeDocument(string memory ipfsHash, uint256 price, string memory metadata) public {
         require(documentOwners[ipfsHash] == address(0), "Document already exists");
@@ -62,6 +63,7 @@ contract DocumentStorage {
         require(msg.value == price, "Exact price required");
 
         earnings[owner] += price;
+        hasPurchased[ipfsHash][msg.sender] = true;
         emit DocumentPurchased(msg.sender, owner, ipfsHash, price);
         return true;
     }
@@ -78,6 +80,10 @@ contract DocumentStorage {
     
      function getMetadata(string memory ipfsHash) public view returns (string memory) {
         return documentMetadata[ipfsHash];
+    }
+
+    function hasAccess(string memory ipfsHash, address user) public view returns (bool) {
+        return documentOwners[ipfsHash] == user || hasPurchased[ipfsHash][user];
     }
 
     function getDocuments(address user) public view returns (string[] memory) {

--- a/prototype/test/DocumentStorage.test.js
+++ b/prototype/test/DocumentStorage.test.js
@@ -151,6 +151,57 @@ describe("DocumentStorage", function () {
     });
   });
 
+  describe("hasAccess", function () {
+    it("Should return true for document owner", async function () {
+      const ipfsHash = "QmAccess100";
+      const price = ethers.utils.parseEther("1.0");
+
+      await documentStorage.storeDocument(ipfsHash, price, "metadata");
+
+      expect(await documentStorage.hasAccess(ipfsHash, owner.address)).to.equal(true);
+    });
+
+    it("Should return false for non-buyer before purchase", async function () {
+      const ipfsHash = "QmAccess200";
+      const price = ethers.utils.parseEther("1.0");
+
+      await documentStorage.storeDocument(ipfsHash, price, "metadata");
+
+      expect(await documentStorage.hasAccess(ipfsHash, buyer.address)).to.equal(false);
+    });
+
+    it("Should return true for buyer after purchase", async function () {
+      const ipfsHash = "QmAccess300";
+      const price = ethers.utils.parseEther("1.0");
+
+      await documentStorage.storeDocument(ipfsHash, price, "metadata");
+      await documentStorage.connect(buyer).purchaseDocument(ipfsHash, { value: price });
+
+      expect(await documentStorage.hasAccess(ipfsHash, buyer.address)).to.equal(true);
+    });
+
+    it("Should set hasPurchased flag after purchase", async function () {
+      const ipfsHash = "QmAccess400";
+      const price = ethers.utils.parseEther("1.0");
+
+      await documentStorage.storeDocument(ipfsHash, price, "metadata");
+
+      expect(await documentStorage.hasPurchased(ipfsHash, buyer.address)).to.equal(false);
+      await documentStorage.connect(buyer).purchaseDocument(ipfsHash, { value: price });
+      expect(await documentStorage.hasPurchased(ipfsHash, buyer.address)).to.equal(true);
+    });
+
+    it("Should return false for unrelated address", async function () {
+      const ipfsHash = "QmAccess500";
+      const price = ethers.utils.parseEther("1.0");
+
+      await documentStorage.storeDocument(ipfsHash, price, "metadata");
+      await documentStorage.connect(buyer).purchaseDocument(ipfsHash, { value: price });
+
+      expect(await documentStorage.hasAccess(ipfsHash, addr1.address)).to.equal(false);
+    });
+  });
+
   describe("withdrawEarnings", function () {
     it("Should withdraw earnings", async function () {
       const ipfsHash = "QmWithdraw123";


### PR DESCRIPTION
## Summary
Adds on-chain purchase access tracking to [DocumentStorage.sol]. Currently, `purchaseDocument` accepts payment and credits seller earnings but stores no buyer entitlement state, buyers have no durable on-chain proof they purchased a document, forcing off-chain systems to rely on fragile log parsing for authorization.
This PR adds:
- `hasPurchased` mapping to persist buyer access per document
- Access flag set in `purchaseDocument` on successful purchase
- `hasAccess(ipfsHash, user)` view function - returns `true` if the user is the owner **or** has purchased the document.
- 5 new tests covering `hasAccess` and `hasPurchased`:
1. Owner has access to their own document by default
2. Non-buyer has no access before purchase
3. Buyer gains access after successful purchase
4. `hasPurchased` flag is correctly set after purchase
5. Unrelated address has no access even after another user purchases
### Linked Issue
Closes #184 
