### PR TITLE
Add IQR, quartiles, and Spearman correlation to descriptive stats

### DIFF
--- a/analytics-service/app/services/descriptive.py
+++ b/analytics-service/app/services/descriptive.py
@@ -10,6 +10,22 @@ import pandas as pd
 
 def compute_column_stats(series: pd.Series) -> dict:
     clean = series.dropna()
+
+    # Guard: return None instead of NaN when column has no data
+    if clean.empty:
+        return {
+            "count": 0,
+            "mean": None,
+            "std": None,
+            "min": None,
+            "q1": None,
+            "median": None,
+            "q3": None,
+            "iqr": None,
+            "max": None,
+            "missing_pct": 100.0,
+        }
+
     q1 = float(clean.quantile(0.25))
     q3 = float(clean.quantile(0.75))
     return {

--- a/analytics-service/app/services/descriptive.py
+++ b/analytics-service/app/services/descriptive.py
@@ -10,13 +10,18 @@ import pandas as pd
 
 def compute_column_stats(series: pd.Series) -> dict:
     clean = series.dropna()
+    q1 = float(clean.quantile(0.25))
+    q3 = float(clean.quantile(0.75))
     return {
         "count": int(clean.count()),
         "mean": round(float(clean.mean()), 4),
         "std": round(float(clean.std()), 4),
         "min": float(clean.min()),
-        "max": float(clean.max()),
+        "q1": round(q1, 4),
         "median": float(clean.median()),
+        "q3": round(q3, 4),
+        "iqr": round(q3 - q1, 4),
+        "max": float(clean.max()),
         "missing_pct": round(float(series.isna().mean() * 100), 2),
     }
 
@@ -34,10 +39,13 @@ def classify_columns(df: pd.DataFrame) -> dict:
 
 
 def compute_correlation_matrix(df: pd.DataFrame, columns: list) -> Optional[dict]:
-    """Pearson correlation matrix. None if < 2 columns."""
+    """Pearson + Spearman correlation matrices. None if < 2 columns."""
     if len(columns) < 2:
         return None
-    return df[columns].corr().round(4).to_dict()
+    return {
+        "pearson": df[columns].corr(method="pearson").round(4).to_dict(),
+        "spearman": df[columns].corr(method="spearman").round(4).to_dict(),
+    }
 
 
 def run_descriptive_analysis(df: pd.DataFrame, columns: Optional[list] = None) -> dict:

--- a/analytics-service/tests/test_descriptive.py
+++ b/analytics-service/tests/test_descriptive.py
@@ -35,6 +35,20 @@ class TestComputeColumnStats:
         stats = compute_column_stats(pd.Series([7, 7, 7, 7]))
         assert stats["std"] == 0.0
 
+    def test_empty_column(self):
+        """All-NaN column should return None stats, not NaN."""
+        stats = compute_column_stats(pd.Series([None, None, None], dtype="float64"))
+        assert stats["count"] == 0
+        assert stats["missing_pct"] == 100.0
+        assert stats["mean"] is None
+        assert stats["std"] is None
+        assert stats["min"] is None
+        assert stats["q1"] is None
+        assert stats["median"] is None
+        assert stats["q3"] is None
+        assert stats["iqr"] is None
+        assert stats["max"] is None
+
 
 class TestClassifyColumns:
 

--- a/analytics-service/tests/test_descriptive.py
+++ b/analytics-service/tests/test_descriptive.py
@@ -54,7 +54,8 @@ class TestCorrelationMatrix:
     def test_perfect_correlation(self):
         df = pd.DataFrame({"x": [1, 2, 3, 4], "y": [2, 4, 6, 8]})
         corr = compute_correlation_matrix(df, ["x", "y"])
-        assert corr["x"]["y"] == 1.0
+        assert corr["pearson"]["x"]["y"] == 1.0
+        assert corr["spearman"]["x"]["y"] == 1.0
 
     def test_single_column_returns_none(self):
         df = pd.DataFrame({"x": [1, 2, 3]})
@@ -63,9 +64,10 @@ class TestCorrelationMatrix:
     def test_values_in_range(self, sample_dataframe):
         cols = ["age", "glucose", "cholesterol"]
         corr = compute_correlation_matrix(sample_dataframe, cols)
-        for a in cols:
-            for b in cols:
-                assert -1.0 <= corr[a][b] <= 1.0
+        for method in ("pearson", "spearman"):
+            for a in cols:
+                for b in cols:
+                    assert -1.0 <= corr[method][a][b] <= 1.0
 
 
 class TestRunDescriptiveAnalysis:


### PR DESCRIPTION

## What Changed

### 1. Added quartiles and IQR to per-column stats

The first PR only returned `mean`, `std`, `min`, `max`, and `median`. That's fine for normally distributed data, but a lot of health datasets are skewed - blood glucose, cholesterol, and BMI all tend to have long tails. IQR (Q3 − Q1) gives a better sense of spread in those cases because it ignores outliers entirely. It's also useful down the line if we want to flag outliers automatically (anything outside 1.5×IQR from the quartiles).

### 2. Added Spearman alongside Pearson in the correlation matrix

Pearson measures linear relationships, which assumes the data is roughly normally distributed. Spearman is rank-based- it catches monotonic trends even when the relationship isn't a straight line. Since we're dealing with health data where distributions are unpredictable, returning both lets the consumer pick whichever is more appropriate.

The `_correlations` key in the response now looks like:

```json
{
  "pearson": { "age": { "glucose": 0.85 }, ... },
  "spearman": { "age": { "glucose": 0.80 }, ... }
}
```

## Files Changed

- `analytics-service/app/services/descriptive.py` — added `q1`, `q3`, `iqr` to column stats; correlation matrix now returns both methods
- `analytics-service/tests/test_descriptive.py` — updated correlation tests for the new nested structure

All 31 tests passing.