### PR TITLE
Add metadata to storeDocument and expose getMetadata, updateMetadata,…

### DIFF
--- a/nextjs-frontend/lib/contractService.ts
+++ b/nextjs-frontend/lib/contractService.ts
@@ -35,10 +35,70 @@ const CONTRACT_ABI: ContractABI[] = [
         name: 'price',
         type: 'uint256',
       },
+      {
+        internalType: 'string',
+        name: 'metadata',
+        type: 'string',
+      },
     ],
     name: 'storeDocument',
     outputs: [],
     stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'string',
+        name: 'ipfsHash',
+        type: 'string',
+      },
+      {
+        internalType: 'uint256',
+        name: 'newPrice',
+        type: 'uint256',
+      },
+      {
+        internalType: 'string',
+        name: 'newMetadata',
+        type: 'string',
+      },
+    ],
+    name: 'updateMetadata',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'string',
+        name: 'ipfsHash',
+        type: 'string',
+      },
+    ],
+    name: 'deleteDocument',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'string',
+        name: 'ipfsHash',
+        type: 'string',
+      },
+    ],
+    name: 'getMetadata',
+    outputs: [
+      {
+        internalType: 'string',
+        name: '',
+        type: 'string',
+      },
+    ],
+    stateMutability: 'view',
     type: 'function',
   },
   {
@@ -165,19 +225,21 @@ const getContract = async (withSigner = true): Promise<Contract> => {
 };
 
 /**
- * Store document hash and price on blockchain
+ * Store document hash, price and metadata on blockchain
  * @param ipfsHash - IPFS hash of the encrypted document
  * @param priceInEth - Price in ETH
+ * @param metadata - Optional metadata string (e.g. tags, description)
  * @returns Transaction hash
  */
 export const storeDocumentHash = async (
   ipfsHash: string,
-  priceInEth: number | string
+  priceInEth: number | string,
+  metadata: string = ''
 ): Promise<string> => {
   const contract = await getContract(true);
   const priceInWei = ethers.parseEther(priceInEth.toString());
 
-  const tx = await contract.storeDocument(ipfsHash, priceInWei);
+  const tx = await contract.storeDocument(ipfsHash, priceInWei, metadata);
   await tx.wait();
   return tx.hash;
 };
@@ -245,6 +307,49 @@ export const getEarnings = async (address: string): Promise<string> => {
 
   const earningsInWei = await contract.earnings(address);
   return ethers.formatEther(earningsInWei);
+};
+
+/**
+ * Get metadata for a document
+ * @param ipfsHash - IPFS hash of the document
+ * @returns Metadata string
+ */
+export const getMetadata = async (ipfsHash: string): Promise<string> => {
+  const contract = await getContract(false);
+  return contract.getMetadata(ipfsHash);
+};
+
+/**
+ * Update document metadata and price (owner only)
+ * @param ipfsHash - IPFS hash of the document
+ * @param newPriceInEth - New price in ETH
+ * @param newMetadata - New metadata string
+ * @returns Transaction hash
+ */
+export const updateMetadata = async (
+  ipfsHash: string,
+  newPriceInEth: number | string,
+  newMetadata: string
+): Promise<string> => {
+  const contract = await getContract(true);
+  const newPriceInWei = ethers.parseEther(newPriceInEth.toString());
+
+  const tx = await contract.updateMetadata(ipfsHash, newPriceInWei, newMetadata);
+  await tx.wait();
+  return tx.hash;
+};
+
+/**
+ * Delete a document (owner only)
+ * @param ipfsHash - IPFS hash of the document
+ * @returns Transaction hash
+ */
+export const deleteDocument = async (ipfsHash: string): Promise<string> => {
+  const contract = await getContract(true);
+
+  const tx = await contract.deleteDocument(ipfsHash);
+  await tx.wait();
+  return tx.hash;
 };
 
 /**

--- a/prototype/src/contractService.js
+++ b/prototype/src/contractService.js
@@ -33,6 +33,11 @@ const CONTRACT_ABI = [
         name: "price",
         type: "uint256",
       },
+      {
+        internalType: "string",
+        name: "metadata",
+        type: "string",
+      },
     ],
     name: "storeDocument",
     outputs: [],
@@ -137,13 +142,13 @@ const CONTRACT_ABI = [
   },
 ];
 
-export const storeDocumentHash = async (ipfsHash, priceInEth) => {
+export const storeDocumentHash = async (ipfsHash, priceInEth, metadata = "") => {
   const provider = new ethers.BrowserProvider(window.ethereum);
   const signer = await provider.getSigner();
   const contract = new ethers.Contract(CONTRACT_ADDRESS, CONTRACT_ABI, signer);
 
   const priceInWei = ethers.parseEther(priceInEth.toString());
-  const tx = await contract.storeDocument(ipfsHash, priceInWei);
+  const tx = await contract.storeDocument(ipfsHash, priceInWei, metadata);
   await tx.wait();
   console.log(`Transaction successful with hash: ${tx.hash}`);
   return tx.hash;


### PR DESCRIPTION
Fixes #191  

## Summary
Aligns the frontend contract services with the DocumentStorage contract by adding the `metadata` parameter to `storeDocument` and exposing `getMetadata`, `updateMetadata`, and `deleteDocument` in the Next.js app.

## Changes
- **Add `metadata` to `storeDocument` (Next.js + prototype):** Extended the `storeDocument` ABI with a third input `metadata` (string). Updated `storeDocumentHash(ipfsHash, priceInEth, metadata?)` to pass it; optional with default `""` so existing two-argument call sites keep working.
- **Expose metadata and document lifecycle in Next.js:** Added ABI entries and exported helpers for `getMetadata`, `updateMetadata`, and `deleteDocument` so the app can read metadata and perform owner-only update/delete.
- **Contract unchanged:** No edits to `DocumentStorage.sol`; only frontend ABI and service layer updates.

## PR checklist
- [x] PR targets the `dev` branch (or as directed by maintainers)
- [x] Linked issue 
- [x] Clear description of what changed and why
- [x] How to test locally (steps) and expected behavior
- [ ] Unit/integration tests added for new functionality (if applicable)
- [x] Code formatted and linted

## How to test locally
1. Check out this branch and ensure the app points at a chain where DocumentStorage is deployed with `storeDocument(ipfsHash, price, metadata)` and the three methods above.
2. **Store (both frontends):** Call `storeDocumentHash(ipfsHash, price)` (two args) → should succeed and send `metadata = ""`. Call `storeDocumentHash(ipfsHash, price, "tags: medical")` → should succeed and store metadata on-chain.
3. **Next.js – getMetadata:** After storing with metadata, call `getMetadata(ipfsHash)` and confirm the returned string matches.
4. **Next.js – updateMetadata / deleteDocument:** As document owner, call `updateMetadata(ipfsHash, newPrice, newMetadata)` and confirm price/metadata change on-chain; then call `deleteDocument(ipfsHash)` and confirm the document is removed (e.g. `getMyDocuments()` no longer includes it, or `documentOwners(ipfsHash)` is zero address).

---