### PR TITLE
security: add file-type validation to IPFS upload endpoint

### DIFF
--- a/javascript_backend/controllers/ipfsController.js
+++ b/javascript_backend/controllers/ipfsController.js
@@ -5,6 +5,7 @@ const fs = require("fs");
 const os = require("os");
 const crypto = require("crypto");
 
+// Configure multer for disk storage with file-type validation
 const storage = multer.diskStorage({
   destination: (req, file, cb) => {
     cb(null, os.tmpdir());
@@ -16,6 +17,45 @@ const storage = multer.diskStorage({
 });
 const upload = multer({
   storage: storage,
+  fileFilter: (req, file, cb) => {
+    // Accept health data formats and encrypted blobs that Bio-Block handles
+    const allowedMimeTypes = [
+      // Encrypted blobs (primary use case for IPFS upload)
+      "application/octet-stream",
+      // Spreadsheet formats
+      "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", // .xlsx
+      "application/vnd.ms-excel", // .xls
+      "text/csv", // .csv
+      "application/csv", // .csv (alternative)
+      "application/vnd.oasis.opendocument.spreadsheet", // .ods
+      "text/tab-separated-values", // .tsv
+      // Image formats
+      "image/jpeg", // .jpg/.jpeg
+      "image/png", // .png
+      // Document formats
+      "application/pdf", // .pdf
+      // Medical imaging
+      "application/dicom", // .dcm
+    ];
+
+    // Extension fallback for cases where MIME type is unreliable
+    const allowedExtensions =
+      /\.(enc|xlsx|xls|csv|ods|tsv|jpg|jpeg|png|pdf|dcm|nii|nii\.gz)$/i;
+
+    if (
+      allowedMimeTypes.includes(file.mimetype) ||
+      allowedExtensions.test(file.originalname)
+    ) {
+      cb(null, true);
+    } else {
+      cb(
+        new Error(
+          "File type not allowed. Accepted: encrypted blobs, spreadsheets (.xlsx, .csv, .ods, .tsv), images (.jpg, .png), documents (.pdf), and medical imaging (.dcm, .nii)."
+        ),
+        false
+      );
+    }
+  },
   limits: {
     fileSize: 2 * 1024 * 1024 * 1024, // 2GB
   },

--- a/javascript_backend/routes/ipfs.js
+++ b/javascript_backend/routes/ipfs.js
@@ -12,6 +12,11 @@ router.use((error, req, res, next) => {
       error: "File too large. Maximum size is 2GB.",
     });
   }
+  if (error.message && error.message.startsWith("File type not allowed")) {
+    return res.status(400).json({
+      error: error.message,
+    });
+  }
   next(error);
 });
 

--- a/javascript_backend/tests/controllers/ipfsController.test.js
+++ b/javascript_backend/tests/controllers/ipfsController.test.js
@@ -339,4 +339,74 @@ describe("IPFS Upload Controller", function () {
       expect(res.body.success).to.be.true;
     });
   });
+
+  // ------------------------------------------------------------------
+  // 7. File-type validation
+  // ------------------------------------------------------------------
+  describe("File-type validation", function () {
+    it("should reject executable files", async function () {
+      const res = await request(app)
+        .post("/api/ipfs/upload")
+        .attach("encryptedFile", Buffer.from("MZ"), "malware.exe")
+        .field("fileName", "malware.exe");
+
+      expect(res.status).to.equal(400);
+      expect(res.body.error).to.include("File type not allowed");
+    });
+
+    it("should reject shell scripts", async function () {
+      const res = await request(app)
+        .post("/api/ipfs/upload")
+        .attach("encryptedFile", Buffer.from("#!/bin/bash"), "script.sh")
+        .field("fileName", "script.sh");
+
+      expect(res.status).to.equal(400);
+      expect(res.body.error).to.include("File type not allowed");
+    });
+
+    it("should accept encrypted blob files (.enc)", async function () {
+      axios.post = async () => ({
+        data: { IpfsHash: "QmEncryptedBlob" },
+      });
+
+      const res = await request(app)
+        .post("/api/ipfs/upload")
+        .attach("encryptedFile", Buffer.from("encrypted data"), "dataset.enc")
+        .field("fileName", "dataset.enc");
+
+      expect(res.status).to.equal(200);
+      expect(res.body.success).to.be.true;
+    });
+
+    it("should accept health data formats (.csv)", async function () {
+      axios.post = async () => ({
+        data: { IpfsHash: "QmCsvData" },
+      });
+
+      const res = await request(app)
+        .post("/api/ipfs/upload")
+        .attach("encryptedFile", Buffer.from("col1,col2\n1,2"), {
+          filename: "data.csv",
+          contentType: "text/csv",
+        })
+        .field("fileName", "data.csv");
+
+      expect(res.status).to.equal(200);
+      expect(res.body.success).to.be.true;
+    });
+
+    it("should accept medical imaging files (.dcm)", async function () {
+      axios.post = async () => ({
+        data: { IpfsHash: "QmDicomFile" },
+      });
+
+      const res = await request(app)
+        .post("/api/ipfs/upload")
+        .attach("encryptedFile", Buffer.from("DICM"), "scan.dcm")
+        .field("fileName", "scan.dcm");
+
+      expect(res.status).to.equal(200);
+      expect(res.body.success).to.be.true;
+    });
+  });
 });


### PR DESCRIPTION
## Problem

The `/api/ipfs/upload` endpoint in `ipfsController.js` has no `fileFilter` on its multer configuration. Any file type can be uploaded and pinned to IPFS through Bio-Block's Pinata credentials — including executables, scripts, or arbitrary content.

I noticed this while looking at how `anonymizeController.js` handles file uploads — it has a proper `fileFilter` (lines 8-34) that only allows spreadsheet formats. But `ipfsController.js` has no such filter at all.

This means someone could do:

```bash
curl -X POST -F "encryptedFile=@ransomware.exe" -F "fileName=totally_safe.exe" \
  http://localhost:3001/api/ipfs/upload
```

...and get back a 200 with a valid IPFS hash. The file gets pinned to IPFS using our Pinata credentials.

## Why this matters

Bio-Block is a health data platform. The IPFS upload should only handle the file types we actually support — encrypted blobs, spreadsheets, images, PDFs, and medical imaging (DICOM, NIfTI). There's no reason to accept executables, shell scripts, or arbitrary binaries.

Pinata bills by storage — accepting arbitrary uploads could rack up costs if someone decides to abuse the open endpoint.

## Changes

### `ipfsController.js`
- Added `fileFilter` to multer config accepting only Bio-Block file types:
  - Encrypted blobs (`application/octet-stream`, `.enc`)
  - Spreadsheets (`.xlsx`, `.xls`, `.csv`, `.ods`, `.tsv`)
  - Images (`.jpg`, `.png`)
  - Documents (`.pdf`)
  - Medical imaging (`.dcm`, `.nii`, `.nii.gz`)
- Uses same pattern as `anonymizeController.js`: MIME type check + extension fallback

### `routes/ipfs.js`
- Added error handler for file filter rejections → returns 400 with clear message

### `ipfsController.test.js`
- Added 5 new tests:
  - [x] Reject `.exe` executable files
  - [x] Reject `.sh` shell scripts
  - [x] Accept `.enc` encrypted blobs
  - [x] Accept `.csv` health data
  - [x] Accept `.dcm` medical imaging

**All 23 tests passing.**

## Checklist

- [x] `fileFilter` added with allowlist of Bio-Block file types
- [x] Route error handler returns 400 for rejected files
- [x] 5 new tests added and passing
- [x] All 18 existing tests still pass
- [x] Follows same pattern as `anonymizeController.js`

closes #189 