### PR TITLE
WEEK 3 - Add visualization engine

### DIFF
--- a/analytics-service/app/main.py
+++ b/analytics-service/app/main.py
@@ -7,8 +7,9 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from app.auth.dependencies import AuthenticatedWallet, require_eip712_auth
 from app.auth.rate_limiter import rate_limiter
-from app.models.schemas import DescriptiveResponse, HealthResponse
+from app.models.schemas import DescriptiveResponse, HealthResponse, VisualizationResponse
 from app.services.descriptive import run_descriptive_analysis
+from app.services.visualization import VALID_CHART_TYPES, generate_chart
 from app.utils.csv_parser import parse_csv
 
 APP_VERSION = "0.1.0"
@@ -44,8 +45,10 @@ async def descriptive_analysis(
 
     contents = await file.read()
     df = parse_csv(contents)
-    target_cols = columns.split(",") if columns else None
-    analysis = run_descriptive_analysis(df, columns=target_cols)
+    target_cols = None
+    if columns and columns.strip() and columns.strip() != "string":
+        target_cols = [c.strip() for c in columns.split(",") if c.strip() and c.strip() != "string"]
+    analysis = run_descriptive_analysis(df, columns=target_cols or None)
 
     return DescriptiveResponse(
         source_dataset_cid=auth.dataset_cid,
@@ -55,9 +58,71 @@ async def descriptive_analysis(
     )
 
 
-@app.post("/analytics/visualize")
-async def visualize():
-    raise HTTPException(501, "Not yet implemented.")
+@app.post("/analytics/visualize", response_model=VisualizationResponse)
+async def visualize(
+    auth: AuthenticatedWallet = Depends(require_eip712_auth),
+    file: UploadFile = File(...),
+    chart_type: str = Form(..., description=f"One of: {', '.join(VALID_CHART_TYPES)}"),
+    x_column: Optional[str] = Form(None),
+    y_column: Optional[str] = Form(None),
+    columns: Optional[str] = Form(None, description="Comma-separated column names for multi-column charts"),
+    group_column: Optional[str] = Form(None),
+    aggregation: Optional[str] = Form("count", description="Aggregation: count, mean, sum"),
+    bins: Optional[int] = Form(20, description="Number of bins for histograms"),
+):
+    # Per-wallet rate limiting
+    if not rate_limiter.check(auth.wallet_address):
+        raise HTTPException(429, "Rate limit exceeded. Try again shortly.")
+
+    contents = await file.read()
+
+    if chart_type not in VALID_CHART_TYPES:
+        raise HTTPException(
+            400,
+            f"Unsupported chart type '{chart_type}'. Valid types: {VALID_CHART_TYPES}",
+        )
+
+    df = parse_csv(contents)
+
+    # Swagger UI sends "string" as default placeholder — treat as empty
+    def _clean(val: Optional[str]) -> Optional[str]:
+        if val is None:
+            return None
+        val = val.strip()
+        if val == "" or val == "string":
+            return None
+        return val
+
+    x_col = _clean(x_column)
+    y_col = _clean(y_column)
+    grp_col = _clean(group_column)
+    cols_list = None
+    if columns and _clean(columns):
+        cols_list = [c.strip() for c in columns.split(",") if c.strip() and c.strip() != "string"]
+        if not cols_list:
+            cols_list = None
+
+    try:
+        result = generate_chart(
+            df=df,
+            chart_type=chart_type,
+            x_column=x_col,
+            y_column=y_col,
+            columns=cols_list,
+            group_column=grp_col,
+            aggregation=_clean(aggregation) or "count",
+            bins=bins or 20,
+        )
+    except ValueError as exc:
+        raise HTTPException(400, str(exc))
+
+    return VisualizationResponse(
+        source_dataset_cid=auth.dataset_cid,
+        chart_type=chart_type,
+        chart_config=result["chart_config"],
+        image=result["image"],
+        row_count=len(df),
+    )
 
 
 @app.post("/analytics/infer")

--- a/analytics-service/app/models/schemas.py
+++ b/analytics-service/app/models/schemas.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field
 
@@ -20,6 +20,15 @@ class DescriptiveResponse(BaseModel):
     row_count: int
     columns_analyzed: list
     results: dict
+
+
+class VisualizationResponse(BaseModel):
+    analysis_type: str = "graphical"
+    source_dataset_cid: str
+    chart_type: str
+    chart_config: Dict[str, Any]
+    image: str = Field(..., description="Base64-encoded PNG image")
+    row_count: int
 
 
 class ErrorResponse(BaseModel):

--- a/analytics-service/app/services/visualization.py
+++ b/analytics-service/app/services/visualization.py
@@ -1,0 +1,682 @@
+from __future__ import annotations
+
+import base64
+import io
+from contextlib import contextmanager
+from typing import Any, Dict, List, Optional
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+from scipy.stats import chi2_contingency
+import matplotlib.dates as mdates
+
+
+def _is_datetime(series: pd.Series) -> bool:
+    return pd.api.types.is_datetime64_any_dtype(series)
+
+
+def _is_categorical(series: pd.Series) -> bool:
+    if np.issubdtype(series.dtype, np.number):
+        return False
+    if _is_datetime(series):
+        return False
+    return True
+
+
+def _coerce_datetime(series: pd.Series) -> pd.Series:
+    """Try parsing strings as datetime; return original on failure."""
+    if _is_datetime(series):
+        return series
+    if series.dtype == object:
+        try:
+            parsed = pd.to_datetime(series, errors='coerce')
+            # Only accept if >50% parsed successfully
+            if parsed.notna().sum() > 0.5 * series.notna().sum():
+                return parsed
+        except Exception:
+            pass
+    return series
+
+
+@contextmanager
+def _safe_figure(figsize=(8, 5)):
+    """Yield (fig, ax) and guarantee plt.close on exit."""
+    fig, ax = plt.subplots(figsize=figsize)
+    try:
+        yield fig, ax
+    finally:
+        plt.close(fig)
+
+
+def _build_histogram_config(
+    df: pd.DataFrame, column: str, bins: int = 20
+) -> Dict[str, Any]:
+    """Histogram for numeric, frequency bar for categorical, time-binned for datetime."""
+
+    series = df[column].dropna()
+
+
+    if _is_datetime(series):
+        with _safe_figure() as (fig, ax):
+            ax.hist(series, bins=bins, edgecolor="black", alpha=0.75, color="#4C9AFF")
+            ax.xaxis.set_major_formatter(mdates.DateFormatter("%Y-%m-%d"))
+            ax.xaxis.set_major_locator(mdates.AutoDateLocator())
+            ax.set_xlabel(column)
+            ax.set_ylabel("Frequency")
+            ax.set_title(f"Distribution of {column}")
+            plt.xticks(rotation=45, ha="right")
+            plt.tight_layout()
+            image_b64 = _fig_to_base64(fig)
+
+        chart_config = {
+            "type": "histogram",
+            "labels": [],
+            "datasets": [{"label": column, "data": []}],
+            "options": {"xLabel": column, "yLabel": "Frequency", "datetime": True, "bins": bins},
+        }
+        return {"chart_config": chart_config, "image": image_b64}
+
+
+    if _is_categorical(series):
+        counts = series.value_counts().sort_index()
+        labels = [str(x) for x in counts.index.tolist()]
+        values = counts.values.tolist()
+
+        chart_config = {
+            "type": "histogram",
+            "labels": labels,
+            "datasets": [{"label": column, "data": values}],
+            "options": {"xLabel": column, "yLabel": "Frequency", "categorical": True},
+        }
+
+        with _safe_figure() as (fig, ax):
+            colors = plt.cm.Set2(np.linspace(0, 1, len(labels)))
+            ax.bar(labels, values, edgecolor="black", alpha=0.8, color=colors)
+            ax.set_xlabel(column)
+            ax.set_ylabel("Frequency")
+            ax.set_title(f"Distribution of {column}")
+            plt.xticks(rotation=45, ha="right")
+            plt.tight_layout()
+            image_b64 = _fig_to_base64(fig)
+        return {"chart_config": chart_config, "image": image_b64}
+
+
+    counts, edges = np.histogram(series, bins=bins)
+    labels = [f"{edges[i]:.1f}-{edges[i+1]:.1f}" for i in range(len(counts))]
+
+    chart_config = {
+        "type": "histogram",
+        "labels": labels,
+        "datasets": [
+            {
+                "label": column,
+                "data": counts.tolist(),
+            }
+        ],
+        "options": {"xLabel": column, "yLabel": "Frequency", "bins": bins},
+    }
+
+    with _safe_figure() as (fig, ax):
+        ax.hist(series, bins=bins, edgecolor="black", alpha=0.75, color="#4C9AFF")
+        ax.set_xlabel(column)
+        ax.set_ylabel("Frequency")
+        ax.set_title(f"Distribution of {column}")
+        plt.tight_layout()
+        image_b64 = _fig_to_base64(fig)
+
+    return {"chart_config": chart_config, "image": image_b64}
+
+
+def _encode_categorical_axis(series: pd.Series):
+    categories = series.dropna().unique()
+    cat_map = {cat: idx for idx, cat in enumerate(categories)}
+    codes = series.map(cat_map)
+    return codes, categories.tolist(), cat_map
+
+
+def _serialize_val(val):
+    if hasattr(val, 'isoformat'):
+        return val.isoformat()
+    try:
+        return float(val)
+    except (TypeError, ValueError):
+        return str(val)
+
+
+def _build_scatter_config(
+    df: pd.DataFrame,
+    x_column: str,
+    y_column: str,
+    group_column: Optional[str] = None,
+) -> Dict[str, Any]:
+    work = df[[x_column, y_column]].dropna().copy()
+
+    x_is_cat = _is_categorical(work[x_column])
+    y_is_cat = _is_categorical(work[y_column])
+    x_is_dt = _is_datetime(work[x_column])
+    y_is_dt = _is_datetime(work[y_column])
+
+    x_tick_labels: Optional[list] = None
+    y_tick_labels: Optional[list] = None
+
+    if x_is_cat:
+        codes, x_tick_labels, _ = _encode_categorical_axis(work[x_column])
+        work[x_column] = codes
+    if y_is_cat:
+        codes, y_tick_labels, _ = _encode_categorical_axis(work[y_column])
+        work[y_column] = codes
+
+    # Jitter categorical axes to avoid overlapping points
+    jitter_x = np.random.uniform(-0.15, 0.15, len(work)) if x_is_cat else 0
+    jitter_y = np.random.uniform(-0.15, 0.15, len(work)) if y_is_cat else 0
+
+    datasets: List[Dict[str, Any]] = []
+
+    with _safe_figure() as (fig, ax):
+        if group_column and group_column in df.columns:
+            groups = df.loc[work.index, group_column].dropna().unique()
+            colors = plt.cm.tab10(np.linspace(0, 1, min(len(groups), 10)))
+            for idx, group in enumerate(groups):
+                mask = df.loc[work.index, group_column] == group
+                subset = work.loc[mask]
+                color = colors[idx % len(colors)]
+                sx = subset[x_column].values + (jitter_x[mask.values] if x_is_cat else 0)
+                sy = subset[y_column].values + (jitter_y[mask.values] if y_is_cat else 0)
+                ax.scatter(sx, sy, label=str(group), alpha=0.7, color=color)
+                datasets.append({
+                    "label": str(group),
+                    "data": [
+                        {"x": _serialize_val(x), "y": _serialize_val(y)}
+                        for x, y in zip(subset[x_column], subset[y_column])
+                    ],
+                })
+            ax.legend()
+        else:
+            sx = work[x_column].values + jitter_x
+            sy = work[y_column].values + jitter_y
+            ax.scatter(sx, sy, alpha=0.7, color="#4C9AFF")
+            datasets.append({
+                "label": f"{x_column} vs {y_column}",
+                "data": [
+                    {"x": _serialize_val(x), "y": _serialize_val(y)}
+                    for x, y in zip(work[x_column], work[y_column])
+                ],
+            })
+
+        if x_tick_labels is not None:
+            ax.set_xticks(range(len(x_tick_labels)))
+            ax.set_xticklabels([str(l) for l in x_tick_labels], rotation=45, ha="right")
+        if y_tick_labels is not None:
+            ax.set_yticks(range(len(y_tick_labels)))
+            ax.set_yticklabels([str(l) for l in y_tick_labels])
+
+
+        if x_is_dt:
+            ax.xaxis.set_major_formatter(mdates.DateFormatter("%Y-%m-%d"))
+            ax.xaxis.set_major_locator(mdates.AutoDateLocator())
+            plt.xticks(rotation=45, ha="right")
+        if y_is_dt:
+            ax.yaxis.set_major_formatter(mdates.DateFormatter("%Y-%m-%d"))
+
+        ax.set_xlabel(x_column)
+        ax.set_ylabel(y_column)
+        ax.set_title(f"{x_column} vs {y_column}")
+        plt.tight_layout()
+        image_b64 = _fig_to_base64(fig)
+
+    options: Dict[str, Any] = {"xLabel": x_column, "yLabel": y_column}
+    if x_tick_labels is not None:
+        options["xCategories"] = [str(l) for l in x_tick_labels]
+    if y_tick_labels is not None:
+        options["yCategories"] = [str(l) for l in y_tick_labels]
+    if x_is_dt:
+        options["xDatetime"] = True
+    if y_is_dt:
+        options["yDatetime"] = True
+
+    chart_config = {
+        "type": "scatter",
+        "datasets": datasets,
+        "options": options,
+    }
+    return {"chart_config": chart_config, "image": image_b64}
+
+
+def _build_box_config(
+    df: pd.DataFrame,
+    columns: List[str],
+    group_column: Optional[str] = None,
+) -> Dict[str, Any]:
+
+    if group_column and group_column in df.columns and len(columns) == 1:
+        col = columns[0]
+        if _is_categorical(df[col]):
+            raise ValueError(
+                f"Column '{col}' is categorical. "
+                "box plot requires numeric columns. "
+                "Use 'bar' or 'pie' chart for categorical data."
+            )
+    else:
+        col = None
+        numeric_cols = [c for c in columns if c in df.columns and not _is_categorical(df[c])]
+        skipped = [c for c in columns if c in df.columns and _is_categorical(df[c])]
+
+        if not numeric_cols:
+            raise ValueError(
+                f"All requested columns are categorical ({', '.join(skipped)}). "
+                "box plot requires at least one numeric column. "
+                "Use 'bar' or 'pie' chart for categorical data, "
+                "or 'heatmap' for a categorical association matrix."
+            )
+
+    with _safe_figure() as (fig, ax):
+        if col is not None:
+            groups = df[group_column].dropna().unique().tolist()
+            data_per_group = [
+                df.loc[df[group_column] == g, col].dropna().tolist() for g in groups
+            ]
+            ax.boxplot(data_per_group, tick_labels=[str(g) for g in groups])
+            ax.set_ylabel(col)
+            ax.set_title(f"{col} by {group_column}")
+
+            datasets = []
+            for g, d in zip(groups, data_per_group):
+                s = pd.Series(d)
+                if s.empty:
+                    datasets.append({"label": str(g), "min": None, "q1": None, "median": None, "q3": None, "max": None})
+                else:
+                    datasets.append({
+                        "label": str(g),
+                        "min": float(s.min()),
+                        "q1": float(s.quantile(0.25)),
+                        "median": float(s.median()),
+                        "q3": float(s.quantile(0.75)),
+                        "max": float(s.max()),
+                    })
+            chart_config = {"type": "box", "labels": [str(g) for g in groups], "datasets": datasets}
+        else:
+            data = [df[c].dropna().tolist() for c in numeric_cols]
+            ax.boxplot(data, tick_labels=numeric_cols)
+            ax.set_title("Box Plot")
+            ax.set_ylabel("Value")
+
+            datasets = []
+            for c in numeric_cols:
+                s = df[c].dropna()
+                datasets.append({
+                    "label": c,
+                    "min": float(s.min()),
+                    "q1": float(s.quantile(0.25)),
+                    "median": float(s.median()),
+                    "q3": float(s.quantile(0.75)),
+                    "max": float(s.max()),
+                })
+            chart_config = {
+                "type": "box",
+                "labels": numeric_cols,
+                "datasets": datasets,
+            }
+            if skipped:
+                chart_config["skipped_categorical"] = skipped
+
+        plt.tight_layout()
+        image_b64 = _fig_to_base64(fig)
+
+    return {"chart_config": chart_config, "image": image_b64}
+
+
+def _cramers_v(x: pd.Series, y: pd.Series) -> float:
+    ct = pd.crosstab(x, y)
+    n = ct.sum().sum()
+    if n == 0:
+        return 0.0
+    chi2 = chi2_contingency(ct)[0]
+    min_dim = min(ct.shape[0], ct.shape[1]) - 1
+    if min_dim == 0:
+        return 0.0
+    return float(np.sqrt(chi2 / (n * min_dim)))
+
+
+def _build_heatmap_config(
+    df: pd.DataFrame, columns: List[str], method: str = "pearson"
+) -> Dict[str, Any]:
+    """Pearson/Spearman for numeric cols, Cramér's V for categorical."""
+
+    numeric_cols = [c for c in columns if c in df.columns and not _is_categorical(df[c])]
+    cat_cols = [c for c in columns if c in df.columns and _is_categorical(df[c])]
+
+
+    if len(cat_cols) >= 2 and len(numeric_cols) < 2:
+        n = len(cat_cols)
+        assoc = pd.DataFrame(np.ones((n, n)), index=cat_cols, columns=cat_cols)
+        for i in range(n):
+            for j in range(i + 1, n):
+                v = _cramers_v(df[cat_cols[i]].dropna(), df[cat_cols[j]].dropna())
+                assoc.iloc[i, j] = round(v, 4)
+                assoc.iloc[j, i] = round(v, 4)
+
+        with _safe_figure(figsize=(8, 6)) as (fig, ax):
+            im = ax.imshow(assoc.values, cmap="YlOrRd", vmin=0, vmax=1, aspect="auto")
+            ax.set_xticks(range(n))
+            ax.set_yticks(range(n))
+            ax.set_xticklabels(cat_cols, rotation=45, ha="right")
+            ax.set_yticklabels(cat_cols)
+
+            for i in range(n):
+                for j in range(n):
+                    val = assoc.values[i, j]
+                    ax.text(j, i, f"{val:.2f}", ha="center", va="center",
+                            color="white" if val > 0.5 else "black", fontsize=9)
+
+            fig.colorbar(im)
+            ax.set_title("Cramér's V Association Heatmap")
+            plt.tight_layout()
+            image_b64 = _fig_to_base64(fig)
+
+        chart_config = {
+            "type": "heatmap",
+            "labels": cat_cols,
+            "data": assoc.round(4).to_dict(),
+            "options": {"method": "cramers_v", "categorical": True},
+        }
+        return {"chart_config": chart_config, "image": image_b64}
+
+
+    if len(numeric_cols) < 2:
+        raise ValueError(
+            "Heatmap requires at least 2 numeric columns for correlation "
+            "or at least 2 categorical columns for association (Cramér's V)."
+        )
+
+    corr = df[numeric_cols].corr(method=method).round(4)
+
+    with _safe_figure(figsize=(8, 6)) as (fig, ax):
+        im = ax.imshow(corr.values, cmap="RdBu_r", vmin=-1, vmax=1, aspect="auto")
+        ax.set_xticks(range(len(numeric_cols)))
+        ax.set_yticks(range(len(numeric_cols)))
+        ax.set_xticklabels(numeric_cols, rotation=45, ha="right")
+        ax.set_yticklabels(numeric_cols)
+
+
+        for i in range(len(numeric_cols)):
+            for j in range(len(numeric_cols)):
+                ax.text(j, i, f"{corr.values[i, j]:.2f}", ha="center", va="center",
+                        color="white" if abs(corr.values[i, j]) > 0.5 else "black", fontsize=9)
+
+        fig.colorbar(im)
+        ax.set_title(f"{method.capitalize()} Correlation Heatmap")
+        plt.tight_layout()
+        image_b64 = _fig_to_base64(fig)
+
+    chart_config = {
+        "type": "heatmap",
+        "labels": numeric_cols,
+        "data": corr.to_dict(),
+        "options": {"method": method},
+    }
+    return {"chart_config": chart_config, "image": image_b64}
+
+
+def _build_bar_config(
+    df: pd.DataFrame,
+    x_column: str,
+    y_column: Optional[str] = None,
+    aggregation: str = "count",
+) -> Dict[str, Any]:
+
+    if y_column and y_column in df.columns and aggregation != "count":
+        grouped = df.groupby(x_column)[y_column]
+        if aggregation == "mean":
+            agg_data = grouped.mean()
+        elif aggregation == "sum":
+            agg_data = grouped.sum()
+        else:
+            agg_data = grouped.count()
+        y_label = f"{aggregation.capitalize()} of {y_column}"
+    else:
+        agg_data = df[x_column].value_counts().sort_index()
+        y_label = "Count"
+
+    labels = [str(x) for x in agg_data.index.tolist()]
+    values = [float(v) for v in agg_data.values.tolist()]
+
+    with _safe_figure() as (fig, ax):
+        ax.bar(labels, values, color="#4C9AFF", edgecolor="black", alpha=0.8)
+        ax.set_xlabel(x_column)
+        ax.set_ylabel(y_label)
+        ax.set_title(f"{y_label} by {x_column}")
+        plt.xticks(rotation=45, ha="right")
+        plt.tight_layout()
+        image_b64 = _fig_to_base64(fig)
+
+    chart_config = {
+        "type": "bar",
+        "labels": labels,
+        "datasets": [{"label": y_label, "data": values}],
+        "options": {"xLabel": x_column, "yLabel": y_label, "aggregation": aggregation},
+    }
+    return {"chart_config": chart_config, "image": image_b64}
+
+
+def _build_line_config(
+    df: pd.DataFrame,
+    x_column: str,
+    y_column: str,
+    aggregation: str = "mean",
+) -> Dict[str, Any]:
+    work = df[[x_column, y_column]].dropna().copy()
+
+
+    work[x_column] = _coerce_datetime(work[x_column])
+    x_is_dt = _is_datetime(work[x_column])
+
+    work = work.sort_values(x_column)
+
+    options: Dict[str, Any] = {"xLabel": x_column, "yLabel": y_column, "aggregation": aggregation}
+
+    with _safe_figure() as (fig, ax):
+        if x_is_dt:
+
+            ax.plot(work[x_column], work[y_column], marker="o", color="#4C9AFF",
+                    linewidth=2, markersize=4)
+            ax.xaxis.set_major_formatter(mdates.DateFormatter("%Y-%m-%d"))
+            ax.xaxis.set_major_locator(mdates.AutoDateLocator())
+            x_vals = [v.isoformat() if hasattr(v, 'isoformat') else str(v)
+                      for v in work[x_column].tolist()]
+            y_vals = [float(v) for v in work[y_column].tolist()]
+            options["datetime"] = True
+
+        elif _is_categorical(work[x_column]):
+            grouped = work.groupby(x_column)[y_column]
+            if aggregation == "mean":
+                agg = grouped.mean()
+            elif aggregation == "sum":
+                agg = grouped.sum()
+            else:
+                agg = grouped.count()
+            x_vals = [str(x) for x in agg.index.tolist()]
+            y_vals = [float(v) for v in agg.values.tolist()]
+            ax.plot(x_vals, y_vals, marker="o", color="#4C9AFF", linewidth=2, markersize=4)
+
+        else:
+            x_vals = [float(v) for v in work[x_column].tolist()]
+            y_vals = [float(v) for v in work[y_column].tolist()]
+            ax.plot(x_vals, y_vals, marker="o", color="#4C9AFF", linewidth=2, markersize=4)
+
+        ax.set_xlabel(x_column)
+        ax.set_ylabel(y_column)
+        ax.set_title(f"{y_column} over {x_column}")
+        plt.xticks(rotation=45, ha="right")
+        plt.tight_layout()
+        image_b64 = _fig_to_base64(fig)
+
+    chart_config = {
+        "type": "line",
+        "labels": x_vals if all(isinstance(v, str) for v in x_vals) else None,
+        "datasets": [
+            {
+                "label": y_column,
+                "data": (
+                    y_vals
+                    if all(isinstance(v, str) for v in x_vals)
+                    else [{"x": x, "y": y} for x, y in zip(x_vals, y_vals)]
+                ),
+            }
+        ],
+        "options": options,
+    }
+    return {"chart_config": chart_config, "image": image_b64}
+
+
+def _build_pie_config(
+    df: pd.DataFrame,
+    column: str,
+) -> Dict[str, Any]:
+
+    counts = df[column].value_counts()
+    labels = [str(x) for x in counts.index.tolist()]
+    values = [int(v) for v in counts.values.tolist()]
+
+    with _safe_figure(figsize=(8, 6)) as (fig, ax):
+        colors = plt.cm.Set3(np.linspace(0, 1, len(labels)))
+        wedges, texts, autotexts = ax.pie(
+            values, labels=labels, autopct="%1.1f%%", colors=colors, startangle=90
+        )
+        ax.set_title(f"Distribution of {column}")
+        plt.tight_layout()
+        image_b64 = _fig_to_base64(fig)
+
+    chart_config = {
+        "type": "pie",
+        "labels": labels,
+        "datasets": [{"data": values}],
+    }
+    return {"chart_config": chart_config, "image": image_b64}
+
+
+
+def _fig_to_base64(fig: plt.Figure) -> str:
+    buf = io.BytesIO()
+    fig.savefig(buf, format="png", dpi=150, bbox_inches="tight")
+    buf.seek(0)
+    return base64.b64encode(buf.read()).decode("utf-8")
+
+
+def _coerce_numeric_columns(df: pd.DataFrame, columns: List[str]) -> pd.DataFrame:
+    """Coerce string columns to numeric — CSVs sometimes parse numbers as object dtype."""
+
+    df = df.copy()
+    for col in columns:
+        if col not in df.columns:
+            continue
+        if np.issubdtype(df[col].dtype, np.number):
+            continue
+        if _is_datetime(df[col]):
+            continue
+        converted = pd.to_numeric(df[col], errors="coerce")
+        if converted.notna().any():
+            df[col] = converted
+    return df
+
+
+# Public API
+
+CHART_BUILDERS = {
+    "histogram": _build_histogram_config,
+    "scatter": _build_scatter_config,
+    "box": _build_box_config,
+    "heatmap": _build_heatmap_config,
+    "bar": _build_bar_config,
+    "line": _build_line_config,
+    "pie": _build_pie_config,
+}
+
+VALID_CHART_TYPES = list(CHART_BUILDERS.keys())
+
+
+def generate_chart(
+    df: pd.DataFrame,
+    chart_type: str,
+    x_column: Optional[str] = None,
+    y_column: Optional[str] = None,
+    columns: Optional[List[str]] = None,
+    group_column: Optional[str] = None,
+    aggregation: str = "count",
+    bins: int = 20,
+) -> Dict[str, Any]:
+    """Route to the appropriate chart builder and return {chart_config, image}."""
+    if chart_type not in CHART_BUILDERS:
+        raise ValueError(
+            f"Unsupported chart type '{chart_type}'. "
+            f"Valid types: {VALID_CHART_TYPES}"
+        )
+
+
+    cols_to_coerce: List[str] = []
+    if x_column and x_column in df.columns:
+        cols_to_coerce.append(x_column)
+    if y_column and y_column in df.columns:
+        cols_to_coerce.append(y_column)
+    if columns:
+        cols_to_coerce.extend(c for c in columns if c in df.columns)
+    if cols_to_coerce:
+        df = _coerce_numeric_columns(df, cols_to_coerce)
+
+    if chart_type == "histogram":
+        if not x_column:
+            raise ValueError("histogram requires 'x_column'.")
+        if x_column not in df.columns:
+            raise ValueError(f"Column '{x_column}' not found in dataset.")
+        return _build_histogram_config(df, x_column, bins=bins)
+
+    elif chart_type == "scatter":
+        if not x_column or not y_column:
+            raise ValueError("scatter requires 'x_column' and 'y_column'.")
+        for c in [x_column, y_column]:
+            if c not in df.columns:
+                raise ValueError(f"Column '{c}' not found in dataset.")
+        return _build_scatter_config(df, x_column, y_column, group_column)
+
+    elif chart_type == "box":
+        effective_cols = columns if columns else ([x_column] if x_column else [])
+        if not effective_cols:
+            raise ValueError("box requires 'columns' or 'x_column'.")
+        for c in effective_cols:
+            if c not in df.columns:
+                raise ValueError(f"Column '{c}' not found in dataset.")
+        return _build_box_config(df, effective_cols, group_column)
+
+    elif chart_type == "heatmap":
+        effective_cols = columns or list(df.select_dtypes(include=[np.number]).columns)
+        if not columns:
+            df = _coerce_numeric_columns(df, list(df.columns))
+            effective_cols = list(df.select_dtypes(include=[np.number]).columns)
+        return _build_heatmap_config(df, effective_cols)
+
+    elif chart_type == "bar":
+        if not x_column:
+            raise ValueError("bar requires 'x_column'.")
+        if x_column not in df.columns:
+            raise ValueError(f"Column '{x_column}' not found in dataset.")
+        return _build_bar_config(df, x_column, y_column, aggregation)
+
+    elif chart_type == "line":
+        if not x_column or not y_column:
+            raise ValueError("line requires 'x_column' and 'y_column'.")
+        for c in [x_column, y_column]:
+            if c not in df.columns:
+                raise ValueError(f"Column '{c}' not found in dataset.")
+        return _build_line_config(df, x_column, y_column, aggregation)
+
+    elif chart_type == "pie":
+        col = x_column or (columns[0] if columns else None)
+        if not col:
+            raise ValueError("pie requires 'x_column' or 'columns'.")
+        if col not in df.columns:
+            raise ValueError(f"Column '{col}' not found in dataset.")
+        return _build_pie_config(df, col)
+
+    raise ValueError(f"Unhandled chart type: {chart_type}")  # pragma: no cover

--- a/analytics-service/app/utils/csv_parser.py
+++ b/analytics-service/app/utils/csv_parser.py
@@ -11,11 +11,20 @@ MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024  # 10 MB
 MAX_ROWS = 10_000
 SUPPORTED_ENCODINGS = ("utf-8", "iso-8859-1")
 
+# Excel magic bytes: XLSX (PK zip) and XLS (OLE2 compound doc)
+_XLSX_MAGIC = b"PK"
+_XLS_MAGIC = b"\xd0\xcf\x11\xe0"
+
 
 def validate_file_size(content: bytes) -> None:
     if len(content) > MAX_FILE_SIZE_BYTES:
         size_mb = round(len(content) / (1024 * 1024), 1)
         raise HTTPException(413, f"File is {size_mb}MB — max is 10MB.")
+
+
+def _is_excel(content: bytes) -> bool:
+    """Detect whether *content* is an Excel file (.xlsx or .xls) by magic bytes."""
+    return content[:2] == _XLSX_MAGIC or content[:4] == _XLS_MAGIC
 
 
 def decode_csv_content(content: bytes) -> str:
@@ -35,8 +44,25 @@ def detect_delimiter(text: str) -> str:
         return ","
 
 
-def parse_csv(content: bytes) -> pd.DataFrame:
-    validate_file_size(content)
+def _parse_excel(content: bytes) -> pd.DataFrame:
+    """Parse an Excel file (.xlsx or .xls) from raw bytes."""
+    try:
+        df = pd.read_excel(io.BytesIO(content), engine="openpyxl")
+    except Exception:
+        # Fallback to xlrd for older .xls files
+        try:
+            df = pd.read_excel(io.BytesIO(content))
+        except Exception as exc:
+            raise HTTPException(
+                400,
+                f"Unable to parse Excel file: {exc}. "
+                "Ensure the file is a valid .xlsx or .xls file.",
+            )
+    return df
+
+
+def _parse_csv_text(content: bytes) -> pd.DataFrame:
+    """Parse a CSV file from raw bytes."""
     text = decode_csv_content(content)
     sep = detect_delimiter(text)
 
@@ -47,10 +73,30 @@ def parse_csv(content: bytes) -> pd.DataFrame:
     except EmptyDataError:
         raise HTTPException(400, "CSV is empty or has no parseable data.")
 
+    return df
+
+
+def parse_csv(content: bytes) -> pd.DataFrame:
+    """Parse an uploaded file (CSV or Excel) into a DataFrame.
+
+    The function auto-detects Excel files by magic bytes and routes
+    to the appropriate parser.  The name ``parse_csv`` is kept for
+    backward compatibility with existing callers.
+    """
+    validate_file_size(content)
+
+    if _is_excel(content):
+        df = _parse_excel(content)
+    else:
+        df = _parse_csv_text(content)
+
     if len(df) > MAX_ROWS:
         raise HTTPException(413, f"Dataset has {len(df):,} rows — max is {MAX_ROWS:,}.")
 
     if df.empty:
-        raise HTTPException(400, "CSV is empty or has no parseable data.")
+        raise HTTPException(400, "File is empty or has no parseable data.")
+
+    # Strip whitespace from column names to prevent "not found" mismatches
+    df.columns = df.columns.str.strip()
 
     return df

--- a/analytics-service/requirements.txt
+++ b/analytics-service/requirements.txt
@@ -10,8 +10,12 @@ web3>=6.0.0,<8.0.0
 # Data analysis
 pandas>=2.0.0,<3.0.0
 numpy>=1.24.0,<2.0.0
+matplotlib>=3.7.0,<4.0.0
+scipy>=1.10.0,<2.0.0
+openpyxl>=3.1.0
 
 # Testing
 pytest>=7.4.0
 pytest-asyncio>=0.21.0
+pytest-cov>=4.1.0
 httpx>=0.24.0

--- a/analytics-service/tests/test_auth.py
+++ b/analytics-service/tests/test_auth.py
@@ -48,11 +48,22 @@ class TestVerifySignature:
 class TestProductionGuard:
     """Verify that production mode does NOT silently bypass crypto checks."""
 
+    def test_production_raises_not_implemented(self):
+        import app.auth.eip712 as mod
+
+        original_env = mod.APP_ENV
+        try:
+            mod.APP_ENV = "production"
+            clear_nonces()
+            with pytest.raises(NotImplementedError, match="not yet implemented"):
+                verify_signature(
+                    WALLET, "QmCID", "0xsig", int(time.time()), 999, "hash"
+                )
+        finally:
+            mod.APP_ENV = original_env
+
     def test_import_fails_without_web3_in_production(self):
-        """Importing eip712 in production without web3.py must raise
-        RuntimeError at import time (fail-fast)."""
         with mock.patch.dict(os.environ, {"APP_ENV": "production"}):
-            # Simulate web3 not being installed
             with mock.patch.dict("sys.modules", {"web3": None, "eth_account.messages": None}):
                 with pytest.raises(RuntimeError, match="web3.py is required"):
                     importlib.reload(importlib.import_module("app.auth.eip712"))
@@ -62,11 +73,8 @@ class TestProductionGuard:
             importlib.reload(importlib.import_module("app.auth.eip712"))
 
     def test_test_env_skips_crypto(self):
-        """In test env, verify_signature should succeed without real crypto."""
         import app.auth.eip712 as mod
 
         assert mod.APP_ENV in mod._SAFE_ENVS
         clear_nonces()
-        # This succeeds because APP_ENV=test skips signer recovery
         assert verify_signature(WALLET, "QmCID", "0xsig", int(time.time()), 777, "hash")
-

--- a/analytics-service/tests/test_visualization.py
+++ b/analytics-service/tests/test_visualization.py
@@ -1,0 +1,235 @@
+
+
+import base64
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from app.services.visualization import (
+    VALID_CHART_TYPES,
+    generate_chart,
+)
+
+
+@pytest.fixture
+def health_df():
+    return pd.DataFrame({
+        "patient_id": [f"P{i:03d}" for i in range(1, 21)],
+        "age": [45, 62, 33, 51, 70, 28, 55, 41, 67, 36, 58, 44, 73, 30, 49, 65, 38, 52, 71, 25],
+        "gender": ["M", "F", "M", "F", "M", "F", "M", "F", "M", "F",
+                    "M", "F", "M", "F", "M", "F", "M", "F", "M", "F"],
+        "glucose_fasting": [92, 145, 88, 126, 165, 85, 138, 95, 152, 90,
+                            142, 98, 170, 82, 118, 148, 87, 130, 160, 80],
+        "cholesterol_total": [185, 242, 178, 215, 268, 165, 230, 192, 255, 172,
+                              238, 188, 275, 160, 205, 248, 175, 220, 262, 155],
+        "diagnosis": ["Healthy", "Type 2 Diabetes", "Healthy", "Pre-Diabetes",
+                       "Type 2 Diabetes", "Healthy", "Type 2 Diabetes", "Healthy",
+                       "Type 2 Diabetes", "Healthy", "Type 2 Diabetes", "Healthy",
+                       "Type 2 Diabetes", "Healthy", "Pre-Diabetes", "Type 2 Diabetes",
+                       "Healthy", "Pre-Diabetes", "Type 2 Diabetes", "Healthy"],
+    })
+
+
+@pytest.fixture
+def simple_df():
+    return pd.DataFrame({
+        "x": [1, 2, 3, 4, 5],
+        "y": [2, 4, 6, 8, 10],
+        "category": ["A", "A", "B", "B", "B"],
+    })
+
+
+def _assert_valid_result(result: dict, chart_type: str):
+    assert "chart_config" in result
+    assert "image" in result
+    assert result["chart_config"]["type"] == chart_type
+    decoded = base64.b64decode(result["image"])
+    assert decoded[:8] == b"\x89PNG\r\n\x1a\n"
+
+
+class TestValidChartTypes:
+    def test_all_seven_types_registered(self):
+        assert len(VALID_CHART_TYPES) == 7
+        expected = {"histogram", "scatter", "box", "heatmap", "bar", "line", "pie"}
+        assert set(VALID_CHART_TYPES) == expected
+
+
+class TestHistogram:
+    def test_basic_histogram(self, health_df):
+        result = generate_chart(health_df, "histogram", x_column="age")
+        _assert_valid_result(result, "histogram")
+        config = result["chart_config"]
+        assert len(config["labels"]) > 0
+        assert len(config["datasets"]) == 1
+        assert config["datasets"][0]["label"] == "age"
+
+    def test_custom_bins(self, health_df):
+        result = generate_chart(health_df, "histogram", x_column="age", bins=5)
+        config = result["chart_config"]
+        assert len(config["labels"]) == 5
+        assert config["options"]["bins"] == 5
+
+    def test_missing_column_raises(self, health_df):
+        with pytest.raises(ValueError, match="not found"):
+            generate_chart(health_df, "histogram", x_column="nonexistent")
+
+    def test_requires_x_column(self, health_df):
+        with pytest.raises(ValueError, match="requires"):
+            generate_chart(health_df, "histogram")
+
+
+class TestScatter:
+    def test_basic_scatter(self, health_df):
+        result = generate_chart(health_df, "scatter", x_column="age", y_column="glucose_fasting")
+        _assert_valid_result(result, "scatter")
+        config = result["chart_config"]
+        assert config["options"]["xLabel"] == "age"
+        assert config["options"]["yLabel"] == "glucose_fasting"
+
+    def test_scatter_with_grouping(self, health_df):
+        result = generate_chart(
+            health_df, "scatter",
+            x_column="age", y_column="glucose_fasting",
+            group_column="gender"
+        )
+        _assert_valid_result(result, "scatter")
+        assert len(result["chart_config"]["datasets"]) == 2  # M and F
+
+    def test_requires_both_columns(self, health_df):
+        with pytest.raises(ValueError, match="requires"):
+            generate_chart(health_df, "scatter", x_column="age")
+
+    def test_missing_y_column(self, health_df):
+        with pytest.raises(ValueError, match="not found"):
+            generate_chart(health_df, "scatter", x_column="age", y_column="nonexistent")
+
+
+class TestBox:
+    def test_multi_column_box(self, health_df):
+        result = generate_chart(
+            health_df, "box",
+            columns=["age", "glucose_fasting", "cholesterol_total"]
+        )
+        _assert_valid_result(result, "box")
+        assert len(result["chart_config"]["datasets"]) == 3
+
+    def test_box_with_grouping(self, health_df):
+        result = generate_chart(
+            health_df, "box",
+            columns=["glucose_fasting"],
+            group_column="gender"
+        )
+        _assert_valid_result(result, "box")
+        assert len(result["chart_config"]["datasets"]) == 2  # M and F
+
+    def test_box_stats_values(self, simple_df):
+        result = generate_chart(simple_df, "box", columns=["x"])
+        ds = result["chart_config"]["datasets"][0]
+        assert ds["min"] == 1.0
+        assert ds["max"] == 5.0
+        assert ds["median"] == 3.0
+
+    def test_requires_columns(self, health_df):
+        with pytest.raises(ValueError, match="requires"):
+            generate_chart(health_df, "box")
+
+
+class TestHeatmap:
+    def test_correlation_heatmap(self, health_df):
+        result = generate_chart(
+            health_df, "heatmap",
+            columns=["age", "glucose_fasting", "cholesterol_total"]
+        )
+        _assert_valid_result(result, "heatmap")
+        data = result["chart_config"]["data"]
+        # Diagonal should be 1.0
+        assert data["age"]["age"] == 1.0
+        assert data["glucose_fasting"]["glucose_fasting"] == 1.0
+
+    def test_auto_selects_numeric(self, health_df):
+        result = generate_chart(health_df, "heatmap")
+        _assert_valid_result(result, "heatmap")
+        # Should only include numeric columns
+        labels = result["chart_config"]["labels"]
+        assert "patient_id" not in labels
+        assert "diagnosis" not in labels
+
+    def test_too_few_columns_raises(self):
+        df = pd.DataFrame({"x": [1, 2, 3]})
+        with pytest.raises(ValueError, match="at least 2"):
+            generate_chart(df, "heatmap", columns=["x"])
+
+
+class TestBar:
+    def test_count_bar(self, health_df):
+        result = generate_chart(health_df, "bar", x_column="diagnosis")
+        _assert_valid_result(result, "bar")
+        config = result["chart_config"]
+        assert len(config["labels"]) > 0
+        assert sum(config["datasets"][0]["data"]) == 20  # Total rows
+
+    def test_mean_aggregation(self, health_df):
+        result = generate_chart(
+            health_df, "bar",
+            x_column="gender", y_column="glucose_fasting",
+            aggregation="mean"
+        )
+        _assert_valid_result(result, "bar")
+        assert result["chart_config"]["options"]["aggregation"] == "mean"
+
+    def test_sum_aggregation(self, simple_df):
+        result = generate_chart(
+            simple_df, "bar",
+            x_column="category", y_column="y",
+            aggregation="sum"
+        )
+        _assert_valid_result(result, "bar")
+
+    def test_requires_x_column(self, health_df):
+        with pytest.raises(ValueError, match="requires"):
+            generate_chart(health_df, "bar")
+
+
+class TestLine:
+    def test_numeric_line(self, simple_df):
+        result = generate_chart(simple_df, "line", x_column="x", y_column="y")
+        _assert_valid_result(result, "line")
+        datasets = result["chart_config"]["datasets"]
+        assert len(datasets) == 1
+        assert datasets[0]["label"] == "y"
+
+    def test_categorical_x_line(self, health_df):
+        result = generate_chart(
+            health_df, "line",
+            x_column="diagnosis", y_column="glucose_fasting",
+            aggregation="mean"
+        )
+        _assert_valid_result(result, "line")
+
+    def test_requires_both_columns(self, health_df):
+        with pytest.raises(ValueError, match="requires"):
+            generate_chart(health_df, "line", x_column="age")
+
+
+class TestPie:
+    def test_basic_pie(self, health_df):
+        result = generate_chart(health_df, "pie", x_column="diagnosis")
+        _assert_valid_result(result, "pie")
+        config = result["chart_config"]
+        assert sum(config["datasets"][0]["data"]) == 20
+
+    def test_pie_gender(self, health_df):
+        result = generate_chart(health_df, "pie", x_column="gender")
+        _assert_valid_result(result, "pie")
+        assert len(result["chart_config"]["labels"]) == 2
+
+    def test_requires_column(self, health_df):
+        with pytest.raises(ValueError, match="requires"):
+            generate_chart(health_df, "pie")
+
+
+class TestInvalidChartType:
+    def test_invalid_type_raises(self, simple_df):
+        with pytest.raises(ValueError, match="Unsupported chart type"):
+            generate_chart(simple_df, "radar", x_column="x")

--- a/analytics-service/tests/test_visualization_categorical.py
+++ b/analytics-service/tests/test_visualization_categorical.py
@@ -1,0 +1,384 @@
+
+
+import io
+import pytest
+import numpy as np
+import pandas as pd
+
+from app.services.visualization import (
+    _is_categorical,
+    _is_datetime,
+    _coerce_datetime,
+    _cramers_v,
+    _encode_categorical_axis,
+    generate_chart,
+)
+from app.utils.csv_parser import parse_csv, _is_excel
+
+
+
+
+@pytest.fixture
+def categorical_df():
+    return pd.DataFrame({
+        "age": [45, 62, 33, 51, 70, 28, 55, 41, 67, 36],
+        "weight": [150, 180, 140, 165, 200, 130, 175, 155, 190, 135],
+        "gender": ["M", "F", "M", "F", "M", "F", "M", "F", "M", "F"],
+        "diagnosis": [
+            "Healthy", "Type2", "Healthy", "PreDiab",
+            "Type2", "Healthy", "Type2", "Healthy",
+            "Type2", "Healthy",
+        ],
+    })
+
+
+@pytest.fixture
+def datetime_df():
+    return pd.DataFrame({
+        "date": pd.to_datetime([
+            "2024-11-30", "2025-01-10", "2025-02-15",
+            "2025-03-01", "2024-12-01", "2025-04-15",
+        ]),
+        "temperature": [98.1, 99.5, 97.8, 100.2, 98.6, 99.0],
+    })
+
+
+@pytest.fixture
+def string_dates_df():
+    return pd.DataFrame({
+        "date": ["12/01/2024", "01/10/2025", "03/01/2025",
+                 "11/30/2024", "02/15/2025"],
+        "value": [50, 10, 30, 45, 20],
+    })
+
+
+
+class TestTypeDetection:
+
+    def test_numeric_is_not_categorical(self):
+        s = pd.Series([1, 2, 3, 4, 5])
+        assert not _is_categorical(s)
+        assert not _is_datetime(s)
+
+    def test_float_is_not_categorical(self):
+        s = pd.Series([1.1, 2.2, 3.3])
+        assert not _is_categorical(s)
+
+    def test_string_is_categorical(self):
+        s = pd.Series(["A", "B", "C"])
+        assert _is_categorical(s)
+        assert not _is_datetime(s)
+
+    def test_datetime_is_not_categorical(self):
+        s = pd.Series(pd.to_datetime(["2025-01-01", "2025-02-01"]))
+        assert not _is_categorical(s)
+        assert _is_datetime(s)
+
+    def test_datetime_detected(self):
+        s = pd.Series(pd.to_datetime(["2025-01-01"]))
+        assert _is_datetime(s)
+
+    def test_coerce_datetime_from_string(self):
+        s = pd.Series(["2025-01-01", "2025-02-01", "2025-03-01"])
+        result = _coerce_datetime(s)
+        assert _is_datetime(result)
+
+    def test_coerce_datetime_preserves_existing(self):
+        s = pd.Series(pd.to_datetime(["2025-01-01"]))
+        result = _coerce_datetime(s)
+        assert _is_datetime(result)
+
+    def test_coerce_datetime_returns_original_on_failure(self):
+        s = pd.Series(["hello", "world", "foo"])
+        result = _coerce_datetime(s)
+        assert result.dtype == object  # unchanged
+
+    def test_coerce_datetime_threshold(self):
+        s = pd.Series(["2025-01-01", "not-a-date", "also-not"])
+        result = _coerce_datetime(s)
+        # Only 1/3 parses = 33%, below 50% threshold
+        assert result.dtype == object
+
+
+
+class TestCategoricalEncoding:
+
+    def test_basic_encoding(self):
+        s = pd.Series(["A", "B", "C", "A", "B"])
+        codes, labels, cat_map = _encode_categorical_axis(s)
+        assert len(labels) == 3
+        assert set(labels) == {"A", "B", "C"}
+        assert codes.notna().all()
+
+    def test_encoding_preserves_mapping(self):
+        assert codes.iloc[0] == codes.iloc[2]
+        assert codes.iloc[0] != codes.iloc[1]
+
+
+
+class TestCramersV:
+
+    def test_perfect_association(self):
+        x = pd.Series(["A", "B", "C"] * 20)
+        v = _cramers_v(x, x)
+        assert v == pytest.approx(1.0, abs=0.01)
+
+    def test_v_in_valid_range(self):
+        x = pd.Series(["A", "B"] * 50)
+        y = pd.Series(["X", "Y", "X", "Y"] * 25)
+        v = _cramers_v(x, y)
+        assert 0 <= v <= 1
+
+    def test_independent_variables_low_v(self):
+        np.random.seed(42)
+        x = pd.Series(np.random.choice(["A", "B", "C"], 200))
+        y = pd.Series(np.random.choice(["X", "Y", "Z"], 200))
+        v = _cramers_v(x, y)
+        assert v < 0.2  # Should be close to 0 for independent vars
+
+
+
+class TestCategoricalHistogram:
+
+    def test_categorical_histogram_succeeds(self, categorical_df):
+        result = generate_chart(categorical_df, "histogram", x_column="gender")
+        assert result["chart_config"]["type"] == "histogram"
+        assert result["chart_config"]["options"].get("categorical") is True
+        assert "image" in result
+
+    def test_categorical_histogram_labels(self, categorical_df):
+        result = generate_chart(categorical_df, "histogram", x_column="diagnosis")
+        labels = result["chart_config"]["labels"]
+        data = result["chart_config"]["datasets"][0]["data"]
+        assert len(labels) == categorical_df["diagnosis"].nunique()
+        assert len(data) == len(labels)
+        assert sum(data) == len(categorical_df)
+
+    def test_numeric_histogram_unchanged(self, categorical_df):
+        result = generate_chart(categorical_df, "histogram", x_column="age")
+        assert result["chart_config"]["options"].get("categorical") is None
+
+
+
+class TestCategoricalScatter:
+
+    def test_two_categoricals(self, categorical_df):
+        result = generate_chart(
+            categorical_df, "scatter",
+            x_column="gender", y_column="diagnosis",
+        )
+        assert result["chart_config"]["type"] == "scatter"
+        opts = result["chart_config"]["options"]
+        assert "xCategories" in opts
+        assert "yCategories" in opts
+
+    def test_categorical_x_numeric_y(self, categorical_df):
+        result = generate_chart(
+            categorical_df, "scatter",
+            x_column="diagnosis", y_column="weight",
+        )
+        opts = result["chart_config"]["options"]
+        assert "xCategories" in opts
+        assert "yCategories" not in opts
+
+    def test_numeric_scatter_unchanged(self, categorical_df):
+        result = generate_chart(
+            categorical_df, "scatter",
+            x_column="age", y_column="weight",
+        )
+        opts = result["chart_config"]["options"]
+        assert "xCategories" not in opts
+        assert "yCategories" not in opts
+
+
+
+class TestCategoricalBox:
+
+    def test_all_categorical_raises_clear_error(self, categorical_df):
+        with pytest.raises(ValueError, match="categorical"):
+            generate_chart(
+                categorical_df, "box",
+                columns=["gender", "diagnosis"],
+            )
+
+    def test_single_categorical_raises_clear_error(self, categorical_df):
+        with pytest.raises(ValueError, match="categorical"):
+            generate_chart(
+                categorical_df, "box",
+                columns=["diagnosis"],
+            )
+
+    def test_mixed_skips_categorical(self, categorical_df):
+        result = generate_chart(
+            categorical_df, "box",
+            columns=["age", "gender"],
+        )
+        config = result["chart_config"]
+        assert "age" in config["labels"]
+        assert "gender" not in config["labels"]
+        assert config.get("skipped_categorical") == ["gender"]
+
+    def test_categorical_with_group_column(self, categorical_df):
+        result = generate_chart(
+            categorical_df, "box",
+            columns=["weight"],
+            group_column="gender",
+        )
+        config = result["chart_config"]
+        assert len(config["datasets"]) == 2  # M and F
+
+
+
+class TestCategoricalHeatmap:
+
+    def test_categorical_heatmap_uses_cramers_v(self, categorical_df):
+        result = generate_chart(
+            categorical_df, "heatmap",
+            columns=["gender", "diagnosis"],
+        )
+        config = result["chart_config"]
+        assert config["options"]["method"] == "cramers_v"
+        assert config["options"].get("categorical") is True
+        assert "image" in result
+
+    def test_categorical_heatmap_values_in_range(self, categorical_df):
+        result = generate_chart(
+            categorical_df, "heatmap",
+            columns=["gender", "diagnosis"],
+        )
+        data = result["chart_config"]["data"]
+        for col_name, col_vals in data.items():
+            for row_name, val in col_vals.items():
+                assert 0 <= val <= 1, f"V({col_name},{row_name})={val} out of range"
+
+    def test_numeric_heatmap_unchanged(self, categorical_df):
+        result = generate_chart(
+            categorical_df, "heatmap",
+            columns=["age", "weight"],
+        )
+        assert result["chart_config"]["options"]["method"] == "pearson"
+
+
+
+class TestDatetimeHistogram:
+
+    def test_datetime_histogram_succeeds(self, datetime_df):
+        result = generate_chart(datetime_df, "histogram", x_column="date")
+        assert result["chart_config"]["type"] == "histogram"
+        assert result["chart_config"]["options"].get("datetime") is True
+        assert "image" in result
+
+
+
+class TestDatetimeScatter:
+
+    def test_datetime_x_axis(self, datetime_df):
+        result = generate_chart(
+            datetime_df, "scatter",
+            x_column="date", y_column="temperature",
+        )
+        opts = result["chart_config"]["options"]
+        assert opts.get("xDatetime") is True
+        assert "xCategories" not in opts
+
+    def test_datetime_not_jittered(self, datetime_df):
+        result = generate_chart(
+            datetime_df, "scatter",
+            x_column="date", y_column="temperature",
+        )
+        assert "xCategories" not in result["chart_config"]["options"]
+
+
+
+class TestDatetimeLineChart:
+
+    def test_datetime_line_chart(self, datetime_df):
+        result = generate_chart(
+            datetime_df, "line",
+            x_column="date", y_column="temperature",
+        )
+        opts = result["chart_config"]["options"]
+        assert opts.get("datetime") is True
+        assert "image" in result
+
+    def test_string_dates_coerced_and_sorted(self, string_dates_df):
+        result = generate_chart(
+            string_dates_df, "line",
+            x_column="date", y_column="value",
+        )
+        opts = result["chart_config"]["options"]
+        assert opts.get("datetime") is True
+
+        labels = result["chart_config"]["labels"]
+        assert labels is not None
+        assert "2024-11-30" in labels[0]
+
+    def test_us_format_dates_not_alphabetical(self, string_dates_df):
+        result = generate_chart(
+            string_dates_df, "line",
+            x_column="date", y_column="value",
+        )
+        labels = result["chart_config"]["labels"]
+        assert "2024" in labels[0]
+
+
+
+class TestExcelParsing:
+
+    def test_xlsx_magic_bytes_detected(self):
+        assert _is_excel(b"PK\x03\x04rest-of-file")
+
+    def test_xls_magic_bytes_detected(self):
+        assert _is_excel(b"\xd0\xcf\x11\xe0rest-of-file")
+
+    def test_csv_not_detected_as_excel(self):
+        assert not _is_excel(b"col1,col2\n1,2\n3,4")
+
+    def test_empty_bytes_not_excel(self):
+        assert not _is_excel(b"")
+
+    def test_parse_csv_still_works(self):
+        csv_bytes = b"name,age\nAlice,30\nBob,25\n"
+        df = parse_csv(csv_bytes)
+        assert list(df.columns) == ["name", "age"]
+        assert len(df) == 2
+
+    def test_parse_csv_strips_whitespace(self):
+        csv_bytes = b" name , age \nAlice,30\n"
+        df = parse_csv(csv_bytes)
+        assert list(df.columns) == ["name", "age"]
+
+    def test_xlsx_roundtrip(self, tmp_path):
+        df_original = pd.DataFrame({
+            "Patient": [1, 2, 3],
+            "Blood Pressure Systolic": [120, 140, 130],
+            "Sex (m/f)": ["Male", "Female", "Male"],
+        })
+        xlsx_path = tmp_path / "test.xlsx"
+        df_original.to_excel(xlsx_path, index=False)
+        content = xlsx_path.read_bytes()
+
+        df_parsed = parse_csv(content)
+        assert "Blood Pressure Systolic" in df_parsed.columns
+        assert "Sex (m/f)" in df_parsed.columns
+        assert len(df_parsed) == 3
+        assert list(df_parsed["Blood Pressure Systolic"]) == [120, 140, 130]
+
+
+
+class TestInputSanitisation:
+
+    def test_box_chart_ignores_none_group(self, categorical_df):
+        result = generate_chart(
+            categorical_df, "box",
+            columns=["age", "weight"],
+            group_column=None,
+        )
+        assert result["chart_config"]["type"] == "box"
+
+    def test_heatmap_with_no_explicit_columns(self, categorical_df):
+        result = generate_chart(
+            categorical_df, "heatmap",
+        )
+        config = result["chart_config"]
+        assert "age" in config["labels"] or "weight" in config["labels"]


### PR DESCRIPTION
## What this does

Adds the `/analytics/visualize` endpoint (Week 3 deliverable) - can upload a CSV/Excel file and get back a chart as a base64 PNG + a structured JSON config for frontend rendering.

### Supported chart types
- **Histogram** — numeric bins, categorical frequency bars, or time-binned
- **Scatter** — with optional grouping, categorical axis encoding, and jitter
- **Box plot** — multi-column or grouped by a categorical column
- **Heatmap** — Pearson/Spearman for numeric, Cramér's V for categorical
- **Bar** — count, mean, or sum aggregation
- **Line** — time series with auto datetime parsing, categorical aggregation
- **Pie** — category distribution

### Other changes
- CSV parser now auto-detects and parses Excel files (.xlsx/.xls) via magic bytes
- `conftest.py` sets `APP_ENV=test` before imports so the eip712 guard doesn't block test runs
- Added `matplotlib`, `scipy`, `openpyxl`, `pytest-cov` to requirements

### Next Step
- Will be making a follow-up pr for test file and categorical visualtion part (need some fixing)