### PR TITLE
Add ingestion routing scaffold Week 1 (plus my first PR in GSoC coding period :D )

### DIFF
--- a/python_backend/main.py
+++ b/python_backend/main.py
@@ -310,6 +310,8 @@ async def ingest_file(
         if not header:
             raise HTTPException(status_code=400, detail="Uploaded file is empty")
 
+        await file.seek(0)
+
         return route_for_ingestion(
             filename=file.filename,
             content_type=file.content_type,

--- a/python_backend/main.py
+++ b/python_backend/main.py
@@ -1,4 +1,4 @@
-from fastapi import FastAPI, HTTPException, File, UploadFile
+from fastapi import FastAPI, HTTPException, File, Form, UploadFile
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
@@ -27,6 +27,7 @@ from eth_account import Account
 # Preview factory imports
 from services.preview.factory import PreviewFactory
 from services.audit_logger import AuditLogger
+from services.ingestion import HEADER_READ_LIMIT, IngestionError, route_for_ingestion
 
 # PDF extraction imports
 try:
@@ -282,7 +283,8 @@ async def root():
             "/anonymize_image_presidio": "Anonymize PHI in images (Presidio only, advanced)",
             "/anonymize_text": "Anonymize PHI in plain text (Presidio + spaCy fallback)",
             "/anonymize_pdf": "Anonymize PHI in PDF documents (per-page extraction and redaction)",
-            "/anonymize_dicom": "Anonymize PHI in DICOM file metadata (strips patient identifiers)"
+            "/anonymize_dicom": "Anonymize PHI in DICOM file metadata (strips patient identifiers)",
+            "/api/v1/ingest": "Route uploaded biomedical files to placeholder anonymization handlers"
         },
         "status": {
             "presidio_available": presidio_available,
@@ -291,6 +293,35 @@ async def root():
             "spacy_model": "en_core_web_lg" if nlp and hasattr(nlp, 'meta') and nlp.meta.get('name') == 'en_core_web_lg' else "en_core_web_sm" if nlp else "not_available"
         }
     }
+
+@app.post("/api/v1/ingest")
+async def ingest_file(
+    file: UploadFile = File(...),
+    profile: str = Form("strict"),
+):
+    """
+    Privacy-safe Week 1 upload entry point.
+
+    This endpoint only detects modality and selects a placeholder handler.
+    It does not store raw uploads, index metadata, or trigger downstream flows.
+    """
+    try:
+        header = await file.read(HEADER_READ_LIMIT)
+        if not header:
+            raise HTTPException(status_code=400, detail="Uploaded file is empty")
+
+        return route_for_ingestion(
+            filename=file.filename,
+            content_type=file.content_type,
+            header=header,
+            profile=profile,
+        )
+    except IngestionError as e:
+        raise HTTPException(status_code=e.status_code, detail=e.detail)
+    except HTTPException:
+        raise
+    except Exception:
+        raise HTTPException(status_code=500, detail="Failed to route uploaded file")
 
 @app.post("/anonymize_image")
 async def anonymize_image(file: UploadFile = File(...)):

--- a/python_backend/services/ingestion.py
+++ b/python_backend/services/ingestion.py
@@ -1,0 +1,154 @@
+from typing import Any, Callable, Dict, Optional
+
+
+SUPPORTED_PROFILES = {"strict", "research"}
+SUPPORTED_MODALITIES = {"csv", "text", "dicom", "nifti", "wsi"}
+HEADER_READ_LIMIT = 4096
+
+
+class IngestionError(ValueError):
+    def __init__(self, detail: str, status_code: int = 400):
+        super().__init__(detail)
+        self.detail = detail
+        self.status_code = status_code
+
+
+def validate_privacy_profile(profile: str) -> str:
+    normalized = (profile or "").strip().lower()
+    if normalized not in SUPPORTED_PROFILES:
+        raise IngestionError(
+            "Invalid privacy profile. Supported profiles: strict, research"
+        )
+    return normalized
+
+
+def _safe_filename(filename: str) -> str:
+    cleaned = (filename or "").strip().replace("\\", "/").rsplit("/", 1)[-1]
+    if not cleaned:
+        raise IngestionError("Uploaded file must include a filename")
+    return cleaned
+
+
+def _extension(filename: str) -> str:
+    lower_name = filename.lower()
+    if lower_name.endswith(".nii.gz"):
+        return ".nii.gz"
+    if "." not in lower_name:
+        return ""
+    return f".{lower_name.rsplit('.', 1)[-1]}"
+
+
+def _has_dicom_preamble(header: bytes) -> bool:
+    return len(header) >= 132 and header[128:132] == b"DICM"
+
+
+def detect_modality(
+    filename: str,
+    content_type: Optional[str],
+    header: bytes,
+) -> str:
+    safe_name = _safe_filename(filename)
+    ext = _extension(safe_name)
+    mime = (content_type or "").strip().lower()
+
+    if _has_dicom_preamble(header):
+        return "dicom"
+
+    if ext == ".csv":
+        return "csv"
+    if ext == ".txt":
+        return "text"
+    if ext in {".dcm", ".dicom"}:
+        return "dicom"
+    if ext in {".nii", ".nii.gz"}:
+        return "nifti"
+    if ext in {".svs", ".tif", ".tiff"}:
+        return "wsi"
+
+    if mime == "text/csv":
+        return "csv"
+    if mime == "text/plain":
+        return "text"
+    if mime in {"application/dicom", "application/x-dicom"} or "dicom" in mime:
+        return "dicom"
+    if mime in {"image/tiff", "image/tif"}:
+        return "wsi"
+
+    raise IngestionError("Unsupported file modality")
+
+
+def _placeholder_result(handler_name: str) -> Dict[str, str]:
+    return {
+        "handler": handler_name,
+        "routing_status": "handler_selected",
+        "anonymization_status": "placeholder",
+        "message": (
+            "Week 1 routing scaffold selected this handler. "
+            "Real anonymization will be added in later milestones."
+        ),
+    }
+
+
+def anonymize_csv() -> Dict[str, str]:
+    return _placeholder_result("anonymize_csv")
+
+
+def anonymize_text() -> Dict[str, str]:
+    return _placeholder_result("anonymize_text")
+
+
+def anonymize_dicom() -> Dict[str, str]:
+    return _placeholder_result("anonymize_dicom")
+
+
+def anonymize_nifti() -> Dict[str, str]:
+    return _placeholder_result("anonymize_nifti")
+
+
+def anonymize_wsi() -> Dict[str, str]:
+    return _placeholder_result("anonymize_wsi")
+
+
+HANDLER_REGISTRY: Dict[str, Callable[[], Dict[str, str]]] = {
+    "csv": anonymize_csv,
+    "text": anonymize_text,
+    "dicom": anonymize_dicom,
+    "nifti": anonymize_nifti,
+    "wsi": anonymize_wsi,
+}
+
+
+def route_for_ingestion(
+    filename: str,
+    content_type: Optional[str],
+    header: bytes,
+    profile: str,
+) -> Dict[str, Any]:
+    safe_name = _safe_filename(filename)
+    privacy_profile = validate_privacy_profile(profile)
+    modality = detect_modality(safe_name, content_type, header)
+
+    handler = HANDLER_REGISTRY.get(modality)
+    if handler is None:
+        raise IngestionError(
+            "No ingestion handler is available for detected modality",
+            status_code=500,
+        )
+
+    handler_result = handler()
+    return {
+        "status": "success",
+        "filename": safe_name,
+        "detected_modality": modality,
+        "privacy_profile": privacy_profile,
+        "handler": handler_result["handler"],
+        "routing_status": handler_result["routing_status"],
+        "anonymization_status": handler_result["anonymization_status"],
+        "message": handler_result["message"],
+        "downstream": {
+            "ipfs_chunking": "pending",
+            "cid_encryption": "pending",
+            "metadata_indexing": "pending",
+            "blockchain_transaction": "pending",
+        },
+    }

--- a/python_backend/tests/test_ingestion.py
+++ b/python_backend/tests/test_ingestion.py
@@ -1,0 +1,97 @@
+import os
+import sys
+import unittest
+from io import BytesIO
+
+from fastapi.testclient import TestClient
+
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from main import app  # noqa: E402
+
+
+client = TestClient(app)
+
+
+def upload_file(filename, content, content_type="application/octet-stream", profile=None):
+    data = {}
+    if profile is not None:
+        data["profile"] = profile
+
+    return client.post(
+        "/api/v1/ingest",
+        files={"file": (filename, BytesIO(content), content_type)},
+        data=data,
+    )
+
+
+class TestIngestionRouting(unittest.TestCase):
+    def assert_routes_to(self, response, modality, handler):
+        self.assertEqual(response.status_code, 200)
+        body = response.json()
+        self.assertEqual(body["status"], "success")
+        self.assertEqual(body["detected_modality"], modality)
+        self.assertEqual(body["handler"], handler)
+        self.assertEqual(body["routing_status"], "handler_selected")
+        self.assertEqual(body["anonymization_status"], "placeholder")
+        self.assertEqual(body["downstream"]["ipfs_chunking"], "pending")
+        self.assertEqual(body["downstream"]["cid_encryption"], "pending")
+        self.assertEqual(body["downstream"]["metadata_indexing"], "pending")
+        self.assertEqual(body["downstream"]["blockchain_transaction"], "pending")
+
+    def test_csv_routes_to_csv_handler(self):
+        response = upload_file("sample.csv", b"age,diagnosis\n42,test\n", "text/csv")
+        self.assert_routes_to(response, "csv", "anonymize_csv")
+
+    def test_text_routes_to_text_handler(self):
+        response = upload_file("note.txt", b"clinical note scaffold\n", "text/plain")
+        self.assert_routes_to(response, "text", "anonymize_text")
+
+    def test_dicom_extension_routes_to_dicom_handler(self):
+        response = upload_file("scan.dcm", b"not-real-dicom-routing-only")
+        self.assert_routes_to(response, "dicom", "anonymize_dicom")
+
+    def test_dicom_octet_stream_routes_by_extension(self):
+        response = upload_file(
+            "scan.dcm",
+            b"dicom routing scaffold",
+            "application/octet-stream",
+        )
+        self.assert_routes_to(response, "dicom", "anonymize_dicom")
+
+    def test_nifti_nii_routes_to_nifti_handler(self):
+        response = upload_file("brain.nii", b"nifti routing scaffold")
+        self.assert_routes_to(response, "nifti", "anonymize_nifti")
+
+    def test_nifti_nii_gz_routes_to_nifti_handler(self):
+        response = upload_file("brain.nii.gz", b"compressed nifti scaffold")
+        self.assert_routes_to(response, "nifti", "anonymize_nifti")
+
+    def test_wsi_routes_to_wsi_handler(self):
+        response = upload_file("slide.svs", b"wsi routing scaffold")
+        self.assert_routes_to(response, "wsi", "anonymize_wsi")
+
+    def test_unsupported_file_type_is_rejected(self):
+        response = upload_file("archive.zip", b"zip scaffold")
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["detail"], "Unsupported file modality")
+
+    def test_empty_file_is_rejected(self):
+        response = upload_file("empty.csv", b"", "text/csv")
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["detail"], "Uploaded file is empty")
+
+    def test_invalid_profile_is_rejected(self):
+        response = upload_file("sample.csv", b"a,b\n1,2\n", "text/csv", "open")
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("Invalid privacy profile", response.json()["detail"])
+
+    def test_dicom_preamble_detection_routes_to_dicom_handler(self):
+        dicom_header = b"\x00" * 128 + b"DICM" + b"routing scaffold"
+        response = upload_file("scan.bin", dicom_header, "application/octet-stream")
+        self.assert_routes_to(response, "dicom", "anonymize_dicom")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python_backend/tests/test_ingestion.py
+++ b/python_backend/tests/test_ingestion.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 import sys
 import unittest
@@ -8,10 +9,32 @@ from fastapi.testclient import TestClient
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from main import app  # noqa: E402
+from main import app, ingest_file  # noqa: E402
 
 
 client = TestClient(app)
+
+
+class FakeUploadFile:
+    def __init__(self, filename, content, content_type):
+        self.filename = filename
+        self.content = content
+        self.content_type = content_type
+        self.position = 0
+        self.seek_offsets = []
+
+    async def read(self, size=-1):
+        if size is None or size < 0:
+            size = len(self.content) - self.position
+
+        start = self.position
+        end = min(start + size, len(self.content))
+        self.position = end
+        return self.content[start:end]
+
+    async def seek(self, offset):
+        self.seek_offsets.append(offset)
+        self.position = offset
 
 
 def upload_file(filename, content, content_type="application/octet-stream", profile=None):
@@ -91,6 +114,20 @@ class TestIngestionRouting(unittest.TestCase):
         dicom_header = b"\x00" * 128 + b"DICM" + b"routing scaffold"
         response = upload_file("scan.bin", dicom_header, "application/octet-stream")
         self.assert_routes_to(response, "dicom", "anonymize_dicom")
+
+    def test_endpoint_resets_upload_stream_after_header_read(self):
+        fake_file = FakeUploadFile(
+            filename="sample.csv",
+            content=b"age,diagnosis\n42,test\n",
+            content_type="text/csv",
+        )
+
+        result = asyncio.run(ingest_file(file=fake_file, profile="strict"))
+
+        self.assertEqual(fake_file.seek_offsets, [0])
+        self.assertEqual(fake_file.position, 0)
+        self.assertEqual(result["detected_modality"], "csv")
+        self.assertEqual(result["handler"], "anonymize_csv")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
@pradeeban @karthiksathishjeemain @Chali-healthy, This PR adds the Week 1 ingestion routing scaffold for the GSoC project:

**Bio-Block: Advanced PHI Anonymization and Hybrid Data Retrieval Pipeline**

The goal of this first Week 1 change is not to perform real anonymization yet. Instead, this PR creates the first safe upload entry point that can receive biomedical files, detect what type of file was uploaded, choose the correct placeholder anonymization handler, and return a clear structured response.

This keeps the first PR small, reviewable, and focused only on routing.

## What This PR Adds

### 1. New ingestion endpoint

Added a new FastAPI endpoint:

```txt
POST /api/v1/ingest
```

The endpoint accepts:

- an uploaded file
- a privacy profile, with default value `strict`

Supported privacy profiles for now are:

- `strict`
- `research`

At this stage, the privacy profile is only validated and returned in the response. Real profile-based anonymization logic will come in later milestones.

### 2. Privacy-safe upload behavior

The endpoint is designed as a safe first step before any real storage or retrieval work happens.

It does not:

- store the raw uploaded file
- write the raw file to disk
- index raw metadata
- call ChromaDB
- call IPFS
- encrypt CIDs
- create blockchain transactions
- trigger the existing search or storage pipeline

For Week 1, the endpoint only reads a small bounded header sample from the upload so it can detect the file type and choose the correct placeholder handler.

This is important because raw biomedical files should not accidentally enter storage or indexing before anonymization exists.

### 3. Modality Detection Service

Added a new focused service module:

```txt
python_backend/services/ingestion.py
```

This module handles the Week 1 ingestion logic.

It can detect these file modalities:

- CSV
- clinical text
- DICOM
- NIfTI
- WSI

Supported examples:

- `.csv`
- `.txt`
- `.dcm`
- `.dicom`
- `.nii`
- `.nii.gz`
- `.svs`
- `.tif`
- `.tiff`

The detector does not rely only on the browser-provided `content_type`, because uploaded medical files are often reported as `application/octet-stream`.

For DICOM, it also checks for the standard DICOM preamble:

```txt
DICM at byte offset 128
```

This means a DICOM file can still be detected even if the filename or browser MIME type is not enough.

### 4. Placeholder Anonymization Handlers

This PR adds placeholder handlers for each supported modality:

- `anonymize_csv`
- `anonymize_text`
- `anonymize_dicom`
- `anonymize_nifti`
- `anonymize_wsi`

These handlers do not perform real anonymization yet.

They only confirm that routing worked and that the correct handler was selected.

The response clearly says:

```txt
anonymization_status: placeholder
```

This is intentional. The API should not claim that PHI was removed when real anonymization has not been implemented yet.

### 5. Handler Registry

Added a simple handler registry that maps each detected modality to the correct placeholder handler.

Example:

```txt
csv   -> anonymize_csv
text  -> anonymize_text
dicom -> anonymize_dicom
nifti -> anonymize_nifti
wsi   -> anonymize_wsi
```

This gives us a clean place to replace placeholder handlers with real anonymization logic in later weeks.

### 6. Structured Response

The endpoint now returns a clear routing response.

Example response:

```json
{
  "status": "success",
  "filename": "sample.dcm",
  "detected_modality": "dicom",
  "privacy_profile": "strict",
  "handler": "anonymize_dicom",
  "routing_status": "handler_selected",
  "anonymization_status": "placeholder",
  "message": "Week 1 routing scaffold selected this handler. Real anonymization will be added in later milestones.",
  "downstream": {
    "ipfs_chunking": "pending",
    "cid_encryption": "pending",
    "metadata_indexing": "pending",
    "blockchain_transaction": "pending"
  }
}
```

The downstream steps are marked as `pending` on purpose. They should only happen after real anonymization is implemented.

## Validation Added

The endpoint now rejects:

- empty uploads
- missing or empty filenames
- unsupported file types
- invalid privacy profiles
- missing handlers in the registry

Errors are returned using FastAPI `HTTPException` with clear messages.

## Tests Added

Added focused routing tests in:

```txt
python_backend/tests/test_ingestion.py
```

The tests cover:

- CSV routes to CSV handler
- text routes to text handler
- DICOM `.dcm` routes to DICOM handler
- DICOM with `application/octet-stream` still routes by extension
- NIfTI `.nii` routes to NIfTI handler
- NIfTI `.nii.gz` routes to NIfTI handler
- WSI `.svs` routes to WSI handler
- unsupported file type is rejected
- empty file is rejected
- invalid profile is rejected
- DICOM preamble detection works

All test files are tiny synthetic uploads created in memory. No real medical files, no PHI, and no large binary files were added.

## Test Result

Ran:

```bash
py -3.11 -m pytest tests/test_ingestion.py
```

Result:

```txt
11 passed
```

There were a few dependency warnings from installed packages, but the new ingestion routing tests passed successfully.

## Files Changed

```txt
python_backend/main.py
python_backend/services/ingestion.py
python_backend/tests/test_ingestion.py
```

## What This PR Does Not Do

This PR does not implement:

- real PHI anonymization
- Presidio logic
- DICOM metadata scrubbing
- NIfTI metadata scrubbing
- OCR redaction
- k-anonymity
- l-diversity
- t-closeness
- BM25
- ChromaDB retrieval
- IPFS upload
- CID encryption
- blockchain transaction flow

Those parts are intentionally left for later milestones.

## Why This Is Useful

This PR creates the first clean entry point for the future anonymization pipeline.

Before Bio-Block can safely anonymize and retrieve biomedical data, it needs a safe upload gateway that can:

1. receive the file,
2. detect the file modality,
3. choose the correct processing path,
4. avoid unsafe storage before anonymization,
5. return a clear routing result.

That is what this PR adds.

It gives future work a small and clear base to build on without changing the existing storage, search, IPFS, or blockchain flows. Please have a look everyone and i will be making further daily commits this week to this PR, let me know if there is any required chnages you need and your feedback :) Thankyou