### PR TITLE
Add cell-level PHI content scanning to Excel anonymization

### DIFF
--- a/javascript_backend/tests/api.test.js
+++ b/javascript_backend/tests/api.test.js
@@ -58,4 +58,41 @@ describe("API Endpoints", function () {
     expect(res.body).to.have.nested.property("files.preview.data");
     expect(res.body).to.have.nested.property("files.preview.filename");
   });
+
+  it("POST /api/anonymize should redact PHI patterns in cell content", async function () {
+    // Create an Excel file with PHI in cell content but non-PHI column headers
+    const cellPhiPath = path.join(__dirname, "test_cell_phi.xlsx");
+    const wb = XLSX.utils.book_new();
+    const ws = XLSX.utils.aoa_to_sheet([
+      ["Notes", "Details", "Record"],
+      ["Contact at 555-123-4567", "SSN: 123-45-6789", "john@hospital.com"],
+      ["Normal text here", "No PHI data", "Just notes"],
+    ]);
+    XLSX.utils.book_append_sheet(wb, ws, "Sheet1");
+    XLSX.writeFile(wb, cellPhiPath);
+
+    const res = await request(app)
+      .post("/api/anonymize")
+      .attach("file", cellPhiPath)
+      .field("generatePreview", "true");
+
+    expect(res.status).to.equal(200);
+
+    // Parse the anonymized output and verify PHI was redacted
+    const outputBuffer = Buffer.from(res.body.files.main.data, "base64");
+    const outputWb = XLSX.read(outputBuffer, { type: "buffer" });
+    const outputData = XLSX.utils.sheet_to_json(outputWb.Sheets["Sheet1"], { header: 1 });
+
+    // Row 1 (index 1) should have PHI redacted from cells
+    expect(outputData[1][0]).to.equal("[PHI_REDACTED]"); // phone number
+    expect(outputData[1][1]).to.equal("[PHI_REDACTED]"); // SSN
+    expect(outputData[1][2]).to.equal("[PHI_REDACTED]"); // email
+
+    // Row 2 (index 2) should remain unchanged (no PHI)
+    expect(outputData[2][0]).to.equal("Normal text here");
+    expect(outputData[2][1]).to.equal("No PHI data");
+    expect(outputData[2][2]).to.equal("Just notes");
+
+    fs.unlinkSync(cellPhiPath);
+  });
 });

--- a/javascript_backend/workers/anonymizeWorker.js
+++ b/javascript_backend/workers/anonymizeWorker.js
@@ -29,6 +29,27 @@ const phiKeywords = [
   "name",
 ];
 
+// Regex patterns to detect PHI in cell content (not just headers)
+const PHI_CONTENT_PATTERNS = {
+  SSN: /\b\d{3}-\d{2}-\d{4}\b/,
+  PHONE: /\b(?:\+?1[-.\s]?)?\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}\b/,
+  EMAIL: /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b/,
+  MRN: /\bMRN[-:\s]?\d{4,}\b/i,
+  DATE_OF_BIRTH: /\b(?:0[1-9]|1[0-2])[-/](?:0[1-9]|[12]\d|3[01])[-/](?:19|20)\d{2}\b/,
+  IP_ADDRESS: /\b(?:\d{1,3}\.){3}\d{1,3}\b/,
+  CREDIT_CARD: /\b(?:\d{4}[-\s]?){3}\d{4}\b/,
+  DRIVERS_LICENSE: /\b[A-Z]\d{7,14}\b/,
+};
+
+/**
+ * Scans a cell value against PHI content patterns.
+ * Returns true if the cell contains potential PHI.
+ */
+const cellContainsPHI = (value) => {
+  if (typeof value !== "string" || value.length === 0) return false;
+  return Object.values(PHI_CONTENT_PATTERNS).some((pattern) => pattern.test(value));
+};
+
 const FORMULA_PREFIXES = ["=", "+", "-", "@", "\t", "\r", "\n"];
 
 const sanitizeCellValue = (value) => {
@@ -158,6 +179,20 @@ parentPort.on("message", (workerData) => {
               maskCols.forEach((c) => {
                 if (row[c] !== undefined) row[c] = id;
               });
+            }
+          }
+        }
+
+        // Cell-level content scanning: detect PHI patterns in non-header cells
+        // that were NOT already caught by header-based detection
+        const maskColSet = new Set(maskCols);
+        for (let i = 1; i < cleanData.length; i++) {
+          const row = cleanData[i];
+          if (!row) continue;
+          for (let j = 0; j < row.length; j++) {
+            if (maskColSet.has(j)) continue; // Already masked by header detection
+            if (row[j] !== undefined && row[j] !== null && cellContainsPHI(String(row[j]))) {
+              row[j] = "[PHI_REDACTED]";
             }
           }
         }


### PR DESCRIPTION
## Summary
- Previously, spreadsheet anonymization only detected PHI based on column header 
  keywords (e.g., "Name", "SSN", "DOB")
- Cells containing PHI in non-PHI-header columns passed through undetected
- Now scans every cell value against regex patterns for 8 PHI types:
  SSN, phone numbers, email addresses, MRNs, dates of birth, IP addresses, 
  credit card numbers, and driver's license numbers
- Header-based detection still takes priority — cell scanning only applies to 
  columns not already flagged by header matching
- Redacted values are replaced with `[PHI_REDACTED]`
- 1 new test verifying cell-level redaction — all 5 tests passing

## Test Results
- Cell with phone number (555-123-4567) → Redacted ✅
- Cell with SSN (123-45-6789) → Redacted ✅
- Cell with email (john@hospital.com) → Redacted ✅
- Clean cells without PHI → Unchanged ✅

Tested against the `dev` branch as requested.

Note: The security_audit CI failure is a pre-existing `undici` vulnerability 
(unrelated to this PR's changes).
