### PR TITLE
security: sanitize formula injection in anonymized outputs

### DIFF
--- a/javascript_backend/controllers/anonymizeController.js
+++ b/javascript_backend/controllers/anonymizeController.js
@@ -41,6 +41,21 @@ const phiKeywords = [
     'name'
 ];
 
+const FORMULA_PREFIXES = ['=', '+', '-', '@', '\t', '\r', '\n'];
+
+function sanitizeCellValue(value) {
+    if (typeof value !== 'string') return value;
+    if (value.length === 0) return value;
+    if (FORMULA_PREFIXES.includes(value[0])) {
+        return "'" + value;
+    }
+    return value;
+}
+
+function sanitizeSheetData(data) {
+    return data.map(row => row.map(cell => sanitizeCellValue(cell)));
+}
+
 function generateAnonymizedId(input, index) {
     const hash = crypto.createHash('sha256').update(input).digest('hex');
     const shortHash = hash.substring(0, 8);
@@ -227,7 +242,8 @@ const anonymizeFile = async (req, res) => {
                 }
             }
 
-            const newWorksheet = XLSX.utils.aoa_to_sheet(cleanedData);
+            const sanitizedData = sanitizeSheetData(cleanedData);
+            const newWorksheet = XLSX.utils.aoa_to_sheet(sanitizedData);
             XLSX.utils.book_append_sheet(cleanedWorkbook, newWorksheet, sheetName);
         });
 


### PR DESCRIPTION
## Summary
- Sanitize all string cells in anonymized spreadsheet outputs against CSV/Excel formula injection (OWASP)
- Cells starting with `=`, `+`, `-`, `@`, `\t`, `\r`, or `\n` are prefixed with a single quote (`'`) to neutralize formula evaluation in Excel/Google Sheets
- Sanitization runs after anonymization, so PHI detection logic is unaffected

## Context
A malicious user could upload a dataset containing payloads like `=cmd|'/C calc'!A0`. These formulas survive the anonymization pass and end up in the output `.xlsx`/`.csv` files. When a buyer downloads the 5% preview to evaluate data quality, opening the file in a spreadsheet application triggers arbitrary code execution.

## Changes
- `javascript_backend/controllers/anonymizeController.js`: added `sanitizeCellValue()` and `sanitizeSheetData()` functions, applied to all sheet data before writing to the output workbook

Closes #151