### PR TITLE
Implement production Week 5 privacy profiles

### DIFF
--- a/python_backend/config/privacy_profiles.json
+++ b/python_backend/config/privacy_profiles.json
@@ -1,0 +1,24 @@
+{
+  "strict": {
+    "redact_dates": true,
+    "date_strategy": "redact",
+    "text_identifier_strategy": "redact",
+    "remove_dicom_private_tags": true,
+    "preserve_dicom_technical_metadata": false,
+    "remove_nifti_extensions": true,
+    "ocr_confidence_threshold": 0.3,
+    "allow_generalized_demographics": false
+  },
+  "research": {
+    "redact_dates": true,
+    "date_strategy": "shift",
+    "text_identifier_strategy": "pseudonymize",
+    "remove_dicom_private_tags": true,
+    "preserve_dicom_technical_metadata": true,
+    "remove_nifti_extensions": true,
+    "ocr_confidence_threshold": 0.5,
+    "allow_generalized_demographics": true
+  }
+}
+
+

--- a/python_backend/main.py
+++ b/python_backend/main.py
@@ -335,7 +335,7 @@ async def ingest_file(
                 )
 
         file_content = None
-        if modality in {"dicom", "nifti"}:
+        if modality in {"dicom", "nifti", "wsi"}:
             await file.seek(0)
             file_content = await file.read()
 

--- a/python_backend/main.py
+++ b/python_backend/main.py
@@ -334,6 +334,11 @@ async def ingest_file(
                     ),
                 )
 
+        file_content = None
+        if modality in {"dicom", "nifti"}:
+            await file.seek(0)
+            file_content = await file.read()
+
         await file.seek(0)
 
         return route_for_ingestion(
@@ -342,6 +347,7 @@ async def ingest_file(
             header=header,
             profile=profile,
             text_content=text_content,
+            file_content=file_content,
         )
     except IngestionError as e:
         raise HTTPException(status_code=e.status_code, detail=e.detail)

--- a/python_backend/main.py
+++ b/python_backend/main.py
@@ -34,6 +34,10 @@ from services.ingestion import (
     detect_modality,
     route_for_ingestion,
 )
+from services.dicom_anonymization import (
+    DicomAnonymizationError,
+    anonymize_dicom_file_bytes,
+)
 
 # PDF extraction imports
 try:
@@ -289,8 +293,8 @@ async def root():
             "/anonymize_image_presidio": "Anonymize PHI in images (Presidio only, advanced)",
             "/anonymize_text": "Anonymize PHI in plain text (Presidio + spaCy fallback)",
             "/anonymize_pdf": "Anonymize PHI in PDF documents (per-page extraction and redaction)",
-            "/anonymize_dicom": "Anonymize PHI in DICOM file metadata (strips patient identifiers)",
-            "/api/v1/ingest": "Route uploaded biomedical files to placeholder anonymization handlers"
+            "/anonymize_dicom": "Anonymize DICOM files with strict/research privacy profiles",
+            "/api/v1/ingest": "Route uploaded biomedical files through profile-aware anonymization handlers"
         },
         "status": {
             "presidio_available": presidio_available,
@@ -308,8 +312,8 @@ async def ingest_file(
     """
     Privacy-safe upload entry point.
 
-    Text uploads are anonymized. Other modalities still route to placeholder
-    handlers until their later milestones.
+    Applies the selected privacy profile across supported production handlers.
+    Supported profiles are strict and research.
     """
     try:
         header = await file.read(HEADER_READ_LIMIT)
@@ -682,73 +686,51 @@ DICOM_PHI_TAGS = {
 
 
 @app.post("/anonymize_dicom")
-async def anonymize_dicom(file: UploadFile = File(...)):
+async def anonymize_dicom(
+    file: UploadFile = File(...),
+    profile: str = Form("strict"),
+):
     """
-    Anonymize PHI in DICOM file metadata. Strips patient identifiers
-    following HIPAA Safe Harbor de-identification standards.
-    Returns the anonymized DICOM file for download.
+    Anonymize DICOM metadata using the selected privacy profile and return a downloadable DICOM file.
+
+    The response is a valid .dcm attachment so it can be saved and opened
+    in a DICOM viewer. Raw PHI values are never returned in the response.
     """
-    if not pydicom_available:
-        raise HTTPException(
-            status_code=503,
-            detail="pydicom not available. Install with: pip install pydicom"
-        )
-
-    if not file.filename or not file.filename.lower().endswith(('.dcm', '.dicom')):
-        raise HTTPException(
-            status_code=400,
-            detail="File must be a DICOM file (.dcm or .dicom)"
-        )
-
     try:
         contents = await file.read()
+        result = anonymize_dicom_file_bytes(contents, profile=profile)
+    except DicomAnonymizationError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail="Failed to anonymize DICOM") from exc
 
-        with tempfile.NamedTemporaryFile(suffix=".dcm", delete=False) as tmp:
-            tmp.write(contents)
-            tmp_path = tmp.name
+    safe_name = (file.filename or "dicom.dcm").strip().replace("\\", "/").rsplit("/", 1)[-1]
+    if not safe_name:
+        safe_name = "dicom.dcm"
+    stem = safe_name.rsplit(".", 1)[0] if "." in safe_name else safe_name
+    download_name = f"anonymized_{stem}.dcm"
+    metadata_summary = result["metadata_summary"]
 
-        try:
-            ds = pydicom.dcmread(tmp_path)
-            stripped_fields = []
+    audit_logger.log_operation(
+        operation="ANONYMIZE",
+        details=(
+            f"dicom: {safe_name}, fields_scrubbed: "
+            f"{metadata_summary['fields_scrubbed']}, "
+            f"private_tags_removed: {metadata_summary['private_tags_removed']}"
+        ),
+    )
 
-            for tag, field_name in DICOM_PHI_TAGS.items():
-                if tag in ds:
-                    original_value = str(ds[tag].value)
-                    ds[tag].value = ""
-                    stripped_fields.append({
-                        "field": field_name,
-                        "tag": f"({tag[0]:04X},{tag[1]:04X})",
-                        "original_value": original_value
-                    })
-
-            # Save anonymized DICOM to buffer
-            anonymized_buffer = io.BytesIO()
-            ds.save_as(anonymized_buffer)
-            anonymized_buffer.seek(0)
-
-            audit_logger.log_operation(
-                operation="ANONYMIZE",
-                details=f"dicom: {file.filename}, fields_stripped: {len(stripped_fields)}",
-            )
-
-            return {
-                "filename": file.filename,
-                "fields_stripped": len(stripped_fields),
-                "stripped_details": stripped_fields,
-                "anonymized_file_base64": anonymized_buffer.getvalue().hex(),
-                "message": f"Successfully anonymized {len(stripped_fields)} PHI fields from DICOM metadata"
-            }
-
-        finally:
-            os.unlink(tmp_path)
-
-    except HTTPException:
-        raise
-    except InvalidDicomError:
-        raise HTTPException(status_code=400, detail="Invalid DICOM file format")
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Failed to anonymize DICOM: {str(e)}")
-
+    return StreamingResponse(
+        io.BytesIO(result["anonymized_dicom_bytes"]),
+        media_type="application/dicom",
+        headers={
+            "Content-Disposition": f'attachment; filename="{download_name}"',
+            "X-BioBlock-Anonymization-Status": result["anonymization_status"],
+            "X-BioBlock-Fields-Scrubbed": str(metadata_summary["fields_scrubbed"]),
+            "X-BioBlock-Private-Tags-Removed": str(metadata_summary["private_tags_removed"]),
+            "X-BioBlock-Pixel-Data-Preserved": str(metadata_summary["pixel_data_preserved"]).lower(),
+        },
+    )
 
 @app.post("/store")
 async def store_data(request: StoreWithContentRequest):
@@ -1524,3 +1506,6 @@ async def get_audit_entry(entry_id: str):
 if __name__ == "__main__":
     import uvicorn
     uvicorn.run(app, host="0.0.0.0", port=3002)
+
+
+

--- a/python_backend/services/dicom_anonymization.py
+++ b/python_backend/services/dicom_anonymization.py
@@ -103,27 +103,17 @@ def _remove_private_tags(dataset: Any) -> int:
     return removed
 
 
-def anonymize_dicom_metadata(
-    file_bytes: bytes,
-    profile: str = "strict",
-) -> Dict[str, Any]:
-    if pydicom is None:
-        raise DicomAnonymizationError(
-            "DICOM metadata anonymization dependency is not available.",
-            status_code=503,
-        )
-    if not file_bytes:
-        raise DicomAnonymizationError("DICOM file is empty")
-
-    privacy_profile = _normalize_profile(profile)
-
+def _read_dataset(file_bytes: bytes) -> Any:
     try:
-        dataset = pydicom.dcmread(BytesIO(file_bytes), force=False)
+        return pydicom.dcmread(BytesIO(file_bytes), force=False)
     except InvalidDicomError as exc:
         raise DicomAnonymizationError("Invalid DICOM file format") from exc
     except Exception as exc:
         raise DicomAnonymizationError("Invalid DICOM file format") from exc
 
+
+def _anonymize_dataset(dataset: Any, profile: str) -> Dict[str, Any]:
+    privacy_profile = _normalize_profile(profile)
     original_pixel_data = bytes(dataset.PixelData) if "PixelData" in dataset else None
 
     scrubbed = _scrub_dataset(dataset)
@@ -145,3 +135,43 @@ def anonymize_dicom_metadata(
         },
         "pixel_redaction_status": PIXEL_REDACTION_STATUS,
     }
+
+
+def _dataset_to_bytes(dataset: Any) -> bytes:
+    output = BytesIO()
+    dataset.save_as(output, enforce_file_format=True)
+    return output.getvalue()
+
+
+def anonymize_dicom_metadata(
+    file_bytes: bytes,
+    profile: str = "strict",
+) -> Dict[str, Any]:
+    if pydicom is None:
+        raise DicomAnonymizationError(
+            "DICOM metadata anonymization dependency is not available.",
+            status_code=503,
+        )
+    if not file_bytes:
+        raise DicomAnonymizationError("DICOM file is empty")
+
+    dataset = _read_dataset(file_bytes)
+    return _anonymize_dataset(dataset, profile)
+
+
+def anonymize_dicom_file_bytes(
+    file_bytes: bytes,
+    profile: str = "strict",
+) -> Dict[str, Any]:
+    if pydicom is None:
+        raise DicomAnonymizationError(
+            "DICOM metadata anonymization dependency is not available.",
+            status_code=503,
+        )
+    if not file_bytes:
+        raise DicomAnonymizationError("DICOM file is empty")
+
+    dataset = _read_dataset(file_bytes)
+    result = _anonymize_dataset(dataset, profile)
+    result["anonymized_dicom_bytes"] = _dataset_to_bytes(dataset)
+    return result

--- a/python_backend/services/dicom_anonymization.py
+++ b/python_backend/services/dicom_anonymization.py
@@ -1,5 +1,13 @@
+import os
+from datetime import datetime, timedelta
 from io import BytesIO
 from typing import Any, Dict
+
+from services.privacy_profiles import (
+    PrivacyProfileError,
+    get_privacy_profile,
+    validate_privacy_profile,
+)
 
 try:
     import pydicom
@@ -9,8 +17,14 @@ except ImportError:
     InvalidDicomError = Exception
 
 
-SUPPORTED_PROFILES = {"strict", "research"}
 PIXEL_REDACTION_STATUS = "metadata_only"
+TEXT_REDACTION_VALUE = ""
+PERSON_NAME_REDACTION_VALUE = ""
+DATE_REDACTION_VALUE = "19000101"
+TIME_REDACTION_VALUE = "000000"
+AGE_REDACTION_VALUE = "000Y"
+SEX_REDACTION_VALUE = "O"
+STUDY_SALT_ENV_VAR = "BIOBLOCK_STUDY_SALT"
 
 PHI_KEYWORDS = {
     "PatientName",
@@ -44,6 +58,19 @@ PHI_KEYWORDS = {
     "PhysiciansOfRecord",
     "InsurancePlanIdentification",
 }
+TECHNICAL_METADATA_KEYWORDS = {
+    "Modality",
+    "Rows",
+    "Columns",
+    "BitsAllocated",
+    "BitsStored",
+    "PixelSpacing",
+    "SliceThickness",
+    "ManufacturerModelName",
+    "KVP",
+    "RepetitionTime",
+    "EchoTime",
+}
 
 
 class DicomAnonymizationError(ValueError):
@@ -53,38 +80,120 @@ class DicomAnonymizationError(ValueError):
         self.status_code = status_code
 
 
-def _normalize_profile(profile: str) -> str:
-    normalized = (profile or "").strip().lower()
-    if normalized not in SUPPORTED_PROFILES:
-        raise DicomAnonymizationError(
-            "Invalid privacy profile. Supported profiles: strict, research"
-        )
-    return normalized
+def _profile_settings(profile: str) -> tuple[str, Dict[str, Any]]:
+    try:
+        normalized = validate_privacy_profile(profile)
+        return normalized, get_privacy_profile(normalized)
+    except PrivacyProfileError as exc:
+        raise DicomAnonymizationError(exc.detail, status_code=exc.status_code) from exc
 
 
-def _scrub_dataset(dataset: Any) -> Dict[str, Any]:
+def _date_shift_days(dataset: Any) -> int:
+    seed = (
+        os.getenv(STUDY_SALT_ENV_VAR)
+        or str(getattr(dataset, "StudyInstanceUID", ""))
+        or str(getattr(dataset, "SOPInstanceUID", ""))
+        or "bioblock-date-shift"
+    )
+    value = sum((index + 1) * ord(char) for index, char in enumerate(seed))
+    days = value % 731 - 365
+    return days or 17
+
+
+def _shift_dicom_date(value: Any, days: int) -> str:
+    try:
+        shifted = datetime.strptime(str(value), "%Y%m%d") + timedelta(days=days)
+    except (TypeError, ValueError):
+        return DATE_REDACTION_VALUE
+    return shifted.strftime("%Y%m%d")
+
+
+def _generalize_age(value: Any) -> str:
+    match = str(value or "").strip()
+    if len(match) < 4 or not match[:3].isdigit():
+        return AGE_REDACTION_VALUE
+
+    years = int(match[:3])
+    decade = min((years // 10) * 10, 90)
+    return f"{decade:03d}Y"
+
+
+def _safe_patient_sex(value: Any) -> str:
+    normalized = str(value or "").strip().upper()
+    if normalized in {"M", "F", "O"}:
+        return normalized
+    return SEX_REDACTION_VALUE
+
+
+def _redaction_value_for(element: Any, settings: Dict[str, Any], date_shift_days: int) -> tuple[str, str]:
+    keyword = element.keyword
+
+    if element.VR == "PN":
+        return PERSON_NAME_REDACTION_VALUE, "redacted"
+    if element.VR == "DA" or keyword.endswith("Date"):
+        if settings["date_strategy"] == "shift":
+            return _shift_dicom_date(element.value, date_shift_days), "shifted"
+        return DATE_REDACTION_VALUE, "redacted"
+    if element.VR == "TM" or keyword.endswith("Time"):
+        return TIME_REDACTION_VALUE, "redacted"
+    if element.VR == "AS" or keyword.endswith("Age"):
+        if settings["allow_generalized_demographics"]:
+            return _generalize_age(element.value), "generalized"
+        return AGE_REDACTION_VALUE, "redacted"
+    if keyword == "PatientSex":
+        if settings["allow_generalized_demographics"]:
+            return _safe_patient_sex(element.value), "generalized"
+        return SEX_REDACTION_VALUE, "redacted"
+
+    return TEXT_REDACTION_VALUE, "redacted"
+
+
+def _scrub_dataset(dataset: Any, settings: Dict[str, Any], date_shift_days: int) -> Dict[str, Any]:
     scrubbed_elements = 0
+    shifted_dates = 0
+    generalized_demographics = 0
     field_counts: Dict[str, int] = {}
 
     for element in dataset:
         if element.VR == "SQ":
             for item in element.value:
-                nested = _scrub_dataset(item)
+                nested = _scrub_dataset(item, settings, date_shift_days)
                 scrubbed_elements += nested["scrubbed_elements"]
+                shifted_dates += nested["dates_shifted"]
+                generalized_demographics += nested["generalized_demographics"]
                 for keyword, count in nested["scrubbed_field_counts"].items():
                     field_counts[keyword] = field_counts.get(keyword, 0) + count
             continue
 
         keyword = element.keyword
         if keyword in PHI_KEYWORDS:
-            element.value = ""
+            replacement, action = _redaction_value_for(
+                element,
+                settings,
+                date_shift_days,
+            )
+            element.value = replacement
             scrubbed_elements += 1
             field_counts[keyword] = field_counts.get(keyword, 0) + 1
+            if action == "shifted":
+                shifted_dates += 1
+            elif action == "generalized":
+                generalized_demographics += 1
 
     return {
         "scrubbed_elements": scrubbed_elements,
         "scrubbed_field_counts": field_counts,
+        "dates_shifted": shifted_dates,
+        "generalized_demographics": generalized_demographics,
     }
+
+
+def _mark_patient_identity_removed(dataset: Any, profile: str, settings: Dict[str, Any]) -> None:
+    dataset.PatientIdentityRemoved = "YES"
+    private_policy = "rm-private" if settings["remove_dicom_private_tags"] else "keep-private"
+    dataset.DeidentificationMethod = (
+        f"BioBlock {profile}; dates={settings['date_strategy']}; {private_policy}"
+    )
 
 
 def _remove_private_tags(dataset: Any) -> int:
@@ -103,6 +212,41 @@ def _remove_private_tags(dataset: Any) -> int:
     return removed
 
 
+
+def _technical_metadata_present(dataset: Any) -> list[str]:
+    return sorted(
+        keyword
+        for keyword in TECHNICAL_METADATA_KEYWORDS
+        if hasattr(dataset, keyword)
+    )
+
+
+def _anonymize_dataset(dataset: Any, profile: str) -> Dict[str, Any]:
+    privacy_profile, settings = _profile_settings(profile)
+    original_pixel_data = bytes(dataset.PixelData) if "PixelData" in dataset else None
+    technical_metadata_preserved = _technical_metadata_present(dataset)
+
+    scrubbed = _scrub_dataset(dataset, settings, _date_shift_days(dataset))
+    private_tags_removed = 0
+    if settings["remove_dicom_private_tags"]:
+        private_tags_removed = _remove_private_tags(dataset)
+
+    current_pixel_data = bytes(dataset.PixelData) if "PixelData" in dataset else None
+    _mark_patient_identity_removed(dataset, privacy_profile, settings)
+
+    return {
+        "profile": privacy_profile,
+        "settings": settings,
+        "scrubbed": scrubbed,
+        "private_tags_removed": private_tags_removed,
+        "pixel_data_present": original_pixel_data is not None,
+        "pixel_data_preserved": original_pixel_data == current_pixel_data,
+        "technical_metadata_preserved": technical_metadata_preserved
+        if settings["preserve_dicom_technical_metadata"]
+        else [],
+    }
+
+
 def _read_dataset(file_bytes: bytes) -> Any:
     try:
         return pydicom.dcmread(BytesIO(file_bytes), force=False)
@@ -112,28 +256,24 @@ def _read_dataset(file_bytes: bytes) -> Any:
         raise DicomAnonymizationError("Invalid DICOM file format") from exc
 
 
-def _anonymize_dataset(dataset: Any, profile: str) -> Dict[str, Any]:
-    privacy_profile = _normalize_profile(profile)
-    original_pixel_data = bytes(dataset.PixelData) if "PixelData" in dataset else None
-
-    scrubbed = _scrub_dataset(dataset)
-    private_tags_removed = 0
-    if privacy_profile == "strict":
-        private_tags_removed = _remove_private_tags(dataset)
-
-    current_pixel_data = bytes(dataset.PixelData) if "PixelData" in dataset else None
-
+def _metadata_summary(anonymized: Dict[str, Any]) -> Dict[str, Any]:
+    scrubbed = anonymized["scrubbed"]
+    settings = anonymized["settings"]
     return {
-        "anonymization_status": "completed",
-        "metadata_summary": {
-            "profile": privacy_profile,
-            "fields_scrubbed": scrubbed["scrubbed_elements"],
-            "scrubbed_field_counts": scrubbed["scrubbed_field_counts"],
-            "private_tags_removed": private_tags_removed,
-            "pixel_data_present": original_pixel_data is not None,
-            "pixel_data_preserved": original_pixel_data == current_pixel_data,
-        },
-        "pixel_redaction_status": PIXEL_REDACTION_STATUS,
+        "profile": anonymized["profile"],
+        "date_strategy": settings["date_strategy"],
+        "fields_scrubbed": scrubbed["scrubbed_elements"],
+        "scrubbed_field_counts": scrubbed["scrubbed_field_counts"],
+        "dates_shifted": scrubbed["dates_shifted"],
+        "generalized_demographics": scrubbed["generalized_demographics"],
+        "private_tags_removed": anonymized["private_tags_removed"],
+        "remove_dicom_private_tags": settings["remove_dicom_private_tags"],
+        "preserve_dicom_technical_metadata": settings[
+            "preserve_dicom_technical_metadata"
+        ],
+        "technical_metadata_preserved": anonymized["technical_metadata_preserved"],
+        "pixel_data_present": anonymized["pixel_data_present"],
+        "pixel_data_preserved": anonymized["pixel_data_preserved"],
     }
 
 
@@ -156,7 +296,13 @@ def anonymize_dicom_metadata(
         raise DicomAnonymizationError("DICOM file is empty")
 
     dataset = _read_dataset(file_bytes)
-    return _anonymize_dataset(dataset, profile)
+    anonymized = _anonymize_dataset(dataset, profile)
+
+    return {
+        "anonymization_status": "completed",
+        "metadata_summary": _metadata_summary(anonymized),
+        "pixel_redaction_status": PIXEL_REDACTION_STATUS,
+    }
 
 
 def anonymize_dicom_file_bytes(
@@ -172,6 +318,13 @@ def anonymize_dicom_file_bytes(
         raise DicomAnonymizationError("DICOM file is empty")
 
     dataset = _read_dataset(file_bytes)
-    result = _anonymize_dataset(dataset, profile)
-    result["anonymized_dicom_bytes"] = _dataset_to_bytes(dataset)
-    return result
+    anonymized = _anonymize_dataset(dataset, profile)
+
+    return {
+        "anonymization_status": "completed",
+        "anonymized_dicom_bytes": _dataset_to_bytes(dataset),
+        "metadata_summary": _metadata_summary(anonymized),
+        "pixel_redaction_status": PIXEL_REDACTION_STATUS,
+    }
+
+

--- a/python_backend/services/dicom_anonymization.py
+++ b/python_backend/services/dicom_anonymization.py
@@ -10,7 +10,7 @@ except ImportError:
 
 
 SUPPORTED_PROFILES = {"strict", "research"}
-PIXEL_REDACTION_STATUS = "not_started_week4"
+PIXEL_REDACTION_STATUS = "metadata_only"
 
 PHI_KEYWORDS = {
     "PatientName",

--- a/python_backend/services/dicom_anonymization.py
+++ b/python_backend/services/dicom_anonymization.py
@@ -1,0 +1,147 @@
+from io import BytesIO
+from typing import Any, Dict
+
+try:
+    import pydicom
+    from pydicom.errors import InvalidDicomError
+except ImportError:
+    pydicom = None
+    InvalidDicomError = Exception
+
+
+SUPPORTED_PROFILES = {"strict", "research"}
+PIXEL_REDACTION_STATUS = "not_started_week4"
+
+PHI_KEYWORDS = {
+    "PatientName",
+    "PatientID",
+    "PatientBirthDate",
+    "PatientBirthTime",
+    "PatientSex",
+    "PatientAge",
+    "OtherPatientIDs",
+    "OtherPatientNames",
+    "PatientAddress",
+    "PatientTelephoneNumbers",
+    "PatientMotherBirthName",
+    "AccessionNumber",
+    "StudyID",
+    "StudyDate",
+    "StudyTime",
+    "SeriesDate",
+    "SeriesTime",
+    "AcquisitionDate",
+    "AcquisitionTime",
+    "ContentDate",
+    "ContentTime",
+    "InstanceCreationDate",
+    "InstanceCreationTime",
+    "InstitutionName",
+    "InstitutionAddress",
+    "ReferringPhysicianName",
+    "PerformingPhysicianName",
+    "OperatorsName",
+    "PhysiciansOfRecord",
+    "InsurancePlanIdentification",
+}
+
+
+class DicomAnonymizationError(ValueError):
+    def __init__(self, detail: str, status_code: int = 400):
+        super().__init__(detail)
+        self.detail = detail
+        self.status_code = status_code
+
+
+def _normalize_profile(profile: str) -> str:
+    normalized = (profile or "").strip().lower()
+    if normalized not in SUPPORTED_PROFILES:
+        raise DicomAnonymizationError(
+            "Invalid privacy profile. Supported profiles: strict, research"
+        )
+    return normalized
+
+
+def _scrub_dataset(dataset: Any) -> Dict[str, Any]:
+    scrubbed_elements = 0
+    field_counts: Dict[str, int] = {}
+
+    for element in dataset:
+        if element.VR == "SQ":
+            for item in element.value:
+                nested = _scrub_dataset(item)
+                scrubbed_elements += nested["scrubbed_elements"]
+                for keyword, count in nested["scrubbed_field_counts"].items():
+                    field_counts[keyword] = field_counts.get(keyword, 0) + count
+            continue
+
+        keyword = element.keyword
+        if keyword in PHI_KEYWORDS:
+            element.value = ""
+            scrubbed_elements += 1
+            field_counts[keyword] = field_counts.get(keyword, 0) + 1
+
+    return {
+        "scrubbed_elements": scrubbed_elements,
+        "scrubbed_field_counts": field_counts,
+    }
+
+
+def _remove_private_tags(dataset: Any) -> int:
+    removed = 0
+
+    for element in list(dataset):
+        if element.tag.is_private:
+            del dataset[element.tag]
+            removed += 1
+            continue
+
+        if element.VR == "SQ":
+            for item in element.value:
+                removed += _remove_private_tags(item)
+
+    return removed
+
+
+def anonymize_dicom_metadata(
+    file_bytes: bytes,
+    profile: str = "strict",
+) -> Dict[str, Any]:
+    if pydicom is None:
+        raise DicomAnonymizationError(
+            "DICOM metadata anonymization dependency is not available.",
+            status_code=503,
+        )
+    if not file_bytes:
+        raise DicomAnonymizationError("DICOM file is empty")
+
+    privacy_profile = _normalize_profile(profile)
+
+    try:
+        dataset = pydicom.dcmread(BytesIO(file_bytes), force=False)
+    except InvalidDicomError as exc:
+        raise DicomAnonymizationError("Invalid DICOM file format") from exc
+    except Exception as exc:
+        raise DicomAnonymizationError("Invalid DICOM file format") from exc
+
+    original_pixel_data = bytes(dataset.PixelData) if "PixelData" in dataset else None
+
+    scrubbed = _scrub_dataset(dataset)
+    private_tags_removed = 0
+    if privacy_profile == "strict":
+        private_tags_removed = _remove_private_tags(dataset)
+
+    current_pixel_data = bytes(dataset.PixelData) if "PixelData" in dataset else None
+
+    return {
+        "anonymization_status": "completed",
+        "metadata_summary": {
+            "profile": privacy_profile,
+            "fields_scrubbed": scrubbed["scrubbed_elements"],
+            "scrubbed_field_counts": scrubbed["scrubbed_field_counts"],
+            "private_tags_removed": private_tags_removed,
+            "pixel_data_present": original_pixel_data is not None,
+            "pixel_data_preserved": original_pixel_data == current_pixel_data,
+        },
+        "pixel_redaction_status": PIXEL_REDACTION_STATUS,
+    }

--- a/python_backend/services/ingestion.py
+++ b/python_backend/services/ingestion.py
@@ -12,6 +12,8 @@ from services.nifti_anonymization import (
     NiftiAnonymizationError,
     anonymize_nifti_metadata,
 )
+from services.ocr_redaction import redact_dicom_pixels, safe_ocr_response
+from services.wsi_tiling import scan_wsi_bytes
 
 SUPPORTED_PROFILES = {"strict", "research"}
 SUPPORTED_MODALITIES = {"csv", "text", "dicom", "nifti", "wsi"}
@@ -137,17 +139,21 @@ def anonymize_text(
 
 def anonymize_dicom(file_content: bytes, profile: str) -> Dict[str, Any]:
     try:
-        result = anonymize_dicom_metadata(file_content, profile=profile)
+        metadata_result = anonymize_dicom_metadata(file_content, profile=profile)
     except DicomAnonymizationError as exc:
         raise IngestionError(exc.detail, status_code=exc.status_code) from exc
+
+    pixel_result = safe_ocr_response(
+        redact_dicom_pixels(file_content, profile=profile)
+    )
 
     return {
         "handler": "anonymize_dicom",
         "routing_status": "handler_selected",
-        "anonymization_status": result["anonymization_status"],
-        "message": "DICOM metadata anonymization completed.",
-        "metadata_summary": result["metadata_summary"],
-        "pixel_redaction_status": result["pixel_redaction_status"],
+        "anonymization_status": metadata_result["anonymization_status"],
+        "message": "DICOM metadata anonymization and pixel redaction completed.",
+        "metadata_summary": metadata_result["metadata_summary"],
+        **pixel_result,
     }
 
 
@@ -174,8 +180,25 @@ def anonymize_nifti(
     }
 
 
-def anonymize_wsi() -> Dict[str, str]:
-    return _placeholder_result("anonymize_wsi")
+def anonymize_wsi(
+    file_content: bytes,
+    filename: str,
+    profile: str,
+) -> Dict[str, Any]:
+    result = scan_wsi_bytes(file_content, filename=filename)
+    anonymization_status = (
+        "redaction_plan_ready"
+        if result["pixel_redaction_status"] == "redaction_plan_ready"
+        else "pending"
+    )
+
+    return {
+        "handler": "anonymize_wsi",
+        "routing_status": "handler_selected",
+        "anonymization_status": anonymization_status,
+        "message": "WSI priority OCR tiling evaluated.",
+        **result,
+    }
 
 
 HANDLER_REGISTRY: Dict[str, Callable[..., Dict[str, Any]]] = {
@@ -228,6 +251,13 @@ def route_for_ingestion(
                 status_code=500,
             )
         handler_result = handler(file_content, safe_name, privacy_profile)
+    elif modality == "wsi":
+        if file_content is None:
+            raise IngestionError(
+                "WSI content was not provided for OCR scan planning",
+                status_code=500,
+            )
+        handler_result = handler(file_content, safe_name, privacy_profile)
     else:
         handler_result = handler()
 
@@ -255,5 +285,20 @@ def route_for_ingestion(
         response["metadata_summary"] = handler_result["metadata_summary"]
     if "pixel_redaction_status" in handler_result:
         response["pixel_redaction_status"] = handler_result["pixel_redaction_status"]
+    for safe_key in (
+        "ocr_boxes_detected",
+        "boxes_redacted",
+        "frames_processed",
+        "scanned_regions",
+        "ocr_engine_status",
+        "tiles_scanned",
+        "priority_regions_scanned",
+        "image_dimensions",
+        "tile_size",
+        "wsi_rewrite_status",
+        "redaction_plan_boxes",
+    ):
+        if safe_key in handler_result:
+            response[safe_key] = handler_result[safe_key]
 
     return response

--- a/python_backend/services/ingestion.py
+++ b/python_backend/services/ingestion.py
@@ -4,6 +4,14 @@ from services.text_anonymization import (
     TextAnonymizationError,
     anonymize_clinical_text,
 )
+from services.dicom_anonymization import (
+    DicomAnonymizationError,
+    anonymize_dicom_metadata,
+)
+from services.nifti_anonymization import (
+    NiftiAnonymizationError,
+    anonymize_nifti_metadata,
+)
 
 SUPPORTED_PROFILES = {"strict", "research"}
 SUPPORTED_MODALITIES = {"csv", "text", "dicom", "nifti", "wsi"}
@@ -127,12 +135,43 @@ def anonymize_text(
     }
 
 
-def anonymize_dicom() -> Dict[str, str]:
-    return _placeholder_result("anonymize_dicom")
+def anonymize_dicom(file_content: bytes, profile: str) -> Dict[str, Any]:
+    try:
+        result = anonymize_dicom_metadata(file_content, profile=profile)
+    except DicomAnonymizationError as exc:
+        raise IngestionError(exc.detail, status_code=exc.status_code) from exc
+
+    return {
+        "handler": "anonymize_dicom",
+        "routing_status": "handler_selected",
+        "anonymization_status": result["anonymization_status"],
+        "message": "DICOM metadata anonymization completed.",
+        "metadata_summary": result["metadata_summary"],
+        "pixel_redaction_status": result["pixel_redaction_status"],
+    }
 
 
-def anonymize_nifti() -> Dict[str, str]:
-    return _placeholder_result("anonymize_nifti")
+def anonymize_nifti(
+    file_content: bytes,
+    filename: str,
+    profile: str,
+) -> Dict[str, Any]:
+    try:
+        result = anonymize_nifti_metadata(
+            file_content,
+            filename=filename,
+            profile=profile,
+        )
+    except NiftiAnonymizationError as exc:
+        raise IngestionError(exc.detail, status_code=exc.status_code) from exc
+
+    return {
+        "handler": "anonymize_nifti",
+        "routing_status": "handler_selected",
+        "anonymization_status": result["anonymization_status"],
+        "message": "NIfTI metadata anonymization completed.",
+        "metadata_summary": result["metadata_summary"],
+    }
 
 
 def anonymize_wsi() -> Dict[str, str]:
@@ -154,6 +193,7 @@ def route_for_ingestion(
     header: bytes,
     profile: str,
     text_content: Optional[bytes] = None,
+    file_content: Optional[bytes] = None,
     study_salt: Optional[str] = None,
 ) -> Dict[str, Any]:
     safe_name = _safe_filename(filename)
@@ -174,6 +214,20 @@ def route_for_ingestion(
                 status_code=500,
             )
         handler_result = handler(text_content, privacy_profile, study_salt)
+    elif modality == "dicom":
+        if file_content is None:
+            raise IngestionError(
+                "DICOM content was not provided for anonymization",
+                status_code=500,
+            )
+        handler_result = handler(file_content, privacy_profile)
+    elif modality == "nifti":
+        if file_content is None:
+            raise IngestionError(
+                "NIfTI content was not provided for anonymization",
+                status_code=500,
+            )
+        handler_result = handler(file_content, safe_name, privacy_profile)
     else:
         handler_result = handler()
 
@@ -197,5 +251,9 @@ def route_for_ingestion(
         response["anonymized_text"] = handler_result["anonymized_text"]
     if "detected_entities" in handler_result:
         response["detected_entities"] = handler_result["detected_entities"]
+    if "metadata_summary" in handler_result:
+        response["metadata_summary"] = handler_result["metadata_summary"]
+    if "pixel_redaction_status" in handler_result:
+        response["pixel_redaction_status"] = handler_result["pixel_redaction_status"]
 
     return response

--- a/python_backend/services/ingestion.py
+++ b/python_backend/services/ingestion.py
@@ -6,7 +6,7 @@ from services.text_anonymization import (
 )
 from services.dicom_anonymization import (
     DicomAnonymizationError,
-    anonymize_dicom_metadata,
+    anonymize_dicom_file_bytes,
 )
 from services.nifti_anonymization import (
     NiftiAnonymizationError,
@@ -139,12 +139,13 @@ def anonymize_text(
 
 def anonymize_dicom(file_content: bytes, profile: str) -> Dict[str, Any]:
     try:
-        metadata_result = anonymize_dicom_metadata(file_content, profile=profile)
+        metadata_result = anonymize_dicom_file_bytes(file_content, profile=profile)
     except DicomAnonymizationError as exc:
         raise IngestionError(exc.detail, status_code=exc.status_code) from exc
 
+    metadata_scrubbed_content = metadata_result["anonymized_dicom_bytes"]
     pixel_result = safe_ocr_response(
-        redact_dicom_pixels(file_content, profile=profile)
+        redact_dicom_pixels(metadata_scrubbed_content, profile=profile)
     )
 
     return {

--- a/python_backend/services/ingestion.py
+++ b/python_backend/services/ingestion.py
@@ -14,6 +14,10 @@ from services.nifti_anonymization import (
 )
 from services.ocr_redaction import redact_dicom_pixels, safe_ocr_response
 from services.wsi_tiling import scan_wsi_bytes
+from services.privacy_profiles import (
+    PrivacyProfileError,
+    validate_privacy_profile as validate_config_privacy_profile,
+)
 
 SUPPORTED_PROFILES = {"strict", "research"}
 SUPPORTED_MODALITIES = {"csv", "text", "dicom", "nifti", "wsi"}
@@ -29,12 +33,10 @@ class IngestionError(ValueError):
 
 
 def validate_privacy_profile(profile: str) -> str:
-    normalized = (profile or "").strip().lower()
-    if normalized not in SUPPORTED_PROFILES:
-        raise IngestionError(
-            "Invalid privacy profile. Supported profiles: strict, research"
-        )
-    return normalized
+    try:
+        return validate_config_privacy_profile(profile)
+    except PrivacyProfileError as exc:
+        raise IngestionError(exc.detail, status_code=exc.status_code) from exc
 
 
 def _safe_filename(filename: str) -> str:
@@ -133,6 +135,8 @@ def anonymize_text(
         "anonymization_status": result["anonymization_status"],
         "message": "Text anonymization completed.",
         "anonymized_text": result["anonymized_text"],
+        "date_strategy": result["date_strategy"],
+        "text_identifier_strategy": result["text_identifier_strategy"],
         "detected_entities": result["detected_entities"],
     }
 
@@ -280,6 +284,10 @@ def route_for_ingestion(
     }
     if "anonymized_text" in handler_result:
         response["anonymized_text"] = handler_result["anonymized_text"]
+    if "date_strategy" in handler_result:
+        response["date_strategy"] = handler_result["date_strategy"]
+    if "text_identifier_strategy" in handler_result:
+        response["text_identifier_strategy"] = handler_result["text_identifier_strategy"]
     if "detected_entities" in handler_result:
         response["detected_entities"] = handler_result["detected_entities"]
     if "metadata_summary" in handler_result:
@@ -292,6 +300,7 @@ def route_for_ingestion(
         "frames_processed",
         "scanned_regions",
         "ocr_engine_status",
+        "ocr_confidence_threshold",
         "tiles_scanned",
         "priority_regions_scanned",
         "image_dimensions",
@@ -303,3 +312,4 @@ def route_for_ingestion(
             response[safe_key] = handler_result[safe_key]
 
     return response
+

--- a/python_backend/services/nifti_anonymization.py
+++ b/python_backend/services/nifti_anonymization.py
@@ -4,13 +4,18 @@ from typing import Any, Dict
 
 import numpy as np
 
+from services.privacy_profiles import (
+    PrivacyProfileError,
+    get_privacy_profile,
+    validate_privacy_profile,
+)
+
 try:
     import nibabel as nib
 except ImportError:
     nib = None
 
 
-SUPPORTED_PROFILES = {"strict", "research"}
 SUPPORTED_EXTENSIONS = {".nii", ".nii.gz"}
 TEXT_HEADER_FIELDS = ("descrip", "aux_file", "intent_name", "db_name")
 
@@ -22,13 +27,12 @@ class NiftiAnonymizationError(ValueError):
         self.status_code = status_code
 
 
-def _normalize_profile(profile: str) -> str:
-    normalized = (profile or "").strip().lower()
-    if normalized not in SUPPORTED_PROFILES:
-        raise NiftiAnonymizationError(
-            "Invalid privacy profile. Supported profiles: strict, research"
-        )
-    return normalized
+def _profile_settings(profile: str) -> tuple[str, Dict[str, Any]]:
+    try:
+        normalized = validate_privacy_profile(profile)
+        return normalized, get_privacy_profile(normalized)
+    except PrivacyProfileError as exc:
+        raise NiftiAnonymizationError(exc.detail, status_code=exc.status_code) from exc
 
 
 def _nifti_suffix(filename: str) -> str:
@@ -100,7 +104,7 @@ def anonymize_nifti_metadata(
     if not file_bytes:
         raise NiftiAnonymizationError("NIfTI file is empty")
 
-    privacy_profile = _normalize_profile(profile)
+    privacy_profile, settings = _profile_settings(profile)
     suffix = _nifti_suffix(filename)
 
     temp_path = None
@@ -113,12 +117,13 @@ def anonymize_nifti_metadata(
         original_shape = tuple(int(dimension) for dimension in image.shape)
         original_affine = np.array(image.affine, copy=True)
         original_dtype = str(image.get_data_dtype())
+        original_extensions = len(image.header.extensions)
 
         scrubbed_header = image.header.copy()
         scrubbed = _scrub_header_fields(scrubbed_header)
 
         extensions_removed = 0
-        if privacy_profile == "strict":
+        if settings["remove_nifti_extensions"]:
             extensions_removed = len(scrubbed_header.extensions)
             scrubbed_header.extensions.clear()
 
@@ -132,9 +137,12 @@ def anonymize_nifti_metadata(
             "anonymization_status": "completed",
             "metadata_summary": {
                 "profile": privacy_profile,
+                "remove_nifti_extensions": settings["remove_nifti_extensions"],
                 "fields_scrubbed": scrubbed["fields_scrubbed"],
                 "scrubbed_field_counts": scrubbed["scrubbed_field_counts"],
+                "extensions_present_before": original_extensions,
                 "extensions_removed": extensions_removed,
+                "extensions_preserved": original_extensions - extensions_removed,
                 "image_shape": list(original_shape),
                 "shape_preserved": tuple(scrubbed_image.shape) == original_shape,
                 "affine_preserved": np.array_equal(
@@ -145,6 +153,12 @@ def anonymize_nifti_metadata(
                     str(scrubbed_image.get_data_dtype()) == original_dtype
                 ),
                 "image_data_preserved": True,
+                "safe_technical_metadata_preserved": [
+                    "shape",
+                    "affine",
+                    "datatype",
+                    "image_data",
+                ],
             },
         }
     finally:

--- a/python_backend/services/nifti_anonymization.py
+++ b/python_backend/services/nifti_anonymization.py
@@ -1,0 +1,152 @@
+import os
+import tempfile
+from typing import Any, Dict
+
+import numpy as np
+
+try:
+    import nibabel as nib
+except ImportError:
+    nib = None
+
+
+SUPPORTED_PROFILES = {"strict", "research"}
+SUPPORTED_EXTENSIONS = {".nii", ".nii.gz"}
+TEXT_HEADER_FIELDS = ("descrip", "aux_file", "intent_name", "db_name")
+
+
+class NiftiAnonymizationError(ValueError):
+    def __init__(self, detail: str, status_code: int = 400):
+        super().__init__(detail)
+        self.detail = detail
+        self.status_code = status_code
+
+
+def _normalize_profile(profile: str) -> str:
+    normalized = (profile or "").strip().lower()
+    if normalized not in SUPPORTED_PROFILES:
+        raise NiftiAnonymizationError(
+            "Invalid privacy profile. Supported profiles: strict, research"
+        )
+    return normalized
+
+
+def _nifti_suffix(filename: str) -> str:
+    lower_name = (filename or "").strip().lower()
+    if lower_name.endswith(".nii.gz"):
+        return ".nii.gz"
+    if lower_name.endswith(".nii"):
+        return ".nii"
+    raise NiftiAnonymizationError("NIfTI uploads must use .nii or .nii.gz")
+
+
+def _header_value_has_text(value: Any) -> bool:
+    if hasattr(value, "tobytes"):
+        raw = value.tobytes()
+    elif isinstance(value, bytes):
+        raw = value
+    else:
+        raw = str(value).encode("utf-8", errors="ignore")
+
+    return bool(raw.replace(b"\x00", b"").strip())
+
+
+def _scrub_header_fields(header: Any) -> Dict[str, Any]:
+    field_counts: Dict[str, int] = {}
+
+    for field_name in TEXT_HEADER_FIELDS:
+        if field_name not in header:
+            continue
+
+        if _header_value_has_text(header[field_name]):
+            field_counts[field_name] = 1
+        header[field_name] = b""
+
+    return {
+        "fields_scrubbed": sum(field_counts.values()),
+        "scrubbed_field_counts": field_counts,
+    }
+
+
+def _load_nifti_from_bytes(file_bytes: bytes, suffix: str):
+    temp_path = None
+    temp_file = tempfile.NamedTemporaryFile(
+        suffix=suffix,
+        prefix="bioblock_nifti_",
+        delete=False,
+    )
+    try:
+        temp_path = temp_file.name
+        temp_file.write(file_bytes)
+        temp_file.close()
+        return nib.load(temp_path), temp_path
+    except Exception:
+        temp_file.close()
+        if temp_path and os.path.exists(temp_path):
+            os.unlink(temp_path)
+        raise
+
+
+def anonymize_nifti_metadata(
+    file_bytes: bytes,
+    filename: str,
+    profile: str = "strict",
+) -> Dict[str, Any]:
+    if nib is None:
+        raise NiftiAnonymizationError(
+            "NIfTI metadata anonymization dependency is not available.",
+            status_code=503,
+        )
+    if not file_bytes:
+        raise NiftiAnonymizationError("NIfTI file is empty")
+
+    privacy_profile = _normalize_profile(profile)
+    suffix = _nifti_suffix(filename)
+
+    temp_path = None
+    try:
+        image, temp_path = _load_nifti_from_bytes(file_bytes, suffix)
+    except Exception as exc:
+        raise NiftiAnonymizationError("Invalid NIfTI file format") from exc
+
+    try:
+        original_shape = tuple(int(dimension) for dimension in image.shape)
+        original_affine = np.array(image.affine, copy=True)
+        original_dtype = str(image.get_data_dtype())
+
+        scrubbed_header = image.header.copy()
+        scrubbed = _scrub_header_fields(scrubbed_header)
+
+        extensions_removed = 0
+        if privacy_profile == "strict":
+            extensions_removed = len(scrubbed_header.extensions)
+            scrubbed_header.extensions.clear()
+
+        scrubbed_image = nib.Nifti1Image(
+            image.dataobj,
+            image.affine.copy(),
+            header=scrubbed_header,
+        )
+
+        return {
+            "anonymization_status": "completed",
+            "metadata_summary": {
+                "profile": privacy_profile,
+                "fields_scrubbed": scrubbed["fields_scrubbed"],
+                "scrubbed_field_counts": scrubbed["scrubbed_field_counts"],
+                "extensions_removed": extensions_removed,
+                "image_shape": list(original_shape),
+                "shape_preserved": tuple(scrubbed_image.shape) == original_shape,
+                "affine_preserved": np.array_equal(
+                    scrubbed_image.affine,
+                    original_affine,
+                ),
+                "datatype_preserved": (
+                    str(scrubbed_image.get_data_dtype()) == original_dtype
+                ),
+                "image_data_preserved": True,
+            },
+        }
+    finally:
+        if temp_path and os.path.exists(temp_path):
+            os.unlink(temp_path)

--- a/python_backend/services/ocr_redaction.py
+++ b/python_backend/services/ocr_redaction.py
@@ -9,6 +9,8 @@ from typing import Any, Dict, Iterable, List, Optional, Protocol, Sequence, Tupl
 import numpy as np
 from PIL import Image, ImageDraw
 
+from services.privacy_profiles import PrivacyProfileError, get_privacy_profile
+
 try:
     import pydicom
     from pydicom.errors import InvalidDicomError
@@ -234,7 +236,7 @@ def redact_dicom_pixels(
     file_bytes: bytes,
     profile: str = "strict",
     ocr_backend: Optional[OCRBackend] = None,
-    min_confidence: float = DEFAULT_MIN_CONFIDENCE,
+    min_confidence: Optional[float] = None,
     include_sanitized_bytes: bool = True,
 ) -> Dict[str, Any]:
     if pydicom is None:
@@ -249,6 +251,21 @@ def redact_dicom_pixels(
             ocr_engine_status="not_applicable",
             include_sanitized_bytes=include_sanitized_bytes,
         )
+
+    try:
+        profile_settings = get_privacy_profile(profile)
+    except PrivacyProfileError:
+        return _dicom_result(
+            pixel_redaction_status="invalid_profile",
+            ocr_engine_status="not_applicable",
+            include_sanitized_bytes=include_sanitized_bytes,
+        )
+
+    effective_min_confidence = (
+        float(min_confidence)
+        if min_confidence is not None
+        else float(profile_settings["ocr_confidence_threshold"])
+    )
 
     backend = ocr_backend or get_default_ocr_backend()
     engine_status = _backend_status(backend)
@@ -308,7 +325,7 @@ def redact_dicom_pixels(
 
             image_width, image_height = ocr_image.size
             for box in boxes:
-                if box.confidence < min_confidence:
+                if box.confidence < effective_min_confidence:
                     continue
 
                 clipped = clip_box_to_image(box, image_width, image_height)
@@ -357,6 +374,7 @@ def redact_dicom_pixels(
         ocr_engine_status=engine_status,
         sanitized_bytes=sanitized_bytes,
         include_sanitized_bytes=include_sanitized_bytes,
+        ocr_confidence_threshold=effective_min_confidence,
     )
 
 
@@ -473,6 +491,7 @@ def _dicom_result(
     ocr_engine_status: str = "not_applicable",
     sanitized_bytes: Optional[bytes] = None,
     include_sanitized_bytes: bool = True,
+    ocr_confidence_threshold: Optional[float] = None,
 ) -> Dict[str, Any]:
     result: Dict[str, Any] = {
         "pixel_redaction_status": pixel_redaction_status,
@@ -482,6 +501,9 @@ def _dicom_result(
         "scanned_regions": scanned_regions,
         "ocr_engine_status": ocr_engine_status,
     }
+    if ocr_confidence_threshold is not None:
+        result["ocr_confidence_threshold"] = ocr_confidence_threshold
     if include_sanitized_bytes and sanitized_bytes is not None:
         result["sanitized_dicom_bytes"] = sanitized_bytes
     return result
+

--- a/python_backend/services/ocr_redaction.py
+++ b/python_backend/services/ocr_redaction.py
@@ -1,0 +1,487 @@
+from __future__ import annotations
+
+import os
+import shutil
+from dataclasses import dataclass
+from io import BytesIO
+from typing import Any, Dict, Iterable, List, Optional, Protocol, Sequence, Tuple
+
+import numpy as np
+from PIL import Image, ImageDraw
+
+try:
+    import pydicom
+    from pydicom.errors import InvalidDicomError
+except ImportError:
+    pydicom = None
+    InvalidDicomError = Exception
+
+
+DEFAULT_MIN_CONFIDENCE = 0.5
+
+
+class OCREngineUnavailable(RuntimeError):
+    pass
+
+
+class OCRBackend(Protocol):
+    ocr_engine_status: str
+
+    def detect_text_boxes(self, image: Image.Image) -> Sequence["OCRBox"]:
+        ...
+
+
+@dataclass(frozen=True)
+class OCRBox:
+    text: str
+    confidence: float
+    x: int
+    y: int
+    width: int
+    height: int
+
+
+@dataclass
+class ImageRedactionResult:
+    image: Image.Image
+    boxes_detected: int
+    boxes_redacted: int
+    redaction_status: str
+    ocr_engine_status: Optional[str] = None
+
+    def safe_summary(self) -> Dict[str, Any]:
+        summary: Dict[str, Any] = {
+            "boxes_detected": self.boxes_detected,
+            "boxes_redacted": self.boxes_redacted,
+            "redaction_status": self.redaction_status,
+        }
+        if self.ocr_engine_status is not None:
+            summary["ocr_engine_status"] = self.ocr_engine_status
+        return summary
+
+
+class UnavailableOCRBackend:
+    ocr_engine_status = "unavailable"
+
+    def detect_text_boxes(self, image: Image.Image) -> Sequence[OCRBox]:
+        raise OCREngineUnavailable("OCR engine is unavailable")
+
+
+class PytesseractOCRBackend:
+    def __init__(self, tesseract_cmd: Optional[str] = None):
+        self._pytesseract = None
+        self._output = None
+        self.ocr_engine_status = "unavailable"
+
+        try:
+            import pytesseract
+            from pytesseract import Output
+        except ImportError:
+            return
+
+        resolved_cmd = _resolve_tesseract_cmd(tesseract_cmd)
+        if not resolved_cmd:
+            return
+
+        pytesseract.pytesseract.tesseract_cmd = resolved_cmd
+        self._pytesseract = pytesseract
+        self._output = Output
+        self.ocr_engine_status = "available"
+
+    def detect_text_boxes(self, image: Image.Image) -> Sequence[OCRBox]:
+        if self.ocr_engine_status != "available" or self._pytesseract is None:
+            raise OCREngineUnavailable("OCR engine is unavailable")
+
+        pil_image = _ensure_pil_image(image)
+        ocr_data = self._pytesseract.image_to_data(
+            pil_image,
+            output_type=self._output.DICT,
+        )
+
+        detections: List[OCRBox] = []
+        for index, text in enumerate(ocr_data.get("text", [])):
+            cleaned_text = str(text).strip()
+            if not cleaned_text:
+                continue
+
+            confidence = _parse_confidence(ocr_data.get("conf", [])[index])
+            if confidence < 0:
+                continue
+
+            detections.append(
+                OCRBox(
+                    text=cleaned_text,
+                    confidence=confidence,
+                    x=int(ocr_data.get("left", [])[index]),
+                    y=int(ocr_data.get("top", [])[index]),
+                    width=int(ocr_data.get("width", [])[index]),
+                    height=int(ocr_data.get("height", [])[index]),
+                )
+            )
+        return detections
+
+
+def get_default_ocr_backend() -> OCRBackend:
+    backend = PytesseractOCRBackend()
+    if backend.ocr_engine_status == "available":
+        return backend
+    return UnavailableOCRBackend()
+
+
+def redact_image_with_backend(
+    image: Any,
+    ocr_backend: Optional[OCRBackend] = None,
+    min_confidence: float = DEFAULT_MIN_CONFIDENCE,
+) -> ImageRedactionResult:
+    backend = ocr_backend or get_default_ocr_backend()
+    engine_status = _backend_status(backend)
+
+    if engine_status == "unavailable":
+        pil_image = _ensure_pil_image(image)
+        return ImageRedactionResult(
+            image=pil_image,
+            boxes_detected=0,
+            boxes_redacted=0,
+            redaction_status="skipped_ocr_unavailable",
+            ocr_engine_status=engine_status,
+        )
+
+    try:
+        boxes = backend.detect_text_boxes(_ensure_pil_image(image))
+    except OCREngineUnavailable:
+        return ImageRedactionResult(
+            image=_ensure_pil_image(image),
+            boxes_detected=0,
+            boxes_redacted=0,
+            redaction_status="skipped_ocr_unavailable",
+            ocr_engine_status="unavailable",
+        )
+    except Exception:
+        return ImageRedactionResult(
+            image=_ensure_pil_image(image),
+            boxes_detected=0,
+            boxes_redacted=0,
+            redaction_status="ocr_failed",
+            ocr_engine_status="error",
+        )
+
+    result = redact_image_regions(
+        image=image,
+        boxes=boxes,
+        min_confidence=min_confidence,
+    )
+    result.ocr_engine_status = engine_status
+    return result
+
+
+def redact_image_regions(
+    image: Any,
+    boxes: Iterable[OCRBox],
+    min_confidence: float = DEFAULT_MIN_CONFIDENCE,
+    fill: Optional[Any] = None,
+) -> ImageRedactionResult:
+    pil_image = _ensure_pil_image(image)
+    redacted = pil_image.copy()
+    draw = ImageDraw.Draw(redacted)
+    image_width, image_height = redacted.size
+    detections = list(boxes)
+    boxes_redacted = 0
+    mask_fill = fill if fill is not None else _black_fill_for_mode(redacted.mode)
+
+    for box in detections:
+        if box.confidence < min_confidence:
+            continue
+
+        clipped = clip_box_to_image(box, image_width, image_height)
+        if clipped is None:
+            continue
+
+        left, top, right, bottom = clipped
+        draw.rectangle((left, top, right - 1, bottom - 1), fill=mask_fill)
+        boxes_redacted += 1
+
+    if boxes_redacted:
+        status = "completed"
+    elif detections:
+        status = "completed_no_boxes_redacted"
+    else:
+        status = "completed_no_boxes"
+
+    return ImageRedactionResult(
+        image=redacted,
+        boxes_detected=len(detections),
+        boxes_redacted=boxes_redacted,
+        redaction_status=status,
+    )
+
+
+def clip_box_to_image(
+    box: OCRBox,
+    image_width: int,
+    image_height: int,
+) -> Optional[Tuple[int, int, int, int]]:
+    left = max(0, int(box.x))
+    top = max(0, int(box.y))
+    right = min(image_width, int(box.x) + max(0, int(box.width)))
+    bottom = min(image_height, int(box.y) + max(0, int(box.height)))
+
+    if right <= left or bottom <= top:
+        return None
+    return left, top, right, bottom
+
+
+def redact_dicom_pixels(
+    file_bytes: bytes,
+    profile: str = "strict",
+    ocr_backend: Optional[OCRBackend] = None,
+    min_confidence: float = DEFAULT_MIN_CONFIDENCE,
+    include_sanitized_bytes: bool = True,
+) -> Dict[str, Any]:
+    if pydicom is None:
+        return _dicom_result(
+            pixel_redaction_status="dependency_unavailable",
+            ocr_engine_status="unavailable",
+            include_sanitized_bytes=include_sanitized_bytes,
+        )
+    if not file_bytes:
+        return _dicom_result(
+            pixel_redaction_status="empty_file",
+            ocr_engine_status="not_applicable",
+            include_sanitized_bytes=include_sanitized_bytes,
+        )
+
+    backend = ocr_backend or get_default_ocr_backend()
+    engine_status = _backend_status(backend)
+    if engine_status == "unavailable":
+        return _dicom_result(
+            pixel_redaction_status="skipped_ocr_unavailable",
+            ocr_engine_status=engine_status,
+            sanitized_bytes=file_bytes,
+            include_sanitized_bytes=include_sanitized_bytes,
+        )
+
+    try:
+        dataset = pydicom.dcmread(BytesIO(file_bytes), force=False)
+    except (InvalidDicomError, Exception):
+        return _dicom_result(
+            pixel_redaction_status="invalid_dicom",
+            ocr_engine_status=engine_status,
+            include_sanitized_bytes=include_sanitized_bytes,
+        )
+
+    if "PixelData" not in dataset:
+        return _dicom_result(
+            pixel_redaction_status="no_pixel_data",
+            ocr_engine_status=engine_status,
+            sanitized_bytes=file_bytes,
+            include_sanitized_bytes=include_sanitized_bytes,
+        )
+
+    try:
+        pixel_array = np.array(dataset.pixel_array, copy=True)
+    except Exception:
+        return _dicom_result(
+            pixel_redaction_status="unsupported_pixel_data",
+            ocr_engine_status=engine_status,
+            sanitized_bytes=file_bytes,
+            include_sanitized_bytes=include_sanitized_bytes,
+        )
+
+    frames = _iter_grayscale_frames(pixel_array, dataset)
+    if frames is None:
+        return _dicom_result(
+            pixel_redaction_status="unsupported_pixel_format",
+            ocr_engine_status=engine_status,
+            sanitized_bytes=file_bytes,
+            include_sanitized_bytes=include_sanitized_bytes,
+        )
+
+    boxes_detected = 0
+    boxes_redacted = 0
+    frames_processed = 0
+
+    try:
+        for frame_index, frame in frames:
+            ocr_image = _frame_to_ocr_image(frame)
+            boxes = list(backend.detect_text_boxes(ocr_image))
+            boxes_detected += len(boxes)
+
+            image_width, image_height = ocr_image.size
+            for box in boxes:
+                if box.confidence < min_confidence:
+                    continue
+
+                clipped = clip_box_to_image(box, image_width, image_height)
+                if clipped is None:
+                    continue
+
+                left, top, right, bottom = clipped
+                frame[top:bottom, left:right] = _redaction_pixel_value(frame)
+                boxes_redacted += 1
+
+            frames_processed += 1
+    except OCREngineUnavailable:
+        return _dicom_result(
+            pixel_redaction_status="skipped_ocr_unavailable",
+            ocr_engine_status="unavailable",
+            sanitized_bytes=file_bytes,
+            include_sanitized_bytes=include_sanitized_bytes,
+        )
+    except Exception:
+        return _dicom_result(
+            pixel_redaction_status="ocr_failed",
+            ocr_engine_status="error",
+            frames_processed=frames_processed,
+            sanitized_bytes=file_bytes,
+            include_sanitized_bytes=include_sanitized_bytes,
+        )
+
+    sanitized_bytes = file_bytes
+    if boxes_redacted:
+        dataset.PixelData = pixel_array.tobytes()
+        sanitized_bytes = _dataset_to_bytes(dataset)
+
+    if boxes_redacted:
+        status = "completed"
+    elif boxes_detected:
+        status = "completed_no_boxes_redacted"
+    else:
+        status = "completed_no_text_detected"
+
+    return _dicom_result(
+        pixel_redaction_status=status,
+        ocr_boxes_detected=boxes_detected,
+        boxes_redacted=boxes_redacted,
+        frames_processed=frames_processed,
+        scanned_regions=frames_processed,
+        ocr_engine_status=engine_status,
+        sanitized_bytes=sanitized_bytes,
+        include_sanitized_bytes=include_sanitized_bytes,
+    )
+
+
+def safe_ocr_response(result: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        key: value
+        for key, value in result.items()
+        if key not in {"sanitized_dicom_bytes", "sanitized_bytes"}
+    }
+
+
+def _resolve_tesseract_cmd(tesseract_cmd: Optional[str]) -> Optional[str]:
+    candidates = [
+        tesseract_cmd,
+        os.getenv("TESSERACT_CMD"),
+        shutil.which("tesseract"),
+        "/opt/homebrew/bin/tesseract",
+        "/usr/local/bin/tesseract",
+        "/usr/bin/tesseract",
+        r"C:\Program Files\Tesseract-OCR\tesseract.exe",
+    ]
+    for candidate in candidates:
+        if not candidate:
+            continue
+        if os.path.isfile(candidate):
+            return candidate
+        resolved = shutil.which(candidate)
+        if resolved:
+            return resolved
+    return None
+
+
+def _parse_confidence(raw_confidence: Any) -> float:
+    try:
+        confidence = float(raw_confidence)
+    except (TypeError, ValueError):
+        return -1.0
+
+    if confidence > 1.0:
+        confidence = confidence / 100.0
+    return confidence
+
+
+def _ensure_pil_image(image: Any) -> Image.Image:
+    if isinstance(image, Image.Image):
+        return image.copy()
+
+    array = np.asarray(image)
+    if array.ndim == 2:
+        return Image.fromarray(array)
+    if array.ndim == 3:
+        return Image.fromarray(array)
+
+    raise ValueError("OCR redaction requires a 2D grayscale or 3D image array")
+
+
+def _black_fill_for_mode(mode: str) -> Any:
+    if mode in {"1", "L", "I", "I;16", "F"}:
+        return 0
+    if mode == "RGBA":
+        return (0, 0, 0, 255)
+    return (0, 0, 0)
+
+
+def _backend_status(backend: OCRBackend) -> str:
+    status = getattr(backend, "ocr_engine_status", "available")
+    if callable(status):
+        status = status()
+    return str(status or "available")
+
+
+def _iter_grayscale_frames(pixel_array: np.ndarray, dataset: Any):
+    samples_per_pixel = int(getattr(dataset, "SamplesPerPixel", 1) or 1)
+
+    if samples_per_pixel != 1:
+        return None
+    if pixel_array.ndim == 2:
+        return [(0, pixel_array)]
+    if pixel_array.ndim == 3:
+        return [(index, pixel_array[index]) for index in range(pixel_array.shape[0])]
+    return None
+
+
+def _frame_to_ocr_image(frame: np.ndarray) -> Image.Image:
+    frame_min = float(np.min(frame))
+    frame_max = float(np.max(frame))
+    if frame_max == frame_min:
+        normalized = np.zeros(frame.shape, dtype=np.uint8)
+    else:
+        normalized = ((frame - frame_min) / (frame_max - frame_min) * 255).astype(
+            np.uint8
+        )
+    return Image.fromarray(normalized, mode="L")
+
+
+def _redaction_pixel_value(frame: np.ndarray) -> Any:
+    if np.issubdtype(frame.dtype, np.integer):
+        return np.iinfo(frame.dtype).min
+    return 0
+
+
+def _dataset_to_bytes(dataset: Any) -> bytes:
+    buffer = BytesIO()
+    dataset.save_as(buffer, enforce_file_format=True)
+    return buffer.getvalue()
+
+
+def _dicom_result(
+    pixel_redaction_status: str,
+    ocr_boxes_detected: int = 0,
+    boxes_redacted: int = 0,
+    frames_processed: int = 0,
+    scanned_regions: int = 0,
+    ocr_engine_status: str = "not_applicable",
+    sanitized_bytes: Optional[bytes] = None,
+    include_sanitized_bytes: bool = True,
+) -> Dict[str, Any]:
+    result: Dict[str, Any] = {
+        "pixel_redaction_status": pixel_redaction_status,
+        "ocr_boxes_detected": ocr_boxes_detected,
+        "boxes_redacted": boxes_redacted,
+        "frames_processed": frames_processed,
+        "scanned_regions": scanned_regions,
+        "ocr_engine_status": ocr_engine_status,
+    }
+    if include_sanitized_bytes and sanitized_bytes is not None:
+        result["sanitized_dicom_bytes"] = sanitized_bytes
+    return result

--- a/python_backend/services/privacy_profiles.py
+++ b/python_backend/services/privacy_profiles.py
@@ -1,0 +1,156 @@
+import json
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Dict
+
+
+PROFILE_CONFIG_PATH = (
+    Path(__file__).resolve().parent.parent / "config" / "privacy_profiles.json"
+)
+REQUIRED_SETTINGS = {
+    "redact_dates",
+    "date_strategy",
+    "text_identifier_strategy",
+    "remove_dicom_private_tags",
+    "preserve_dicom_technical_metadata",
+    "remove_nifti_extensions",
+    "ocr_confidence_threshold",
+    "allow_generalized_demographics",
+}
+REQUIRED_PROFILES = {"strict", "research"}
+DATE_STRATEGIES = {"redact", "shift", "generalize"}
+TEXT_IDENTIFIER_STRATEGIES = {"redact", "pseudonymize"}
+
+
+class PrivacyProfileError(ValueError):
+    def __init__(self, detail: str, status_code: int = 400):
+        super().__init__(detail)
+        self.detail = detail
+        self.status_code = status_code
+
+
+def load_privacy_profiles() -> Dict[str, Dict[str, Any]]:
+    return {name: dict(settings) for name, settings in _load_profiles().items()}
+
+
+def get_privacy_profile(profile: str) -> Dict[str, Any]:
+    profiles = _load_profiles()
+    normalized = _normalize_profile_name(profile, profiles)
+    return dict(profiles[normalized])
+
+
+def validate_privacy_profile(profile: str) -> str:
+    return _normalize_profile_name(profile, _load_profiles())
+
+
+@lru_cache(maxsize=1)
+def _load_profiles() -> Dict[str, Dict[str, Any]]:
+    try:
+        raw_profiles = json.loads(PROFILE_CONFIG_PATH.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise PrivacyProfileError(
+            f"Privacy profile config not found: {PROFILE_CONFIG_PATH}",
+            status_code=500,
+        ) from exc
+    except json.JSONDecodeError as exc:
+        raise PrivacyProfileError(
+            "Privacy profile config is not valid JSON.",
+            status_code=500,
+        ) from exc
+
+    if not isinstance(raw_profiles, dict):
+        raise PrivacyProfileError(
+            "Privacy profile config must be a JSON object.",
+            status_code=500,
+        )
+
+    missing_profiles = REQUIRED_PROFILES - set(raw_profiles)
+    if missing_profiles:
+        missing = ", ".join(sorted(missing_profiles))
+        raise PrivacyProfileError(
+            f"Privacy profile config missing required profiles: {missing}",
+            status_code=500,
+        )
+
+    profiles: Dict[str, Dict[str, Any]] = {}
+    for name, settings in raw_profiles.items():
+        normalized = str(name).strip().lower()
+        if not normalized:
+            raise PrivacyProfileError(
+                "Privacy profile names must not be empty.",
+                status_code=500,
+            )
+        if not isinstance(settings, dict):
+            raise PrivacyProfileError(
+                f"Privacy profile '{normalized}' must be a JSON object.",
+                status_code=500,
+            )
+
+        _validate_settings(normalized, settings)
+        profiles[normalized] = dict(settings)
+
+    return profiles
+
+
+def _normalize_profile_name(
+    profile: str,
+    profiles: Dict[str, Dict[str, Any]],
+) -> str:
+    normalized = (profile or "").strip().lower()
+    if normalized not in profiles:
+        supported = ", ".join(sorted(profiles))
+        raise PrivacyProfileError(
+            f"Invalid privacy profile '{profile}'. Supported profiles: {supported}"
+        )
+    return normalized
+
+
+def _validate_settings(name: str, settings: Dict[str, Any]) -> None:
+    missing_settings = REQUIRED_SETTINGS - set(settings)
+    if missing_settings:
+        missing = ", ".join(sorted(missing_settings))
+        raise PrivacyProfileError(
+            f"Privacy profile '{name}' missing settings: {missing}",
+            status_code=500,
+        )
+
+    for key in (
+        "redact_dates",
+        "remove_dicom_private_tags",
+        "preserve_dicom_technical_metadata",
+        "remove_nifti_extensions",
+        "allow_generalized_demographics",
+    ):
+        if not isinstance(settings[key], bool):
+            raise PrivacyProfileError(
+                f"Privacy profile '{name}' setting '{key}' must be a boolean.",
+                status_code=500,
+            )
+
+    if settings["date_strategy"] not in DATE_STRATEGIES:
+        allowed = ", ".join(sorted(DATE_STRATEGIES))
+        raise PrivacyProfileError(
+            f"Privacy profile '{name}' date_strategy must be one of: {allowed}",
+            status_code=500,
+        )
+
+    if settings["text_identifier_strategy"] not in TEXT_IDENTIFIER_STRATEGIES:
+        allowed = ", ".join(sorted(TEXT_IDENTIFIER_STRATEGIES))
+        raise PrivacyProfileError(
+            (
+                f"Privacy profile '{name}' text_identifier_strategy must be "
+                f"one of: {allowed}"
+            ),
+            status_code=500,
+        )
+
+    threshold = settings["ocr_confidence_threshold"]
+    if not isinstance(threshold, (int, float)) or not 0 <= float(threshold) <= 1:
+        raise PrivacyProfileError(
+            (
+                f"Privacy profile '{name}' ocr_confidence_threshold must be "
+                "between 0 and 1."
+            ),
+            status_code=500,
+        )
+

--- a/python_backend/services/text_anonymization.py
+++ b/python_backend/services/text_anonymization.py
@@ -1,9 +1,16 @@
 import hashlib
 import os
 import re
+from datetime import datetime, timedelta
 from functools import lru_cache
 from pathlib import Path
 from typing import Any, Dict, Iterable, Iterator, List, Tuple
+
+from services.privacy_profiles import (
+    PrivacyProfileError,
+    get_privacy_profile,
+    validate_privacy_profile,
+)
 
 SUPPORTED_PROFILES = {"strict", "research"}
 STUDY_SALT_ENV_VAR = "BIOBLOCK_STUDY_SALT"
@@ -18,6 +25,16 @@ _ID_ENTITY_TYPES = {
     "DEVICE_ID",
 }
 _IDENTIFIER_AT_END = re.compile(r"([A-Z0-9][A-Z0-9-]{3,30})\b", re.IGNORECASE)
+DIRECT_IDENTIFIER_REDACTIONS = {
+    "PERSON": "<REDACTED_NAME>",
+    "MEDICAL_RECORD_NUMBER": "<REDACTED_MRN>",
+    "PATIENT_ID": "<REDACTED_PATIENT_ID>",
+    "HEALTH_PLAN_ID": "<REDACTED_HEALTH_PLAN>",
+    "INSURANCE_ID": "<REDACTED_HEALTH_PLAN>",
+    "ACCESSION_NUMBER": "<REDACTED_ACCESSION>",
+    "DEVICE_ID": "<REDACTED_DEVICE_ID>",
+}
+
 
 
 class TextAnonymizationError(ValueError):
@@ -242,6 +259,18 @@ def _common_phi_recognizers() -> List[Any]:
 
     return [
         PatternRecognizer(
+            supported_entity="PERSON",
+            name="Patient Context Name Recognizer",
+            patterns=[
+                _pattern(
+                    "patient_context_name",
+                    r"(?<=\bPatient\s)(?-i:[A-Z][a-z]+(?:\s+[A-Z][a-z]+){1,3})\b",
+                    0.75,
+                )
+            ],
+            context=["patient", "name"],
+        ),
+        PatternRecognizer(
             supported_entity="EMAIL_ADDRESS",
             name="Email Address Recognizer",
             patterns=[
@@ -316,13 +345,16 @@ def _get_analyzer():
         ) from exc
 
 
+def _profile_settings(profile: str) -> tuple[str, Dict[str, Any]]:
+    try:
+        normalized = validate_privacy_profile(profile)
+        return normalized, get_privacy_profile(normalized)
+    except PrivacyProfileError as exc:
+        raise TextAnonymizationError(exc.detail, status_code=exc.status_code) from exc
+
+
 def _normalize_profile(profile: str) -> str:
-    normalized = (profile or "").strip().lower()
-    if normalized not in SUPPORTED_PROFILES:
-        raise TextAnonymizationError(
-            "Invalid privacy profile. Supported profiles: strict, research"
-        )
-    return normalized
+    return _profile_settings(profile)[0]
 
 
 def _select_non_overlapping(results: Iterable[Any]) -> List[Any]:
@@ -359,7 +391,41 @@ def _hash_value(entity_type: str, value: str) -> str:
     return value
 
 
-def _replacement_for(entity_type: str, value: str, salt: str) -> str:
+def _date_shift_days(salt: str) -> int:
+    value = int(stable_hash("date-shift", salt, length=6), 16)
+    days = value % 731 - 365
+    return days or 17
+
+
+def _shift_date_text(value: str, salt: str) -> str:
+    cleaned = value.strip()
+    formats = [
+        ("%Y-%m-%d", "%Y-%m-%d"),
+        ("%m/%d/%Y", "%m/%d/%Y"),
+        ("%m/%d/%y", "%m/%d/%Y"),
+    ]
+    for input_format, output_format in formats:
+        try:
+            shifted = datetime.strptime(cleaned, input_format) + timedelta(
+                days=_date_shift_days(salt)
+            )
+            return shifted.strftime(output_format)
+        except ValueError:
+            continue
+    return "<REDACTED_DATE>"
+
+def _replacement_for(
+    entity_type: str,
+    value: str,
+    salt: str,
+    settings: Dict[str, Any],
+) -> str:
+    if (
+        entity_type in DIRECT_IDENTIFIER_REDACTIONS
+        and settings["text_identifier_strategy"] == "redact"
+    ):
+        return DIRECT_IDENTIFIER_REDACTIONS[entity_type]
+
     hash_value = _hash_value(entity_type, value)
     if entity_type == "PERSON":
         return pseudonymize_person(hash_value, salt)
@@ -380,11 +446,18 @@ def _replacement_for(entity_type: str, value: str, salt: str) -> str:
     if entity_type in {"US_SSN", "SSN"}:
         return "<REDACTED_SSN>"
     if entity_type == "DATE_TIME":
+        if settings["date_strategy"] == "shift":
+            return _shift_date_text(value, salt)
         return "<REDACTED_DATE>"
     return f"<REDACTED_{entity_type}>"
 
 
-def _replace_entities(text: str, results: List[Any], salt: str) -> str:
+def _replace_entities(
+    text: str,
+    results: List[Any],
+    salt: str,
+    settings: Dict[str, Any],
+) -> str:
     anonymized_parts = []
     cursor = 0
 
@@ -392,7 +465,7 @@ def _replace_entities(text: str, results: List[Any], salt: str) -> str:
         anonymized_parts.append(text[cursor : result.start])
         original_value = text[result.start : result.end]
         anonymized_parts.append(
-            _replacement_for(result.entity_type, original_value, salt)
+            _replacement_for(result.entity_type, original_value, salt, settings)
         )
         cursor = result.end
 
@@ -448,7 +521,7 @@ def anonymize_clinical_text(
     if not text.strip():
         raise TextAnonymizationError("Text input is empty")
 
-    _normalize_profile(profile)
+    privacy_profile, settings = _profile_settings(profile)
     salt = _resolve_study_salt(study_salt)
 
     analyzer = _get_analyzer()
@@ -479,6 +552,13 @@ def anonymize_clinical_text(
     selected_results = _select_non_overlapping(results)
     return {
         "anonymization_status": "completed",
-        "anonymized_text": _replace_entities(text, selected_results, salt),
+        "privacy_profile": privacy_profile,
+        "date_strategy": settings["date_strategy"],
+        "text_identifier_strategy": settings["text_identifier_strategy"],
+        "anonymized_text": _replace_entities(text, selected_results, salt, settings),
         "detected_entities": _entity_summary(selected_results),
     }
+
+
+
+

--- a/python_backend/services/wsi_tiling.py
+++ b/python_backend/services/wsi_tiling.py
@@ -1,0 +1,350 @@
+from __future__ import annotations
+
+import os
+import tempfile
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+
+from PIL import Image
+
+from services.ocr_redaction import (
+    OCRBackend,
+    OCRBox,
+    OCREngineUnavailable,
+    get_default_ocr_backend,
+)
+
+
+DEFAULT_TILE_SIZE = 1024
+DEFAULT_BORDER_FRACTION = 0.15
+
+
+@dataclass(frozen=True)
+class TileCoordinate:
+    x: int
+    y: int
+    width: int
+    height: int
+    priority_region: str
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "x": self.x,
+            "y": self.y,
+            "width": self.width,
+            "height": self.height,
+            "priority_region": self.priority_region,
+        }
+
+
+def generate_priority_tiles(
+    width: int,
+    height: int,
+    tile_size: int = DEFAULT_TILE_SIZE,
+    border_fraction: float = DEFAULT_BORDER_FRACTION,
+) -> List[TileCoordinate]:
+    if width <= 0 or height <= 0:
+        raise ValueError("Image dimensions must be positive")
+    if tile_size <= 0:
+        raise ValueError("Tile size must be positive")
+    if border_fraction <= 0:
+        raise ValueError("Border fraction must be positive")
+
+    tiles: List[TileCoordinate] = []
+    seen = set()
+
+    def add_tile(x: int, y: int, region: str):
+        clamped_x = _clamp_start(x, width, tile_size)
+        clamped_y = _clamp_start(y, height, tile_size)
+        tile_width = min(tile_size, width - clamped_x)
+        tile_height = min(tile_size, height - clamped_y)
+        key = (clamped_x, clamped_y, tile_width, tile_height)
+        if key in seen:
+            return
+        seen.add(key)
+        tiles.append(
+            TileCoordinate(
+                x=clamped_x,
+                y=clamped_y,
+                width=tile_width,
+                height=tile_height,
+                priority_region=region,
+            )
+        )
+
+    right_x = max(0, width - tile_size)
+    bottom_y = max(0, height - tile_size)
+
+    add_tile(0, 0, "corner_top_left")
+    add_tile(right_x, 0, "corner_top_right")
+    add_tile(0, bottom_y, "corner_bottom_left")
+    add_tile(right_x, bottom_y, "corner_bottom_right")
+
+    border_depth_x = max(1, int(round(width * border_fraction)))
+    border_depth_y = max(1, int(round(height * border_fraction)))
+    x_positions = _axis_tile_positions(width, tile_size)
+    y_positions = _axis_tile_positions(height, tile_size)
+
+    for y in _leading_border_positions(height, tile_size, border_depth_y):
+        for x in x_positions:
+            add_tile(x, y, "top_border")
+
+    for y in _trailing_border_positions(height, tile_size, border_depth_y):
+        for x in x_positions:
+            add_tile(x, y, "bottom_border")
+
+    for x in _leading_border_positions(width, tile_size, border_depth_x):
+        for y in y_positions:
+            add_tile(x, y, "left_border")
+
+    for x in _trailing_border_positions(width, tile_size, border_depth_x):
+        for y in y_positions:
+            add_tile(x, y, "right_border")
+
+    return tiles
+
+
+def map_tile_boxes_to_slide(
+    tile: TileCoordinate,
+    boxes: Iterable[OCRBox],
+) -> List[OCRBox]:
+    return [
+        OCRBox(
+            text=box.text,
+            confidence=box.confidence,
+            x=tile.x + box.x,
+            y=tile.y + box.y,
+            width=box.width,
+            height=box.height,
+        )
+        for box in boxes
+    ]
+
+
+def scan_wsi_slide(
+    slide: Any,
+    ocr_backend: Optional[OCRBackend] = None,
+    tile_size: int = DEFAULT_TILE_SIZE,
+    border_fraction: float = DEFAULT_BORDER_FRACTION,
+) -> Dict[str, Any]:
+    width, height = _slide_dimensions(slide)
+    tiles = generate_priority_tiles(
+        width=width,
+        height=height,
+        tile_size=tile_size,
+        border_fraction=border_fraction,
+    )
+
+    backend = ocr_backend or get_default_ocr_backend()
+    engine_status = _backend_status(backend)
+    if engine_status == "unavailable":
+        return _wsi_result(
+            pixel_redaction_status="skipped_ocr_unavailable",
+            ocr_engine_status=engine_status,
+            image_dimensions={"width": width, "height": height},
+            tile_size=tile_size,
+        )
+
+    boxes_detected = 0
+    tiles_scanned = 0
+    priority_regions: List[str] = []
+
+    try:
+        for tile in tiles:
+            tile_image = slide.read_region(
+                (tile.x, tile.y),
+                0,
+                (tile.width, tile.height),
+            )
+            if isinstance(tile_image, Image.Image) and tile_image.mode == "RGBA":
+                tile_image = tile_image.convert("RGB")
+
+            boxes = list(backend.detect_text_boxes(tile_image))
+            boxes_detected += len(map_tile_boxes_to_slide(tile, boxes))
+            tiles_scanned += 1
+            if tile.priority_region not in priority_regions:
+                priority_regions.append(tile.priority_region)
+    except OCREngineUnavailable:
+        return _wsi_result(
+            pixel_redaction_status="skipped_ocr_unavailable",
+            ocr_engine_status="unavailable",
+            image_dimensions={"width": width, "height": height},
+            tile_size=tile_size,
+            tiles_scanned=tiles_scanned,
+            priority_regions_scanned=priority_regions,
+        )
+    except Exception:
+        return _wsi_result(
+            pixel_redaction_status="ocr_failed",
+            ocr_engine_status="error",
+            image_dimensions={"width": width, "height": height},
+            tile_size=tile_size,
+            tiles_scanned=tiles_scanned,
+            priority_regions_scanned=priority_regions,
+        )
+
+    return _wsi_result(
+        pixel_redaction_status="redaction_plan_ready",
+        ocr_boxes_detected=boxes_detected,
+        boxes_redacted=0,
+        redaction_plan_boxes=boxes_detected,
+        ocr_engine_status=engine_status,
+        image_dimensions={"width": width, "height": height},
+        tile_size=tile_size,
+        tiles_scanned=tiles_scanned,
+        priority_regions_scanned=priority_regions,
+    )
+
+
+def scan_wsi_bytes(
+    file_bytes: bytes,
+    filename: str,
+    ocr_backend: Optional[OCRBackend] = None,
+    tile_size: int = DEFAULT_TILE_SIZE,
+    border_fraction: float = DEFAULT_BORDER_FRACTION,
+) -> Dict[str, Any]:
+    openslide_module = _load_openslide_module()
+    if openslide_module is None:
+        return _wsi_result(
+            pixel_redaction_status="redaction_plan_unavailable",
+            ocr_engine_status=_backend_status(ocr_backend or get_default_ocr_backend()),
+            tile_size=tile_size,
+        )
+
+    suffix = _safe_suffix(filename)
+    temp_path = None
+    try:
+        temp_file = tempfile.NamedTemporaryFile(
+            suffix=suffix,
+            prefix="bioblock_wsi_",
+            delete=False,
+        )
+        temp_path = temp_file.name
+        with temp_file:
+            temp_file.write(file_bytes)
+
+        slide = openslide_module.OpenSlide(temp_path)
+    except Exception:
+        if temp_path and os.path.exists(temp_path):
+            os.unlink(temp_path)
+        return _wsi_result(
+            pixel_redaction_status="unsupported_wsi_format",
+            ocr_engine_status=_backend_status(ocr_backend or get_default_ocr_backend()),
+            tile_size=tile_size,
+        )
+
+    try:
+        return scan_wsi_slide(
+            slide=slide,
+            ocr_backend=ocr_backend,
+            tile_size=tile_size,
+            border_fraction=border_fraction,
+        )
+    finally:
+        try:
+            slide.close()
+        finally:
+            if temp_path and os.path.exists(temp_path):
+                os.unlink(temp_path)
+
+
+def _axis_tile_positions(length: int, tile_size: int) -> List[int]:
+    if length <= tile_size:
+        return [0]
+
+    positions = list(range(0, length, tile_size))
+    final_start = max(0, length - tile_size)
+    if positions[-1] != final_start:
+        positions.append(final_start)
+    return positions
+
+
+def _leading_border_positions(length: int, tile_size: int, depth: int) -> List[int]:
+    positions = []
+    current = 0
+    limit = min(depth, length)
+    while current < limit:
+        positions.append(_clamp_start(current, length, tile_size))
+        current += tile_size
+    return _dedupe_preserve_order(positions)
+
+
+def _trailing_border_positions(length: int, tile_size: int, depth: int) -> List[int]:
+    positions = []
+    current = _clamp_start(length - tile_size, length, tile_size)
+    limit = max(0, length - depth)
+    while current + min(tile_size, length - current) > limit:
+        positions.append(_clamp_start(current, length, tile_size))
+        current -= tile_size
+        if current < 0:
+            break
+    return _dedupe_preserve_order(positions)
+
+
+def _clamp_start(start: int, length: int, tile_size: int) -> int:
+    return max(0, min(int(start), max(0, length - tile_size)))
+
+
+def _dedupe_preserve_order(values: Sequence[int]) -> List[int]:
+    seen = set()
+    result = []
+    for value in values:
+        if value in seen:
+            continue
+        seen.add(value)
+        result.append(value)
+    return result
+
+
+def _slide_dimensions(slide: Any) -> Tuple[int, int]:
+    dimensions = getattr(slide, "dimensions", None)
+    if not dimensions or len(dimensions) != 2:
+        raise ValueError("WSI slide must expose width and height dimensions")
+    return int(dimensions[0]), int(dimensions[1])
+
+
+def _backend_status(backend: OCRBackend) -> str:
+    status = getattr(backend, "ocr_engine_status", "available")
+    if callable(status):
+        status = status()
+    return str(status or "available")
+
+
+def _load_openslide_module():
+    try:
+        import openslide
+    except Exception:
+        return None
+    return openslide
+
+
+def _safe_suffix(filename: str) -> str:
+    _, extension = os.path.splitext(filename or "")
+    if not extension:
+        return ".svs"
+    return extension.lower()
+
+
+def _wsi_result(
+    pixel_redaction_status: str,
+    ocr_boxes_detected: int = 0,
+    boxes_redacted: int = 0,
+    redaction_plan_boxes: int = 0,
+    tiles_scanned: int = 0,
+    priority_regions_scanned: Optional[List[str]] = None,
+    image_dimensions: Optional[Dict[str, int]] = None,
+    tile_size: int = DEFAULT_TILE_SIZE,
+    ocr_engine_status: str = "not_applicable",
+) -> Dict[str, Any]:
+    return {
+        "pixel_redaction_status": pixel_redaction_status,
+        "ocr_boxes_detected": ocr_boxes_detected,
+        "boxes_redacted": boxes_redacted,
+        "redaction_plan_boxes": redaction_plan_boxes,
+        "tiles_scanned": tiles_scanned,
+        "priority_regions_scanned": priority_regions_scanned or [],
+        "image_dimensions": image_dimensions,
+        "tile_size": tile_size,
+        "ocr_engine_status": ocr_engine_status,
+        "wsi_rewrite_status": "not_supported_yet",
+    }

--- a/python_backend/tests/test_api.py
+++ b/python_backend/tests/test_api.py
@@ -2,6 +2,7 @@ import unittest
 from fastapi.testclient import TestClient
 import sys
 import os
+from io import BytesIO
 
 # Add parent directory to path to import main
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -176,7 +177,7 @@ class TestAPI(unittest.TestCase):
         self.assertEqual(resp.status_code, 400)
 
     def test_anonymize_dicom_with_phi(self):
-        """Test DICOM anonymization strips PHI metadata tags"""
+        """Test DICOM anonymization replaces PHI metadata tags with safe placeholders"""
         try:
             import pydicom
             from pydicom.dataset import Dataset, FileDataset
@@ -205,14 +206,19 @@ class TestAPI(unittest.TestCase):
             os.unlink(tmp.name)
 
             self.assertEqual(resp.status_code, 200)
-            result = resp.json()
-            self.assertIn("fields_stripped", result)
-            self.assertGreater(result["fields_stripped"], 0)
-            # Verify known PHI fields were stripped
-            stripped_names = [s["field"] for s in result["stripped_details"]]
-            self.assertIn("PatientName", stripped_names)
-            self.assertIn("PatientID", stripped_names)
-            self.assertIn("PatientBirthDate", stripped_names)
+            self.assertTrue(resp.headers["content-type"].startswith("application/dicom"))
+            self.assertIn("anonymized_test.dcm", resp.headers["content-disposition"])
+            self.assertGreater(int(resp.headers["x-bioblock-fields-scrubbed"]), 0)
+
+            downloaded = pydicom.dcmread(BytesIO(resp.content), force=False)
+            self.assertEqual(str(downloaded.PatientName), "")
+            self.assertEqual(str(downloaded.PatientID), "")
+            self.assertEqual(str(downloaded.PatientBirthDate), "19000101")
+            self.assertEqual(str(downloaded.ReferringPhysicianName), "")
+            self.assertEqual(str(downloaded.InstitutionName), "")
+            self.assertEqual(str(downloaded.PatientIdentityRemoved), "YES")
+            self.assertNotIn(b"John Smith", resp.content)
+            self.assertNotIn(b"PAT12345", resp.content)
         except ImportError:
             self.skipTest("pydicom not installed, skipping DICOM test")
 
@@ -241,10 +247,15 @@ class TestAPI(unittest.TestCase):
             os.unlink(tmp.name)
 
             self.assertEqual(resp.status_code, 200)
-            result = resp.json()
-            self.assertEqual(result["fields_stripped"], 0)
+            self.assertTrue(resp.headers["content-type"].startswith("application/dicom"))
+            self.assertIn("anonymized_clean.dcm", resp.headers["content-disposition"])
+            self.assertEqual(int(resp.headers["x-bioblock-fields-scrubbed"]), 0)
+
+            downloaded = pydicom.dcmread(BytesIO(resp.content), force=False)
+            self.assertEqual(downloaded.Modality, "CT")
         except ImportError:
             self.skipTest("pydicom not installed, skipping DICOM test")
 
 if __name__ == "__main__":
     unittest.main()
+

--- a/python_backend/tests/test_dicom_anonymization.py
+++ b/python_backend/tests/test_dicom_anonymization.py
@@ -115,10 +115,23 @@ def test_dicom_pixel_data_is_not_modified():
 
     assert result["metadata_summary"]["pixel_data_present"] is True
     assert result["metadata_summary"]["pixel_data_preserved"] is True
-    assert result["pixel_redaction_status"] == "not_started_week4"
+    assert result["pixel_redaction_status"] == "metadata_only"
 
 
-def test_dicom_api_returns_completed_without_raw_phi():
+def test_dicom_api_returns_completed_without_raw_phi(monkeypatch):
+    monkeypatch.setattr(
+        "services.ingestion.redact_dicom_pixels",
+        lambda file_content, profile="strict": {
+            "pixel_redaction_status": "completed",
+            "ocr_boxes_detected": 1,
+            "boxes_redacted": 1,
+            "frames_processed": 1,
+            "scanned_regions": 1,
+            "ocr_engine_status": "available",
+            "sanitized_dicom_bytes": b"internal-only",
+        },
+    )
+
     response = client.post(
         "/api/v1/ingest",
         files={
@@ -136,7 +149,12 @@ def test_dicom_api_returns_completed_without_raw_phi():
     assert body["detected_modality"] == "dicom"
     assert body["handler"] == "anonymize_dicom"
     assert body["anonymization_status"] == "completed"
-    assert body["pixel_redaction_status"] == "not_started_week4"
+    assert body["pixel_redaction_status"] == "completed"
+    assert body["ocr_boxes_detected"] == 1
+    assert body["boxes_redacted"] == 1
+    assert body["ocr_engine_status"] == "available"
     assert TOP_LEVEL_NAME not in response_text
     assert PATIENT_ID not in response_text
+    assert "BURNED_IN_LABEL" not in response_text
+    assert "sanitized_dicom_bytes" not in body
     assert "file_bytes" not in body

--- a/python_backend/tests/test_dicom_anonymization.py
+++ b/python_backend/tests/test_dicom_anonymization.py
@@ -3,6 +3,7 @@ import os
 import sys
 from io import BytesIO
 
+import pydicom
 import pytest
 from fastapi.testclient import TestClient
 from pydicom.dataset import Dataset, FileDataset, FileMetaDataset
@@ -14,6 +15,7 @@ os.environ.setdefault("BIOBLOCK_STUDY_SALT", "week3-test-salt")
 
 from main import app  # noqa: E402
 from services.dicom_anonymization import (  # noqa: E402
+    anonymize_dicom_file_bytes,
     DicomAnonymizationError,
     anonymize_dicom_metadata,
 )
@@ -118,10 +120,29 @@ def test_dicom_pixel_data_is_not_modified():
     assert result["pixel_redaction_status"] == "metadata_only"
 
 
+def test_dicom_file_bytes_are_metadata_scrubbed_and_readable():
+    result = anonymize_dicom_file_bytes(build_dicom_bytes())
+    safe_result = {
+        key: value
+        for key, value in result.items()
+        if key != "anonymized_dicom_bytes"
+    }
+    dataset = pydicom.dcmread(BytesIO(result["anonymized_dicom_bytes"]))
+
+    assert dataset.PatientName == ""
+    assert dataset.PatientID == ""
+    assert dataset.PixelData == PIXEL_BYTES
+    assert TOP_LEVEL_NAME not in json.dumps(safe_result)
+    assert PATIENT_ID not in json.dumps(safe_result)
+    assert result["metadata_summary"]["pixel_data_preserved"] is True
+
 def test_dicom_api_returns_completed_without_raw_phi(monkeypatch):
-    monkeypatch.setattr(
-        "services.ingestion.redact_dicom_pixels",
-        lambda file_content, profile="strict": {
+    def fake_pixel_redaction(file_content, profile="strict"):
+        dataset = pydicom.dcmread(BytesIO(file_content))
+        assert dataset.PatientName == ""
+        assert dataset.PatientID == ""
+        assert dataset.PixelData == PIXEL_BYTES
+        return {
             "pixel_redaction_status": "completed",
             "ocr_boxes_detected": 1,
             "boxes_redacted": 1,
@@ -129,7 +150,11 @@ def test_dicom_api_returns_completed_without_raw_phi(monkeypatch):
             "scanned_regions": 1,
             "ocr_engine_status": "available",
             "sanitized_dicom_bytes": b"internal-only",
-        },
+        }
+
+    monkeypatch.setattr(
+        "services.ingestion.redact_dicom_pixels",
+        fake_pixel_redaction,
     )
 
     response = client.post(

--- a/python_backend/tests/test_dicom_anonymization.py
+++ b/python_backend/tests/test_dicom_anonymization.py
@@ -1,0 +1,142 @@
+import json
+import os
+import sys
+from io import BytesIO
+
+import pytest
+from fastapi.testclient import TestClient
+from pydicom.dataset import Dataset, FileDataset, FileMetaDataset
+from pydicom.sequence import Sequence
+from pydicom.uid import ExplicitVRLittleEndian, SecondaryCaptureImageStorage
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+os.environ.setdefault("BIOBLOCK_STUDY_SALT", "week3-test-salt")
+
+from main import app  # noqa: E402
+from services.dicom_anonymization import (  # noqa: E402
+    DicomAnonymizationError,
+    anonymize_dicom_metadata,
+)
+
+
+client = TestClient(app)
+
+TOP_LEVEL_NAME = "SYNTHETIC^PERSON"
+NESTED_NAME = "NESTED^SYNTH"
+PATIENT_ID = "SYN-PAT-001"
+PRIVATE_VALUE = "SYN_PRIV"
+PIXEL_BYTES = b"\x01\x02\x03\x04"
+
+
+def build_dicom_bytes() -> bytes:
+    file_meta = FileMetaDataset()
+    file_meta.TransferSyntaxUID = ExplicitVRLittleEndian
+    file_meta.MediaStorageSOPClassUID = SecondaryCaptureImageStorage
+    file_meta.MediaStorageSOPInstanceUID = "1.2.826.0.1.3680043.8.498.1"
+    file_meta.ImplementationClassUID = "1.2.826.0.1.3680043.8.498.2"
+
+    dataset = FileDataset(
+        None,
+        {},
+        file_meta=file_meta,
+        preamble=b"\0" * 128,
+    )
+    dataset.SOPClassUID = SecondaryCaptureImageStorage
+    dataset.SOPInstanceUID = file_meta.MediaStorageSOPInstanceUID
+    dataset.PatientName = TOP_LEVEL_NAME
+    dataset.PatientID = PATIENT_ID
+    dataset.PatientBirthDate = "19600101"
+    dataset.AccessionNumber = "SYN-ACC-01"
+    dataset.StudyDate = "20240101"
+    dataset.InstitutionName = "SYN_INST"
+
+    nested_item = Dataset()
+    nested_item.PatientName = NESTED_NAME
+    nested_item.PatientID = "NEST-ID-01"
+    dataset.ReferencedPatientSequence = Sequence([nested_item])
+
+    dataset.add_new((0x0043, 0x0010), "LO", "SYN_CREATOR")
+    dataset.add_new((0x0043, 0x1010), "LO", PRIVATE_VALUE)
+
+    dataset.Rows = 2
+    dataset.Columns = 2
+    dataset.SamplesPerPixel = 1
+    dataset.PhotometricInterpretation = "MONOCHROME2"
+    dataset.BitsAllocated = 8
+    dataset.BitsStored = 8
+    dataset.HighBit = 7
+    dataset.PixelRepresentation = 0
+    dataset.PixelData = PIXEL_BYTES
+
+    buffer = BytesIO()
+    dataset.save_as(buffer, enforce_file_format=True)
+    return buffer.getvalue()
+
+
+def test_dicom_phi_scrubbing_returns_safe_summary_only():
+    result = anonymize_dicom_metadata(build_dicom_bytes())
+    response_text = json.dumps(result)
+    summary = result["metadata_summary"]
+
+    assert result["anonymization_status"] == "completed"
+    assert summary["fields_scrubbed"] >= 6
+    assert summary["scrubbed_field_counts"]["PatientName"] == 2
+    assert summary["scrubbed_field_counts"]["PatientID"] == 2
+    assert TOP_LEVEL_NAME not in response_text
+    assert PATIENT_ID not in response_text
+    assert "SYN_INST" not in response_text
+
+
+def test_dicom_nested_sequence_scrubbing_is_counted():
+    result = anonymize_dicom_metadata(build_dicom_bytes())
+
+    assert result["metadata_summary"]["scrubbed_field_counts"]["PatientName"] == 2
+    assert result["metadata_summary"]["scrubbed_field_counts"]["PatientID"] == 2
+
+
+def test_dicom_private_tags_removed_in_strict_mode():
+    result = anonymize_dicom_metadata(build_dicom_bytes(), profile="strict")
+    response_text = json.dumps(result)
+
+    assert result["metadata_summary"]["private_tags_removed"] == 2
+    assert PRIVATE_VALUE not in response_text
+
+
+def test_invalid_dicom_is_rejected():
+    with pytest.raises(DicomAnonymizationError) as exc:
+        anonymize_dicom_metadata(b"not a dicom file")
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "Invalid DICOM file format"
+
+
+def test_dicom_pixel_data_is_not_modified():
+    result = anonymize_dicom_metadata(build_dicom_bytes())
+
+    assert result["metadata_summary"]["pixel_data_present"] is True
+    assert result["metadata_summary"]["pixel_data_preserved"] is True
+    assert result["pixel_redaction_status"] == "not_started_week4"
+
+
+def test_dicom_api_returns_completed_without_raw_phi():
+    response = client.post(
+        "/api/v1/ingest",
+        files={
+            "file": (
+                "scan.dcm",
+                BytesIO(build_dicom_bytes()),
+                "application/dicom",
+            )
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    response_text = json.dumps(body)
+    assert body["detected_modality"] == "dicom"
+    assert body["handler"] == "anonymize_dicom"
+    assert body["anonymization_status"] == "completed"
+    assert body["pixel_redaction_status"] == "not_started_week4"
+    assert TOP_LEVEL_NAME not in response_text
+    assert PATIENT_ID not in response_text
+    assert "file_bytes" not in body

--- a/python_backend/tests/test_dicom_anonymization.py
+++ b/python_backend/tests/test_dicom_anonymization.py
@@ -18,6 +18,7 @@ from services.dicom_anonymization import (  # noqa: E402
     anonymize_dicom_file_bytes,
     DicomAnonymizationError,
     anonymize_dicom_metadata,
+    anonymize_dicom_file_bytes,
 )
 
 
@@ -48,6 +49,8 @@ def build_dicom_bytes() -> bytes:
     dataset.PatientName = TOP_LEVEL_NAME
     dataset.PatientID = PATIENT_ID
     dataset.PatientBirthDate = "19600101"
+    dataset.PatientAge = "045Y"
+    dataset.PatientSex = "F"
     dataset.AccessionNumber = "SYN-ACC-01"
     dataset.StudyDate = "20240101"
     dataset.InstitutionName = "SYN_INST"
@@ -183,3 +186,72 @@ def test_dicom_api_returns_completed_without_raw_phi(monkeypatch):
     assert "BURNED_IN_LABEL" not in response_text
     assert "sanitized_dicom_bytes" not in body
     assert "file_bytes" not in body
+
+def test_dicom_download_endpoint_returns_readable_anonymized_file(monkeypatch):
+    monkeypatch.setattr(
+        "main.audit_logger.log_operation",
+        lambda *args, **kwargs: None,
+    )
+
+    response = client.post(
+        "/anonymize_dicom",
+        files={
+            "file": (
+                "scan.dcm",
+                BytesIO(build_dicom_bytes()),
+                "application/dicom",
+            )
+        },
+        data={"profile": "strict"},
+    )
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("application/dicom")
+    assert "anonymized_scan.dcm" in response.headers["content-disposition"]
+    assert response.headers["x-bioblock-anonymization-status"] == "completed"
+    assert int(response.headers["x-bioblock-fields-scrubbed"]) >= 6
+    assert int(response.headers["x-bioblock-private-tags-removed"]) == 2
+
+    import pydicom
+
+    downloaded = pydicom.dcmread(BytesIO(response.content), force=False)
+    assert str(downloaded.PatientName) == ""
+    assert str(downloaded.PatientID) == ""
+    assert str(downloaded.PatientBirthDate) == "19000101"
+    assert str(downloaded.ReferencedPatientSequence[0].PatientName) == ""
+    assert str(downloaded.ReferencedPatientSequence[0].PatientID) == ""
+    assert str(downloaded.PatientIdentityRemoved) == "YES"
+    assert (0x0043, 0x1010) not in downloaded
+    assert bytes(downloaded.PixelData) == PIXEL_BYTES
+    assert TOP_LEVEL_NAME.encode("utf-8") not in response.content
+    assert PATIENT_ID.encode("utf-8") not in response.content
+
+
+
+def test_dicom_research_shifts_dates_generalizes_demographics_and_removes_private_tags():
+    result = anonymize_dicom_file_bytes(build_dicom_bytes(), profile="research")
+    summary = result["metadata_summary"]
+
+    assert summary["profile"] == "research"
+    assert summary["date_strategy"] == "shift"
+    assert summary["dates_shifted"] >= 2
+    assert summary["generalized_demographics"] == 2
+    assert summary["private_tags_removed"] == 2
+    assert summary["preserve_dicom_technical_metadata"] is True
+    assert "Rows" in summary["technical_metadata_preserved"]
+    assert "Columns" in summary["technical_metadata_preserved"]
+
+    import pydicom
+
+    downloaded = pydicom.dcmread(BytesIO(result["anonymized_dicom_bytes"]), force=False)
+    assert str(downloaded.PatientName) == ""
+    assert str(downloaded.PatientID) == ""
+    assert str(downloaded.PatientBirthDate) not in {"19600101", "19000101"}
+    assert str(downloaded.StudyDate) not in {"20240101", "19000101"}
+    assert str(downloaded.PatientAge) == "040Y"
+    assert str(downloaded.PatientSex) == "F"
+    assert (0x0043, 0x1010) not in downloaded
+
+
+
+

--- a/python_backend/tests/test_ingestion.py
+++ b/python_backend/tests/test_ingestion.py
@@ -1,9 +1,11 @@
 import asyncio
+import json
 import os
 import sys
 import tempfile
 import unittest
 from io import BytesIO
+from unittest.mock import patch
 
 import nibabel as nib
 import numpy as np
@@ -19,6 +21,36 @@ from main import app, ingest_file  # noqa: E402
 from services.ingestion import TEXT_READ_LIMIT_BYTES  # noqa: E402
 
 client = TestClient(app)
+
+
+def fake_dicom_pixel_redaction(file_content, profile="strict"):
+    return {
+        "pixel_redaction_status": "completed",
+        "ocr_boxes_detected": 1,
+        "boxes_redacted": 1,
+        "frames_processed": 1,
+        "scanned_regions": 1,
+        "ocr_engine_status": "available",
+        "sanitized_dicom_bytes": b"internal-only",
+    }
+
+
+def fake_wsi_scan(file_content, filename):
+    return {
+        "pixel_redaction_status": "redaction_plan_ready",
+        "ocr_boxes_detected": 2,
+        "boxes_redacted": 0,
+        "redaction_plan_boxes": 2,
+        "tiles_scanned": 4,
+        "priority_regions_scanned": [
+            "corner_top_left",
+            "corner_top_right",
+        ],
+        "image_dimensions": {"width": 2048, "height": 2048},
+        "tile_size": 1024,
+        "ocr_engine_status": "available",
+        "wsi_rewrite_status": "not_supported_yet",
+    }
 
 
 class FakeUploadFile:
@@ -183,16 +215,23 @@ class TestIngestionRouting(unittest.TestCase):
         self.assertIn("PATIENT_ID_", body["anonymized_text"])
 
     def test_dicom_extension_routes_to_dicom_handler(self):
-        response = upload_file("scan.dcm", build_dicom_bytes())
+        with patch("services.ingestion.redact_dicom_pixels", fake_dicom_pixel_redaction):
+            response = upload_file("scan.dcm", build_dicom_bytes())
         self.assert_completed_metadata_route(response, "dicom", "anonymize_dicom")
+        body = response.json()
+        self.assertEqual(body["pixel_redaction_status"], "completed")
+        self.assertEqual(body["ocr_boxes_detected"], 1)
+        self.assertNotIn("sanitized_dicom_bytes", body)
 
     def test_dicom_octet_stream_routes_by_extension(self):
-        response = upload_file(
-            "scan.dcm",
-            build_dicom_bytes(),
-            "application/octet-stream",
-        )
+        with patch("services.ingestion.redact_dicom_pixels", fake_dicom_pixel_redaction):
+            response = upload_file(
+                "scan.dcm",
+                build_dicom_bytes(),
+                "application/octet-stream",
+            )
         self.assert_completed_metadata_route(response, "dicom", "anonymize_dicom")
+        self.assertEqual(response.json()["pixel_redaction_status"], "completed")
 
     def test_nifti_nii_routes_to_nifti_handler(self):
         response = upload_file("brain.nii", build_nifti_bytes(".nii"))
@@ -203,8 +242,21 @@ class TestIngestionRouting(unittest.TestCase):
         self.assert_completed_metadata_route(response, "nifti", "anonymize_nifti")
 
     def test_wsi_routes_to_wsi_handler(self):
-        response = upload_file("slide.svs", b"wsi routing scaffold")
-        self.assert_routes_to(response, "wsi", "anonymize_wsi")
+        with patch("services.ingestion.scan_wsi_bytes", fake_wsi_scan):
+            response = upload_file("slide.svs", b"wsi routing scaffold")
+
+        self.assertEqual(response.status_code, 200)
+        body = response.json()
+        self.assertEqual(body["status"], "success")
+        self.assertEqual(body["detected_modality"], "wsi")
+        self.assertEqual(body["handler"], "anonymize_wsi")
+        self.assertEqual(body["routing_status"], "handler_selected")
+        self.assertEqual(body["anonymization_status"], "redaction_plan_ready")
+        self.assertEqual(body["pixel_redaction_status"], "redaction_plan_ready")
+        self.assertEqual(body["tiles_scanned"], 4)
+        self.assertEqual(body["boxes_redacted"], 0)
+        self.assertEqual(body["wsi_rewrite_status"], "not_supported_yet")
+        self.assertNotIn("ocr_text", json.dumps(body).lower())
 
     def test_unsupported_file_type_is_rejected(self):
         response = upload_file("archive.zip", b"zip scaffold")
@@ -241,12 +293,17 @@ class TestIngestionRouting(unittest.TestCase):
         self.assertIn("Text uploads must be", response.json()["detail"])
 
     def test_dicom_preamble_detection_routes_to_dicom_handler(self):
-        response = upload_file(
-            "scan.bin",
-            build_dicom_bytes(),
-            "application/octet-stream",
-        )
+        with patch("services.ingestion.redact_dicom_pixels", fake_dicom_pixel_redaction):
+            response = upload_file(
+                "scan.bin",
+                build_dicom_bytes(),
+                "application/octet-stream",
+            )
         self.assert_completed_metadata_route(response, "dicom", "anonymize_dicom")
+        self.assertNotEqual(
+            response.json()["pixel_redaction_status"],
+            "not_started_week4",
+        )
 
     def test_endpoint_resets_upload_stream_after_header_read(self):
         fake_file = FakeUploadFile(

--- a/python_backend/tests/test_ingestion.py
+++ b/python_backend/tests/test_ingestion.py
@@ -1,10 +1,16 @@
 import asyncio
 import os
 import sys
+import tempfile
 import unittest
 from io import BytesIO
 
+import nibabel as nib
+import numpy as np
 from fastapi.testclient import TestClient
+from pydicom.dataset import Dataset, FileDataset, FileMetaDataset
+from pydicom.sequence import Sequence
+from pydicom.uid import ExplicitVRLittleEndian, SecondaryCaptureImageStorage
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 os.environ.setdefault("BIOBLOCK_STUDY_SALT", "week2-test-salt")
@@ -51,6 +57,59 @@ def upload_file(
     )
 
 
+def build_dicom_bytes():
+    file_meta = FileMetaDataset()
+    file_meta.TransferSyntaxUID = ExplicitVRLittleEndian
+    file_meta.MediaStorageSOPClassUID = SecondaryCaptureImageStorage
+    file_meta.MediaStorageSOPInstanceUID = "1.2.826.0.1.3680043.8.498.11"
+    file_meta.ImplementationClassUID = "1.2.826.0.1.3680043.8.498.12"
+
+    dataset = FileDataset(
+        None,
+        {},
+        file_meta=file_meta,
+        preamble=b"\0" * 128,
+    )
+    dataset.SOPClassUID = SecondaryCaptureImageStorage
+    dataset.SOPInstanceUID = file_meta.MediaStorageSOPInstanceUID
+    dataset.PatientName = "SYN^ROUTE"
+    dataset.PatientID = "SYN-ROUTE-ID"
+
+    nested_item = Dataset()
+    nested_item.PatientName = "NEST^ROUTE"
+    dataset.ReferencedPatientSequence = Sequence([nested_item])
+
+    dataset.Rows = 2
+    dataset.Columns = 2
+    dataset.SamplesPerPixel = 1
+    dataset.PhotometricInterpretation = "MONOCHROME2"
+    dataset.BitsAllocated = 8
+    dataset.BitsStored = 8
+    dataset.HighBit = 7
+    dataset.PixelRepresentation = 0
+    dataset.PixelData = b"\x01\x02\x03\x04"
+
+    buffer = BytesIO()
+    dataset.save_as(buffer, enforce_file_format=True)
+    return buffer.getvalue()
+
+
+def build_nifti_bytes(suffix=".nii"):
+    data = np.arange(8, dtype=np.int16).reshape((2, 2, 2))
+    image = nib.Nifti1Image(data, np.eye(4))
+    image.header["descrip"] = b"SYNTHETIC_ROUTING_HEADER"
+
+    with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as temp_file:
+        temp_path = temp_file.name
+
+    try:
+        nib.save(image, temp_path)
+        with open(temp_path, "rb") as saved_file:
+            return saved_file.read()
+    finally:
+        os.unlink(temp_path)
+
+
 class TestIngestionRouting(unittest.TestCase):
     def assert_routes_to(self, response, modality, handler):
         self.assertEqual(response.status_code, 200)
@@ -60,6 +119,20 @@ class TestIngestionRouting(unittest.TestCase):
         self.assertEqual(body["handler"], handler)
         self.assertEqual(body["routing_status"], "handler_selected")
         self.assertEqual(body["anonymization_status"], "placeholder")
+        self.assertEqual(body["downstream"]["ipfs_chunking"], "pending")
+        self.assertEqual(body["downstream"]["cid_encryption"], "pending")
+        self.assertEqual(body["downstream"]["metadata_indexing"], "pending")
+        self.assertEqual(body["downstream"]["blockchain_transaction"], "pending")
+
+    def assert_completed_metadata_route(self, response, modality, handler):
+        self.assertEqual(response.status_code, 200)
+        body = response.json()
+        self.assertEqual(body["status"], "success")
+        self.assertEqual(body["detected_modality"], modality)
+        self.assertEqual(body["handler"], handler)
+        self.assertEqual(body["routing_status"], "handler_selected")
+        self.assertEqual(body["anonymization_status"], "completed")
+        self.assertIn("metadata_summary", body)
         self.assertEqual(body["downstream"]["ipfs_chunking"], "pending")
         self.assertEqual(body["downstream"]["cid_encryption"], "pending")
         self.assertEqual(body["downstream"]["metadata_indexing"], "pending")
@@ -110,24 +183,24 @@ class TestIngestionRouting(unittest.TestCase):
         self.assertIn("PATIENT_ID_", body["anonymized_text"])
 
     def test_dicom_extension_routes_to_dicom_handler(self):
-        response = upload_file("scan.dcm", b"not-real-dicom-routing-only")
-        self.assert_routes_to(response, "dicom", "anonymize_dicom")
+        response = upload_file("scan.dcm", build_dicom_bytes())
+        self.assert_completed_metadata_route(response, "dicom", "anonymize_dicom")
 
     def test_dicom_octet_stream_routes_by_extension(self):
         response = upload_file(
             "scan.dcm",
-            b"dicom routing scaffold",
+            build_dicom_bytes(),
             "application/octet-stream",
         )
-        self.assert_routes_to(response, "dicom", "anonymize_dicom")
+        self.assert_completed_metadata_route(response, "dicom", "anonymize_dicom")
 
     def test_nifti_nii_routes_to_nifti_handler(self):
-        response = upload_file("brain.nii", b"nifti routing scaffold")
-        self.assert_routes_to(response, "nifti", "anonymize_nifti")
+        response = upload_file("brain.nii", build_nifti_bytes(".nii"))
+        self.assert_completed_metadata_route(response, "nifti", "anonymize_nifti")
 
     def test_nifti_nii_gz_routes_to_nifti_handler(self):
-        response = upload_file("brain.nii.gz", b"compressed nifti scaffold")
-        self.assert_routes_to(response, "nifti", "anonymize_nifti")
+        response = upload_file("brain.nii.gz", build_nifti_bytes(".nii.gz"))
+        self.assert_completed_metadata_route(response, "nifti", "anonymize_nifti")
 
     def test_wsi_routes_to_wsi_handler(self):
         response = upload_file("slide.svs", b"wsi routing scaffold")
@@ -168,9 +241,12 @@ class TestIngestionRouting(unittest.TestCase):
         self.assertIn("Text uploads must be", response.json()["detail"])
 
     def test_dicom_preamble_detection_routes_to_dicom_handler(self):
-        dicom_header = b"\x00" * 128 + b"DICM" + b"routing scaffold"
-        response = upload_file("scan.bin", dicom_header, "application/octet-stream")
-        self.assert_routes_to(response, "dicom", "anonymize_dicom")
+        response = upload_file(
+            "scan.bin",
+            build_dicom_bytes(),
+            "application/octet-stream",
+        )
+        self.assert_completed_metadata_route(response, "dicom", "anonymize_dicom")
 
     def test_endpoint_resets_upload_stream_after_header_read(self):
         fake_file = FakeUploadFile(

--- a/python_backend/tests/test_ingestion.py
+++ b/python_backend/tests/test_ingestion.py
@@ -190,7 +190,9 @@ class TestIngestionRouting(unittest.TestCase):
         self.assertEqual(body["anonymization_status"], "completed")
         self.assertNotIn("123456", body["anonymized_text"])
         self.assertNotIn("john.doe@example.com", body["anonymized_text"])
-        self.assertIn("MRN_", body["anonymized_text"])
+        self.assertEqual(body["date_strategy"], "redact")
+        self.assertEqual(body["text_identifier_strategy"], "redact")
+        self.assertIn("<REDACTED_MRN>", body["anonymized_text"])
         self.assertIn("<REDACTED_EMAIL>", body["anonymized_text"])
         self.assertIn("diabetes", body["anonymized_text"])
         self.assertEqual(body["detected_entities"]["MEDICAL_RECORD_NUMBER"], 1)
@@ -212,7 +214,7 @@ class TestIngestionRouting(unittest.TestCase):
         self.assertEqual(body["detected_modality"], "text")
         self.assertEqual(body["anonymization_status"], "completed")
         self.assertNotIn("PT-1001", body["anonymized_text"])
-        self.assertIn("PATIENT_ID_", body["anonymized_text"])
+        self.assertIn("<REDACTED_PATIENT_ID>", body["anonymized_text"])
 
     def test_dicom_extension_routes_to_dicom_handler(self):
         with patch("services.ingestion.redact_dicom_pixels", fake_dicom_pixel_redaction):
@@ -322,3 +324,5 @@ class TestIngestionRouting(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+

--- a/python_backend/tests/test_nifti_anonymization.py
+++ b/python_backend/tests/test_nifti_anonymization.py
@@ -107,3 +107,22 @@ def test_nifti_api_returns_completed_for_supported_extensions(filename, suffix):
     assert HEADER_TEXT.decode("ascii") not in response_text
     assert AUX_TEXT.decode("ascii") not in response_text
     assert "file_bytes" not in body
+
+
+def test_nifti_research_profile_removes_extensions_and_preserves_safe_metadata():
+    result = anonymize_nifti_metadata(
+        build_nifti_bytes(".nii"),
+        "scan.nii",
+        profile="research",
+    )
+    summary = result["metadata_summary"]
+
+    assert summary["profile"] == "research"
+    assert summary["remove_nifti_extensions"] is True
+    assert summary["extensions_removed"] == 1
+    assert summary["extensions_preserved"] == 0
+    assert summary["shape_preserved"] is True
+    assert summary["affine_preserved"] is True
+    assert summary["datatype_preserved"] is True
+
+

--- a/python_backend/tests/test_nifti_anonymization.py
+++ b/python_backend/tests/test_nifti_anonymization.py
@@ -1,0 +1,109 @@
+import json
+import os
+import sys
+import tempfile
+from io import BytesIO
+
+import nibabel as nib
+import numpy as np
+import pytest
+from fastapi.testclient import TestClient
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+os.environ.setdefault("BIOBLOCK_STUDY_SALT", "week3-test-salt")
+
+from main import app  # noqa: E402
+from services.nifti_anonymization import (  # noqa: E402
+    NiftiAnonymizationError,
+    anonymize_nifti_metadata,
+)
+
+
+client = TestClient(app)
+
+HEADER_TEXT = b"SYNTHETIC_NIFTI_HEADER_TEXT"
+AUX_TEXT = b"SYNTHETIC_AUX_FILE"
+INTENT_TEXT = b"SYNTHETIC_INTENT_NAME"
+EXTENSION_TEXT = b"SYNTHETIC_EXTENSION_TEXT"
+
+
+def build_nifti_bytes(suffix: str = ".nii") -> bytes:
+    data = np.arange(8, dtype=np.int16).reshape((2, 2, 2))
+    affine = np.eye(4)
+    image = nib.Nifti1Image(data, affine)
+    image.header["descrip"] = HEADER_TEXT
+    image.header["aux_file"] = AUX_TEXT
+    image.header["intent_name"] = INTENT_TEXT
+    image.header.extensions.append(nib.nifti1.Nifti1Extension(6, EXTENSION_TEXT))
+
+    with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as temp_file:
+        temp_path = temp_file.name
+
+    try:
+        nib.save(image, temp_path)
+        with open(temp_path, "rb") as saved_file:
+            return saved_file.read()
+    finally:
+        os.unlink(temp_path)
+
+
+def test_nifti_header_scrubbing_preserves_image_properties():
+    result = anonymize_nifti_metadata(build_nifti_bytes(".nii"), "scan.nii")
+    response_text = json.dumps(result)
+    summary = result["metadata_summary"]
+
+    assert result["anonymization_status"] == "completed"
+    assert summary["fields_scrubbed"] == 3
+    assert summary["scrubbed_field_counts"] == {
+        "descrip": 1,
+        "aux_file": 1,
+        "intent_name": 1,
+    }
+    assert summary["extensions_removed"] == 1
+    assert summary["image_shape"] == [2, 2, 2]
+    assert summary["shape_preserved"] is True
+    assert summary["affine_preserved"] is True
+    assert summary["datatype_preserved"] is True
+    assert summary["image_data_preserved"] is True
+    assert HEADER_TEXT.decode("ascii") not in response_text
+    assert AUX_TEXT.decode("ascii") not in response_text
+    assert EXTENSION_TEXT.decode("ascii") not in response_text
+
+
+def test_invalid_nifti_is_rejected():
+    with pytest.raises(NiftiAnonymizationError) as exc:
+        anonymize_nifti_metadata(b"not nifti", "scan.nii")
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "Invalid NIfTI file format"
+
+
+@pytest.mark.parametrize(
+    ("filename", "suffix"),
+    [
+        ("scan.nii", ".nii"),
+        ("scan.nii.gz", ".nii.gz"),
+    ],
+)
+def test_nifti_api_returns_completed_for_supported_extensions(filename, suffix):
+    response = client.post(
+        "/api/v1/ingest",
+        files={
+            "file": (
+                filename,
+                BytesIO(build_nifti_bytes(suffix)),
+                "application/octet-stream",
+            )
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    response_text = json.dumps(body)
+    assert body["detected_modality"] == "nifti"
+    assert body["handler"] == "anonymize_nifti"
+    assert body["anonymization_status"] == "completed"
+    assert body["metadata_summary"]["fields_scrubbed"] == 3
+    assert HEADER_TEXT.decode("ascii") not in response_text
+    assert AUX_TEXT.decode("ascii") not in response_text
+    assert "file_bytes" not in body

--- a/python_backend/tests/test_ocr_redaction.py
+++ b/python_backend/tests/test_ocr_redaction.py
@@ -1,0 +1,173 @@
+import json
+import os
+import sys
+from io import BytesIO
+
+import numpy as np
+from PIL import Image
+from pydicom.dataset import FileDataset, FileMetaDataset
+from pydicom.uid import ExplicitVRLittleEndian, SecondaryCaptureImageStorage
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from services.ocr_redaction import (  # noqa: E402
+    OCRBox,
+    redact_dicom_pixels,
+    redact_image_regions,
+    redact_image_with_backend,
+    safe_ocr_response,
+)
+
+
+RAW_OCR_TEXT = "PATIENT^BURNED"
+
+
+class FakeOCRBackend:
+    ocr_engine_status = "available"
+
+    def __init__(self, boxes):
+        self.boxes = boxes
+
+    def detect_text_boxes(self, image):
+        return self.boxes
+
+
+def build_grayscale_dicom(pixel_array: np.ndarray) -> bytes:
+    file_meta = FileMetaDataset()
+    file_meta.TransferSyntaxUID = ExplicitVRLittleEndian
+    file_meta.MediaStorageSOPClassUID = SecondaryCaptureImageStorage
+    file_meta.MediaStorageSOPInstanceUID = "1.2.826.0.1.3680043.8.498.41"
+    file_meta.ImplementationClassUID = "1.2.826.0.1.3680043.8.498.42"
+
+    dataset = FileDataset(
+        None,
+        {},
+        file_meta=file_meta,
+        preamble=b"\0" * 128,
+    )
+    dataset.SOPClassUID = SecondaryCaptureImageStorage
+    dataset.SOPInstanceUID = file_meta.MediaStorageSOPInstanceUID
+    dataset.PatientName = RAW_OCR_TEXT
+    dataset.PatientID = "OCR-PAT-001"
+    dataset.Rows = int(pixel_array.shape[0])
+    dataset.Columns = int(pixel_array.shape[1])
+    dataset.SamplesPerPixel = 1
+    dataset.PhotometricInterpretation = "MONOCHROME2"
+    dataset.BitsAllocated = 8
+    dataset.BitsStored = 8
+    dataset.HighBit = 7
+    dataset.PixelRepresentation = 0
+    dataset.PixelData = pixel_array.astype(np.uint8).tobytes()
+
+    buffer = BytesIO()
+    dataset.save_as(buffer, enforce_file_format=True)
+    return buffer.getvalue()
+
+
+def test_fake_ocr_box_gets_redacted():
+    image = Image.fromarray(np.full((6, 6), 255, dtype=np.uint8), mode="L")
+    result = redact_image_with_backend(
+        image,
+        ocr_backend=FakeOCRBackend([OCRBox(RAW_OCR_TEXT, 0.98, 1, 1, 3, 2)]),
+    )
+    pixels = np.asarray(result.image)
+
+    assert result.boxes_detected == 1
+    assert result.boxes_redacted == 1
+    assert pixels[1:3, 1:4].max() == 0
+
+
+def test_no_ocr_boxes_leaves_image_unchanged():
+    image = np.full((5, 5), 127, dtype=np.uint8)
+    result = redact_image_regions(image, [])
+
+    assert result.boxes_detected == 0
+    assert result.boxes_redacted == 0
+    assert np.array_equal(np.asarray(result.image), image)
+
+
+def test_low_confidence_boxes_are_skipped():
+    image = np.full((5, 5), 255, dtype=np.uint8)
+    result = redact_image_regions(
+        image,
+        [OCRBox(RAW_OCR_TEXT, 0.2, 0, 0, 3, 3)],
+        min_confidence=0.5,
+    )
+
+    assert result.boxes_detected == 1
+    assert result.boxes_redacted == 0
+    assert np.asarray(result.image).min() == 255
+
+
+def test_redaction_summary_does_not_contain_raw_ocr_text():
+    result = redact_image_regions(
+        np.full((5, 5), 255, dtype=np.uint8),
+        [OCRBox(RAW_OCR_TEXT, 0.9, 0, 0, 2, 2)],
+    )
+
+    assert RAW_OCR_TEXT not in json.dumps(result.safe_summary())
+
+
+def test_box_clipping_redacts_boundary_intersection():
+    image = np.full((4, 4), 255, dtype=np.uint8)
+    result = redact_image_regions(
+        image,
+        [OCRBox(RAW_OCR_TEXT, 0.99, 2, 2, 10, 10)],
+    )
+    pixels = np.asarray(result.image)
+
+    assert result.boxes_redacted == 1
+    assert pixels[2:, 2:].max() == 0
+    assert pixels[:2, :].min() == 255
+    assert pixels[:, :2].min() == 255
+
+
+def test_dicom_pixel_redaction_changes_only_detected_region():
+    pixels = np.full((8, 8), 20, dtype=np.uint8)
+    pixels[0:2, 0:4] = 250
+    dicom_bytes = build_grayscale_dicom(pixels)
+
+    result = redact_dicom_pixels(
+        dicom_bytes,
+        ocr_backend=FakeOCRBackend([OCRBox(RAW_OCR_TEXT, 0.99, 0, 0, 4, 2)]),
+    )
+    sanitized = result["sanitized_dicom_bytes"]
+
+    import pydicom
+
+    dataset = pydicom.dcmread(BytesIO(sanitized))
+    redacted_pixels = dataset.pixel_array
+
+    assert result["pixel_redaction_status"] == "completed"
+    assert result["ocr_boxes_detected"] == 1
+    assert result["boxes_redacted"] == 1
+    assert redacted_pixels[0:2, 0:4].max() == 0
+    assert np.array_equal(redacted_pixels[2:, :], pixels[2:, :])
+    assert np.array_equal(redacted_pixels[:, 4:], pixels[:, 4:])
+
+
+def test_dicom_pixel_data_remains_valid_after_redaction():
+    pixels = np.full((4, 4), 100, dtype=np.uint8)
+    dicom_bytes = build_grayscale_dicom(pixels)
+
+    result = redact_dicom_pixels(
+        dicom_bytes,
+        ocr_backend=FakeOCRBackend([OCRBox(RAW_OCR_TEXT, 0.99, 1, 1, 2, 2)]),
+    )
+
+    import pydicom
+
+    dataset = pydicom.dcmread(BytesIO(result["sanitized_dicom_bytes"]))
+    assert dataset.PixelData
+    assert dataset.pixel_array.shape == (4, 4)
+
+
+def test_dicom_safe_response_does_not_expose_ocr_text_or_bytes():
+    result = redact_dicom_pixels(
+        build_grayscale_dicom(np.full((4, 4), 100, dtype=np.uint8)),
+        ocr_backend=FakeOCRBackend([OCRBox(RAW_OCR_TEXT, 0.99, 0, 0, 2, 2)]),
+    )
+    safe = safe_ocr_response(result)
+
+    assert "sanitized_dicom_bytes" not in safe
+    assert RAW_OCR_TEXT not in json.dumps(safe)

--- a/python_backend/tests/test_ocr_redaction.py
+++ b/python_backend/tests/test_ocr_redaction.py
@@ -171,3 +171,24 @@ def test_dicom_safe_response_does_not_expose_ocr_text_or_bytes():
 
     assert "sanitized_dicom_bytes" not in safe
     assert RAW_OCR_TEXT not in json.dumps(safe)
+
+
+def test_dicom_pixel_redaction_uses_profile_confidence_thresholds():
+    dicom_bytes = build_grayscale_dicom(np.full((6, 6), 255, dtype=np.uint8))
+    backend = FakeOCRBackend([OCRBox(RAW_OCR_TEXT, 0.4, 1, 1, 3, 3)])
+
+    strict = redact_dicom_pixels(
+        dicom_bytes,
+        profile="strict",
+        ocr_backend=backend,
+    )
+    research = redact_dicom_pixels(
+        dicom_bytes,
+        profile="research",
+        ocr_backend=backend,
+    )
+
+    assert strict["ocr_confidence_threshold"] == 0.3
+    assert strict["boxes_redacted"] == 1
+    assert research["ocr_confidence_threshold"] == 0.5
+    assert research["boxes_redacted"] == 0

--- a/python_backend/tests/test_privacy_profiles.py
+++ b/python_backend/tests/test_privacy_profiles.py
@@ -1,0 +1,50 @@
+import os
+import sys
+
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from services.privacy_profiles import (  # noqa: E402
+    PrivacyProfileError,
+    get_privacy_profile,
+    load_privacy_profiles,
+    validate_privacy_profile,
+)
+
+
+def test_strict_and_research_profiles_load():
+    profiles = load_privacy_profiles()
+
+    assert set(profiles) >= {"strict", "research"}
+    assert profiles["strict"]["date_strategy"] == "redact"
+    assert profiles["strict"]["text_identifier_strategy"] == "redact"
+    assert profiles["strict"]["remove_dicom_private_tags"] is True
+    assert profiles["research"]["date_strategy"] == "shift"
+    assert profiles["research"]["text_identifier_strategy"] == "pseudonymize"
+    assert profiles["research"]["preserve_dicom_technical_metadata"] is True
+    assert profiles["research"]["remove_nifti_extensions"] is True
+
+
+def test_profile_name_validation_is_case_insensitive():
+    assert validate_privacy_profile(" Strict ") == "strict"
+    assert validate_privacy_profile("RESEARCH") == "research"
+
+
+def test_profile_settings_are_returned_as_a_copy():
+    strict_settings = get_privacy_profile("strict")
+    strict_settings["redact_dates"] = False
+
+    assert get_privacy_profile("strict")["redact_dates"] is True
+
+
+def test_invalid_profile_fails_clearly():
+    with pytest.raises(PrivacyProfileError) as exc:
+        get_privacy_profile("public")
+
+    assert exc.value.status_code == 400
+    assert "Invalid privacy profile" in exc.value.detail
+    assert "strict" in exc.value.detail
+    assert "research" in exc.value.detail
+
+

--- a/python_backend/tests/test_text_anonymization.py
+++ b/python_backend/tests/test_text_anonymization.py
@@ -20,7 +20,7 @@ def test_mrn_with_context_is_detected_and_replaced():
 
     assert result["anonymization_status"] == "completed"
     assert "123456" not in result["anonymized_text"]
-    assert "MRN_" in result["anonymized_text"]
+    assert "<REDACTED_MRN>" in result["anonymized_text"]
     assert result["detected_entities"]["MEDICAL_RECORD_NUMBER"] == 1
 
 
@@ -50,7 +50,7 @@ def test_patient_id_is_detected_and_replaced():
     )
 
     assert "PT-1001" not in result["anonymized_text"]
-    assert "PATIENT_ID_" in result["anonymized_text"]
+    assert "<REDACTED_PATIENT_ID>" in result["anonymized_text"]
     assert result["detected_entities"]["PATIENT_ID"] == 1
 
 
@@ -61,15 +61,15 @@ def test_health_plan_id_is_detected_and_replaced():
     )
 
     assert "ABC123456789" not in result["anonymized_text"]
-    assert "HEALTH_PLAN_" in result["anonymized_text"]
+    assert "<REDACTED_HEALTH_PLAN>" in result["anonymized_text"]
     assert result["detected_entities"]["HEALTH_PLAN_ID"] == 1
 
 
 def test_deterministic_surrogate_consistency_with_same_salt():
     text = "Patient has MRN: 123456."
 
-    first = anonymize_clinical_text(text, study_salt="study-a")
-    second = anonymize_clinical_text(text, study_salt="study-a")
+    first = anonymize_clinical_text(text, profile="research", study_salt="study-a")
+    second = anonymize_clinical_text(text, profile="research", study_salt="study-a")
 
     assert first["anonymized_text"] == second["anonymized_text"]
 
@@ -77,8 +77,8 @@ def test_deterministic_surrogate_consistency_with_same_salt():
 def test_different_salt_changes_surrogate():
     text = "Patient has MRN: 123456."
 
-    first = anonymize_clinical_text(text, study_salt="study-a")
-    second = anonymize_clinical_text(text, study_salt="study-b")
+    first = anonymize_clinical_text(text, profile="research", study_salt="study-a")
+    second = anonymize_clinical_text(text, profile="research", study_salt="study-b")
 
     assert first["anonymized_text"] != second["anonymized_text"]
     assert "123456" not in first["anonymized_text"]
@@ -165,3 +165,38 @@ def test_overlapping_email_text_does_not_leave_email_exposed():
 
     assert "john.doe@example.com" not in result["anonymized_text"]
     assert "<REDACTED_EMAIL>" in result["anonymized_text"]
+
+
+def test_research_profile_shifts_dates_and_removes_patient_context_name():
+    result = anonymize_clinical_text(
+        "Patient John Doe, MRN 123456, visited on 2026-06-16.",
+        profile="research",
+        study_salt="study-a",
+    )
+
+    assert result["privacy_profile"] == "research"
+    assert result["date_strategy"] == "shift"
+    assert result["text_identifier_strategy"] == "pseudonymize"
+    assert "John Doe" not in result["anonymized_text"]
+    assert "123456" not in result["anonymized_text"]
+    assert "2026-06-16" not in result["anonymized_text"]
+    assert "<REDACTED_DATE>" not in result["anonymized_text"]
+    assert result["detected_entities"]["PERSON"] == 1
+    assert result["detected_entities"]["DATE_TIME"] == 1
+
+
+def test_strict_profile_redacts_dates():
+    result = anonymize_clinical_text(
+        "Patient John Doe, MRN 123456, visited on 2026-06-16.",
+        profile="strict",
+        study_salt="study-a",
+    )
+
+    assert result["privacy_profile"] == "strict"
+    assert result["date_strategy"] == "redact"
+    assert result["text_identifier_strategy"] == "redact"
+    assert "<REDACTED_NAME>" in result["anonymized_text"]
+    assert "<REDACTED_MRN>" in result["anonymized_text"]
+    assert "2026-06-16" not in result["anonymized_text"]
+    assert "<REDACTED_DATE>" in result["anonymized_text"]
+

--- a/python_backend/tests/test_wsi_tiling.py
+++ b/python_backend/tests/test_wsi_tiling.py
@@ -1,0 +1,132 @@
+import json
+import math
+import os
+import sys
+
+from PIL import Image
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from services.ocr_redaction import OCRBox  # noqa: E402
+from services.wsi_tiling import (  # noqa: E402
+    TileCoordinate,
+    generate_priority_tiles,
+    map_tile_boxes_to_slide,
+    scan_wsi_bytes,
+    scan_wsi_slide,
+)
+
+
+class FakeOCRBackend:
+    ocr_engine_status = "available"
+
+    def __init__(self, boxes=None):
+        self.boxes = boxes or []
+
+    def detect_text_boxes(self, image):
+        return self.boxes
+
+
+class FakeSlide:
+    def __init__(self, width, height):
+        self.dimensions = (width, height)
+        self.read_regions = []
+
+    def read_region(self, location, level, size):
+        self.read_regions.append((location, level, size))
+        return Image.new("RGB", size, "white")
+
+
+def test_priority_tile_generator_returns_corners_and_borders_first():
+    tiles = generate_priority_tiles(4096, 3072, tile_size=1024)
+
+    assert [tile.priority_region for tile in tiles[:4]] == [
+        "corner_top_left",
+        "corner_top_right",
+        "corner_bottom_left",
+        "corner_bottom_right",
+    ]
+    assert "top_border" in [tile.priority_region for tile in tiles]
+    assert "bottom_border" in [tile.priority_region for tile in tiles]
+    assert "left_border" in [tile.priority_region for tile in tiles]
+    assert "right_border" in [tile.priority_region for tile in tiles]
+
+
+def test_tile_coordinates_stay_inside_image_bounds():
+    width = 2500
+    height = 1800
+    tiles = generate_priority_tiles(width, height, tile_size=700)
+
+    assert tiles
+    for tile in tiles:
+        assert tile.x >= 0
+        assert tile.y >= 0
+        assert tile.width > 0
+        assert tile.height > 0
+        assert tile.x + tile.width <= width
+        assert tile.y + tile.height <= height
+
+
+def test_large_wsi_scan_reads_priority_tiles_not_full_image():
+    slide = FakeSlide(10000, 8000)
+    result = scan_wsi_slide(
+        slide,
+        ocr_backend=FakeOCRBackend(),
+        tile_size=1024,
+    )
+
+    assert result["pixel_redaction_status"] == "redaction_plan_ready"
+    assert result["tiles_scanned"] == len(slide.read_regions)
+    full_tile_count = math.ceil(10000 / 1024) * math.ceil(8000 / 1024)
+    assert result["tiles_scanned"] < full_tile_count
+    for _location, _level, size in slide.read_regions:
+        assert size[0] <= 1024
+        assert size[1] <= 1024
+
+
+def test_tile_ocr_boxes_map_to_global_coordinates():
+    tile = TileCoordinate(
+        x=1024,
+        y=2048,
+        width=512,
+        height=512,
+        priority_region="top_border",
+    )
+    mapped = map_tile_boxes_to_slide(
+        tile,
+        [OCRBox("SLIDE_LABEL", 0.95, 10, 20, 100, 30)],
+    )
+
+    assert mapped == [
+        OCRBox("SLIDE_LABEL", 0.95, 1034, 2068, 100, 30),
+    ]
+
+
+def test_wsi_scan_is_honest_when_rewrite_is_not_supported():
+    result = scan_wsi_slide(
+        FakeSlide(2048, 2048),
+        ocr_backend=FakeOCRBackend([OCRBox("WSI_LABEL", 0.99, 0, 0, 50, 20)]),
+        tile_size=1024,
+    )
+    response_text = json.dumps(result)
+
+    assert result["pixel_redaction_status"] == "redaction_plan_ready"
+    assert result["wsi_rewrite_status"] == "not_supported_yet"
+    assert result["ocr_boxes_detected"] > 0
+    assert result["boxes_redacted"] == 0
+    assert result["redaction_plan_boxes"] == result["ocr_boxes_detected"]
+    assert "WSI_LABEL" not in response_text
+
+
+def test_wsi_bytes_returns_honest_status_without_openslide(monkeypatch):
+    monkeypatch.setattr("services.wsi_tiling._load_openslide_module", lambda: None)
+
+    result = scan_wsi_bytes(
+        b"not a real slide",
+        filename="slide.svs",
+        ocr_backend=FakeOCRBackend(),
+    )
+
+    assert result["pixel_redaction_status"] == "redaction_plan_unavailable"
+    assert result["wsi_rewrite_status"] == "not_supported_yet"
+    assert result["tiles_scanned"] == 0


### PR DESCRIPTION
@pradeeban @karthiksathishjeemain @Chali-healthy. This PR implements the Week 5 privacy profile work as production backend behavior rather than a local demo.

It introduces two configurable privacy profiles, `strict` and `research`, and wires them into the real anonymization paths used by the FastAPI backend. The goal is to let users choose a privacy mode during upload/anonymization while keeping direct PHI removal consistent across text, DICOM, NIfTI, and OCR-related flows.

This replaces the earlier demo/prototype approach with actual backend integration.

## Why This Is Needed

Different biomedical workflows need different privacy/utility tradeoffs.

`strict` mode prioritizes maximum privacy and aggressive removal/redaction.

`research` mode still removes direct identifiers, but preserves safe research utility where possible, such as shifted dates, generalized demographics, and safe technical metadata summaries.

This gives the project a clearer foundation for privacy-aware anonymization behavior without hardcoding one policy everywhere.

## What Changed

Added a new privacy profile config:

- `python_backend/config/privacy_profiles.json`

Added a profile loader/validator service:

- `python_backend/services/privacy_profiles.py`

The loader validates supported profiles, required settings, date strategies, OCR thresholds, and text identifier behavior.

Integrated profiles into existing production paths:

- `/api/v1/ingest`
- `/anonymize_dicom`
- text anonymization
- DICOM anonymization
- NIfTI anonymization
- OCR redaction threshold selection

Removed demo-only code from the production PR:

- no local Week 5 FastAPI demo wrapper
- no synthetic privacy profile demo endpoint
- no demo-only comparison service

## Strict Profile Behavior

Strict mode is the most privacy-preserving option.

For text:

- direct identifiers are redacted instead of pseudonymized
- names, MRNs, patient IDs, health plan IDs, accession numbers, and device IDs are replaced with redaction tokens
- dates are fully redacted

For DICOM:

- direct PHI fields are removed/blanked
- dates are redacted
- private tags are removed
- patient identity removal metadata is written
- pixel data is preserved unless OCR pixel redaction modifies it

For NIfTI:

- text-like header fields are cleared
- unknown extensions are removed
- safe technical metadata such as shape, affine, datatype, and image data preservation is reported

For OCR:

- strict uses the configured lower confidence threshold for more aggressive redaction behavior

## Research Profile Behavior

Research mode still removes direct identifiers, but preserves safe utility where possible.

For text:

- direct identifiers are pseudonymized deterministically where appropriate
- dates are shifted instead of fully redacted
- raw PHI values are not returned

For DICOM:

- patient names, patient IDs, and direct identifiers are removed
- private tags are still removed for safety
- dates are shifted
- demographics such as age/sex may be generalized where configured
- safe technical metadata summaries can be preserved

For NIfTI:

- text-like fields are cleared
- unknown extensions are still removed for production safety
- shape, affine, datatype, and image data preservation are reported

For OCR:

- research uses its configured OCR confidence threshold

## Privacy Notes

This PR avoids preserving direct identifiers in either profile.

The implementation is designed around HIPAA Safe Harbor-style removal of direct identifiers, but this PR does not claim full legal compliance by itself. It provides the backend controls needed for stricter PHI removal and safer research-oriented anonymization behavior.