### PR TITLE
Update withdrawEarnings to use cfix(contract): replace transfer with …

### DIFF
--- a/prototype/src/DocumentStorage.sol
+++ b/prototype/src/DocumentStorage.sol
@@ -23,7 +23,8 @@ contract DocumentStorage {
         uint256 amount = earnings[msg.sender];
         require(amount > 0, "No earnings");
         earnings[msg.sender] = 0;
-        payable(msg.sender).transfer(amount);
+        (bool callSuccess,) = payable(msg.sender).call{value: amount}("");
+        require(callSuccess, "Call failed");
     }
     
     function getDocuments(address user) public view returns (string[] memory) {


### PR DESCRIPTION
…callall for transfers

transfer() may fail due to gas stipend limitations. Replaced it with call() to follow Solidity best practices and remove compiler warning.