### PR TITLE
Gsoc week8 bm25 lexical retrieval

### DIFF
--- a/python_backend/config/privacy_profiles.json
+++ b/python_backend/config/privacy_profiles.json
@@ -1,0 +1,24 @@
+{
+  "strict": {
+    "redact_dates": true,
+    "date_strategy": "redact",
+    "text_identifier_strategy": "redact",
+    "remove_dicom_private_tags": true,
+    "preserve_dicom_technical_metadata": false,
+    "remove_nifti_extensions": true,
+    "ocr_confidence_threshold": 0.3,
+    "allow_generalized_demographics": false
+  },
+  "research": {
+    "redact_dates": true,
+    "date_strategy": "shift",
+    "text_identifier_strategy": "pseudonymize",
+    "remove_dicom_private_tags": true,
+    "preserve_dicom_technical_metadata": true,
+    "remove_nifti_extensions": true,
+    "ocr_confidence_threshold": 0.5,
+    "allow_generalized_demographics": true
+  }
+}
+
+

--- a/python_backend/main.py
+++ b/python_backend/main.py
@@ -335,7 +335,7 @@ async def ingest_file(
                 )
 
         file_content = None
-        if modality in {"dicom", "nifti"}:
+        if modality in {"dicom", "nifti", "wsi"}:
             await file.seek(0)
             file_content = await file.read()
 

--- a/python_backend/main.py
+++ b/python_backend/main.py
@@ -334,6 +334,11 @@ async def ingest_file(
                     ),
                 )
 
+        file_content = None
+        if modality in {"dicom", "nifti"}:
+            await file.seek(0)
+            file_content = await file.read()
+
         await file.seek(0)
 
         return route_for_ingestion(
@@ -342,6 +347,7 @@ async def ingest_file(
             header=header,
             profile=profile,
             text_content=text_content,
+            file_content=file_content,
         )
     except IngestionError as e:
         raise HTTPException(status_code=e.status_code, detail=e.detail)

--- a/python_backend/main.py
+++ b/python_backend/main.py
@@ -34,6 +34,10 @@ from services.ingestion import (
     detect_modality,
     route_for_ingestion,
 )
+from services.dicom_anonymization import (
+    DicomAnonymizationError,
+    anonymize_dicom_file_bytes,
+)
 
 # PDF extraction imports
 try:
@@ -289,8 +293,8 @@ async def root():
             "/anonymize_image_presidio": "Anonymize PHI in images (Presidio only, advanced)",
             "/anonymize_text": "Anonymize PHI in plain text (Presidio + spaCy fallback)",
             "/anonymize_pdf": "Anonymize PHI in PDF documents (per-page extraction and redaction)",
-            "/anonymize_dicom": "Anonymize PHI in DICOM file metadata (strips patient identifiers)",
-            "/api/v1/ingest": "Route uploaded biomedical files to placeholder anonymization handlers"
+            "/anonymize_dicom": "Anonymize DICOM files with strict/research privacy profiles",
+            "/api/v1/ingest": "Route uploaded biomedical files through profile-aware anonymization handlers"
         },
         "status": {
             "presidio_available": presidio_available,
@@ -308,8 +312,8 @@ async def ingest_file(
     """
     Privacy-safe upload entry point.
 
-    Text uploads are anonymized. Other modalities still route to placeholder
-    handlers until their later milestones.
+    Applies the selected privacy profile across supported production handlers.
+    Supported profiles are strict and research.
     """
     try:
         header = await file.read(HEADER_READ_LIMIT)
@@ -682,73 +686,51 @@ DICOM_PHI_TAGS = {
 
 
 @app.post("/anonymize_dicom")
-async def anonymize_dicom(file: UploadFile = File(...)):
+async def anonymize_dicom(
+    file: UploadFile = File(...),
+    profile: str = Form("strict"),
+):
     """
-    Anonymize PHI in DICOM file metadata. Strips patient identifiers
-    following HIPAA Safe Harbor de-identification standards.
-    Returns the anonymized DICOM file for download.
+    Anonymize DICOM metadata using the selected privacy profile and return a downloadable DICOM file.
+
+    The response is a valid .dcm attachment so it can be saved and opened
+    in a DICOM viewer. Raw PHI values are never returned in the response.
     """
-    if not pydicom_available:
-        raise HTTPException(
-            status_code=503,
-            detail="pydicom not available. Install with: pip install pydicom"
-        )
-
-    if not file.filename or not file.filename.lower().endswith(('.dcm', '.dicom')):
-        raise HTTPException(
-            status_code=400,
-            detail="File must be a DICOM file (.dcm or .dicom)"
-        )
-
     try:
         contents = await file.read()
+        result = anonymize_dicom_file_bytes(contents, profile=profile)
+    except DicomAnonymizationError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail="Failed to anonymize DICOM") from exc
 
-        with tempfile.NamedTemporaryFile(suffix=".dcm", delete=False) as tmp:
-            tmp.write(contents)
-            tmp_path = tmp.name
+    safe_name = (file.filename or "dicom.dcm").strip().replace("\\", "/").rsplit("/", 1)[-1]
+    if not safe_name:
+        safe_name = "dicom.dcm"
+    stem = safe_name.rsplit(".", 1)[0] if "." in safe_name else safe_name
+    download_name = f"anonymized_{stem}.dcm"
+    metadata_summary = result["metadata_summary"]
 
-        try:
-            ds = pydicom.dcmread(tmp_path)
-            stripped_fields = []
+    audit_logger.log_operation(
+        operation="ANONYMIZE",
+        details=(
+            f"dicom: {safe_name}, fields_scrubbed: "
+            f"{metadata_summary['fields_scrubbed']}, "
+            f"private_tags_removed: {metadata_summary['private_tags_removed']}"
+        ),
+    )
 
-            for tag, field_name in DICOM_PHI_TAGS.items():
-                if tag in ds:
-                    original_value = str(ds[tag].value)
-                    ds[tag].value = ""
-                    stripped_fields.append({
-                        "field": field_name,
-                        "tag": f"({tag[0]:04X},{tag[1]:04X})",
-                        "original_value": original_value
-                    })
-
-            # Save anonymized DICOM to buffer
-            anonymized_buffer = io.BytesIO()
-            ds.save_as(anonymized_buffer)
-            anonymized_buffer.seek(0)
-
-            audit_logger.log_operation(
-                operation="ANONYMIZE",
-                details=f"dicom: {file.filename}, fields_stripped: {len(stripped_fields)}",
-            )
-
-            return {
-                "filename": file.filename,
-                "fields_stripped": len(stripped_fields),
-                "stripped_details": stripped_fields,
-                "anonymized_file_base64": anonymized_buffer.getvalue().hex(),
-                "message": f"Successfully anonymized {len(stripped_fields)} PHI fields from DICOM metadata"
-            }
-
-        finally:
-            os.unlink(tmp_path)
-
-    except HTTPException:
-        raise
-    except InvalidDicomError:
-        raise HTTPException(status_code=400, detail="Invalid DICOM file format")
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Failed to anonymize DICOM: {str(e)}")
-
+    return StreamingResponse(
+        io.BytesIO(result["anonymized_dicom_bytes"]),
+        media_type="application/dicom",
+        headers={
+            "Content-Disposition": f'attachment; filename="{download_name}"',
+            "X-BioBlock-Anonymization-Status": result["anonymization_status"],
+            "X-BioBlock-Fields-Scrubbed": str(metadata_summary["fields_scrubbed"]),
+            "X-BioBlock-Private-Tags-Removed": str(metadata_summary["private_tags_removed"]),
+            "X-BioBlock-Pixel-Data-Preserved": str(metadata_summary["pixel_data_preserved"]).lower(),
+        },
+    )
 
 @app.post("/store")
 async def store_data(request: StoreWithContentRequest):
@@ -1524,3 +1506,6 @@ async def get_audit_entry(entry_id: str):
 if __name__ == "__main__":
     import uvicorn
     uvicorn.run(app, host="0.0.0.0", port=3002)
+
+
+

--- a/python_backend/main.py
+++ b/python_backend/main.py
@@ -38,6 +38,10 @@ from services.dicom_anonymization import (
     DicomAnonymizationError,
     anonymize_dicom_file_bytes,
 )
+from services.tabular_anonymization import (
+    TabularAnonymizationError,
+    anonymize_tabular_csv,
+)
 
 # PDF extraction imports
 try:
@@ -294,6 +298,7 @@ async def root():
             "/anonymize_text": "Anonymize PHI in plain text (Presidio + spaCy fallback)",
             "/anonymize_pdf": "Anonymize PHI in PDF documents (per-page extraction and redaction)",
             "/anonymize_dicom": "Anonymize DICOM files with strict/research privacy profiles",
+            "/anonymize_csv": "Anonymize CSV files and return a downloadable CSV",
             "/api/v1/ingest": "Route uploaded biomedical files through profile-aware anonymization handlers"
         },
         "status": {
@@ -339,7 +344,7 @@ async def ingest_file(
                 )
 
         file_content = None
-        if modality in {"dicom", "nifti", "wsi"}:
+        if modality in {"csv", "dicom", "nifti", "wsi"}:
             await file.seek(0)
             file_content = await file.read()
 
@@ -731,6 +736,132 @@ async def anonymize_dicom(
             "X-BioBlock-Pixel-Data-Preserved": str(metadata_summary["pixel_data_preserved"]).lower(),
         },
     )
+
+def _parse_optional_csv_columns(columns: Optional[str]) -> Optional[List[str]]:
+    if columns is None:
+        return None
+    if columns.strip().lower() == "string":
+        return None
+    parsed = [column.strip() for column in columns.split(",") if column.strip()]
+    return parsed or None
+
+
+def _parse_optional_csv_column(column: Optional[str]) -> Optional[str]:
+    if column is None:
+        return None
+    parsed = column.strip()
+    if not parsed or parsed.lower() == "string":
+        return None
+    return parsed
+
+
+def _parse_safe_harbor_mappings(
+    mappings: Optional[str],
+) -> Optional[Dict[str, List[str]]]:
+    if mappings is None or not mappings.strip() or mappings.strip().lower() == "string":
+        return None
+    try:
+        parsed = json.loads(mappings)
+    except json.JSONDecodeError as exc:
+        raise TabularAnonymizationError(
+            "safe_harbor_mappings must be a valid JSON object"
+        ) from exc
+    if not isinstance(parsed, dict):
+        raise TabularAnonymizationError(
+            "safe_harbor_mappings must be a JSON object"
+        )
+    normalized: Dict[str, List[str]] = {}
+    for category, columns in parsed.items():
+        if isinstance(columns, str):
+            columns = [columns]
+        if not isinstance(columns, list) or not all(
+            isinstance(column, str) for column in columns
+        ):
+            raise TabularAnonymizationError(
+                "Safe Harbor mapping values must be column-name lists"
+            )
+        normalized[str(category)] = columns
+    return normalized
+
+
+@app.post("/anonymize_csv")
+async def anonymize_csv_file(
+    file: UploadFile = File(...),
+    k: int = Form(5),
+    l: int = Form(2),
+    direct_identifiers: Optional[str] = Form(None),
+    quasi_identifiers: Optional[str] = Form(None),
+    sensitive_column: Optional[str] = Form(None),
+    safe_harbor_mappings: Optional[str] = Form(None),
+):
+    """
+    Anonymize a CSV file and return a downloadable anonymized CSV.
+
+    Use this endpoint for local before/after demos. The general ingestion route
+    remains summary-only and does not return raw uploaded rows.
+    """
+    try:
+        contents = await file.read()
+        result = anonymize_tabular_csv(
+            contents,
+            k=k,
+            l=l,
+            direct_identifiers=_parse_optional_csv_columns(direct_identifiers),
+            quasi_identifiers=_parse_optional_csv_columns(quasi_identifiers),
+            sensitive_column=_parse_optional_csv_column(sensitive_column),
+            safe_harbor_mappings=_parse_safe_harbor_mappings(
+                safe_harbor_mappings
+            ),
+            include_anonymized_csv=True,
+        )
+    except TabularAnonymizationError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
+    except Exception:
+        raise HTTPException(status_code=500, detail="Failed to anonymize CSV")
+
+    safe_name = (
+        (file.filename or "dataset.csv")
+        .strip()
+        .replace("\\", "/")
+        .rsplit("/", 1)[-1]
+    )
+    if not safe_name:
+        safe_name = "dataset.csv"
+    stem = safe_name.rsplit(".", 1)[0] if "." in safe_name else safe_name
+    download_name = "anonymized_dataset.csv"
+    anonymized_csv = result.pop("_internal_anonymized_csv")
+
+    audit_logger.log_operation(
+        operation="ANONYMIZE",
+        details=(
+            f"csv upload, rows_in: {result['rows_in']}, "
+            f"rows_out: {result['rows_out']}, k_satisfied: "
+            f"{result['k_anonymity_satisfied']}"
+        ),
+    )
+
+    return StreamingResponse(
+        io.BytesIO(anonymized_csv.encode("utf-8")),
+        media_type="text/csv",
+        headers={
+            "Content-Disposition": f'attachment; filename="{download_name}"',
+            "X-BioBlock-Anonymization-Status": result["anonymization_status"],
+            "X-BioBlock-Rows-In": str(result["rows_in"]),
+            "X-BioBlock-Rows-Out": str(result["rows_out"]),
+            "X-BioBlock-K-Anonymity-Satisfied": str(
+                result["k_anonymity_satisfied"]
+            ).lower(),
+            "X-BioBlock-L-Diversity-Satisfied": str(
+                result["l_diversity_satisfied"]
+            ).lower(),
+            "X-BioBlock-Equivalence-Classes": str(result["equivalence_classes"]),
+            "X-BioBlock-Min-Group-Size": str(result["min_group_size"]),
+            "X-BioBlock-Safe-Harbor-Status": result["safe_harbor_report"][
+                "safe_harbor_validation_status"
+            ],
+        },
+    )
+
 
 @app.post("/store")
 async def store_data(request: StoreWithContentRequest):

--- a/python_backend/main.py
+++ b/python_backend/main.py
@@ -1,9 +1,10 @@
 from fastapi import FastAPI, HTTPException, File, Form, UploadFile
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import StreamingResponse
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 from typing import Optional, Dict, Any, List
 import chromadb
+import logging
 import time
 import uuid
 import os
@@ -42,6 +43,11 @@ from services.tabular_anonymization import (
     TabularAnonymizationError,
     anonymize_tabular_csv,
 )
+from services.bm25_retrieval import (
+    BM25QueryError,
+    BM25RetrievalService,
+    tokenize as tokenize_bm25,
+)
 
 # PDF extraction imports
 try:
@@ -77,6 +83,7 @@ except ImportError:
     print("Install with: pip install presidio_analyzer presidio_anonymizer presidio_image_redactor")
 
 app = FastAPI()
+logger = logging.getLogger(__name__)
 
 app.add_middleware(
     CORSMiddleware,
@@ -89,6 +96,7 @@ app.add_middleware(
 chroma_client = chromadb.PersistentClient(path="./chroma_db")
 collection = chroma_client.get_or_create_collection(name="new_user_data")
 audit_logger = AuditLogger(chroma_client)
+bm25_retrieval_service = BM25RetrievalService()
 
 # 1. Cross-platform Tesseract detection
 tesseract_cmd = os.getenv('TESSERACT_CMD') or shutil.which('tesseract')
@@ -170,6 +178,14 @@ class StoreRequest(BaseModel):
 class SearchRequest(BaseModel):
     query: str = Field(..., min_length=1)
     n_results: Optional[int] = Field(default=5, ge=1, le=100)
+
+class BM25SearchRequest(BaseModel):
+    query: str = Field(..., min_length=1)
+    top_k: int = Field(default=10, ge=1, le=100)
+    modality: Optional[str] = None
+
+    model_config = ConfigDict(extra="forbid")
+
 
 class FilterRequest(BaseModel):
     filters: Dict[str, Any] = Field(..., min_length=1)
@@ -290,6 +306,7 @@ async def root():
         "endpoints": {
             "/store": "Store document data",
             "/search": "Search documents", 
+            "/api/v1/search/bm25": "Search anonymized documents with BM25",
             "/filter": "Filter documents by metadata",
             "/search_with_filter": "Combined search and filter",
             "/documents/{doc_id}": "GET: Retrieve document by ID, PUT: Update document metadata, DELETE: Remove document",
@@ -1054,6 +1071,59 @@ async def search_data(request: SearchRequest):
         
     except Exception as e:
         raise HTTPException(status_code=500, detail="Failed to search data")
+
+@app.post("/api/v1/search/bm25")
+async def search_bm25(request: BM25SearchRequest):
+    """Search only privacy-gated, anonymized documents in the BM25 index."""
+    if not request.query.strip():
+        raise HTTPException(
+            status_code=422,
+            detail="Search query must contain at least one token",
+        )
+
+    filters = (
+        {"modality": request.modality}
+        if request.modality is not None
+        else None
+    )
+    try:
+        query_token_count = len(tokenize_bm25(request.query))
+        results = bm25_retrieval_service.search(
+            request.query,
+            top_k=request.top_k,
+            filters=filters,
+        )
+    except BM25QueryError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except Exception:
+        logger.exception(
+            "BM25 search failed query_length=%d",
+            len(request.query),
+        )
+        raise HTTPException(status_code=500, detail="BM25 search failed")
+
+    index_document_count = bm25_retrieval_service.document_count
+    if index_document_count == 0:
+        retrieval_status = "empty_index"
+    elif not results:
+        retrieval_status = "no_matches"
+    else:
+        retrieval_status = "completed"
+
+    logger.info(
+        "BM25 search completed query_length=%d token_count=%d results=%d",
+        len(request.query),
+        query_token_count,
+        len(results),
+    )
+    return {
+        "search_type": "bm25",
+        "query_metadata": {"token_count": query_token_count},
+        "result_count": len(results),
+        "results": results,
+        "index_document_count": index_document_count,
+        "retrieval_status": retrieval_status,
+    }
 
 @app.post("/filter")
 async def filter_data(request: FilterRequest):

--- a/python_backend/services/bm25_retrieval.py
+++ b/python_backend/services/bm25_retrieval.py
@@ -1,0 +1,464 @@
+"""Privacy-gated in-memory BM25 retrieval over anonymized documents.
+
+The checks in this module are an additional indexing safety gate. They do not
+independently establish that upstream content has been de-identified.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+from collections import Counter
+from dataclasses import dataclass, field
+from threading import RLock
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence
+
+DEFAULT_K1 = 1.5
+DEFAULT_B = 0.75
+DEFAULT_SNIPPET_LENGTH = 200
+
+_TOKEN_PATTERN = re.compile(r"[^\W_]+(?:[.-][^\W_]+)*", re.UNICODE)
+_DOCUMENT_FIELDS = {
+    "document_id",
+    "modality",
+    "anonymized_text",
+    "safe_metadata",
+    "anonymization_status",
+    "privacy_validation_status",
+}
+_REQUIRED_DOCUMENT_FIELDS = {
+    "document_id",
+    "modality",
+    "anonymized_text",
+    "anonymization_status",
+}
+_SAFE_METADATA_KEYS = {
+    "modality": "modality",
+    "documenttype": "document_type",
+    "clinicalterms": "clinical_terms",
+    "categorylabels": "category_labels",
+    "clinicalcodes": "clinical_codes",
+    "diseasetags": "disease_tags",
+}
+_UNSAFE_METADATA_KEY_PARTS = {
+    "patientname",
+    "patientid",
+    "socialsecurity",
+    "ssn",
+    "medicalrecordnumber",
+    "mrn",
+    "passport",
+    "driverlicense",
+    "driverlicence",
+    "email",
+    "phone",
+    "telephone",
+    "mobile",
+    "address",
+    "coordinates",
+    "latitude",
+    "longitude",
+    "originalfilename",
+    "filename",
+    "rawuploadpath",
+    "uploadpath",
+    "filepath",
+    "filesystempath",
+    "rawdicommetadata",
+    "rawniftimetadata",
+    "dicommetadata",
+    "niftimetadata",
+    "filebytes",
+    "rawbytes",
+    "uploadbytes",
+    "temporarypath",
+    "temppath",
+    "rawcontent",
+    "originalcontent",
+    "extractedcontent",
+}
+_PASSING_PRIVACY_STATUSES = {
+    "approved",
+    "completed",
+    "passed",
+    "satisfied",
+    "success",
+    "valid",
+}
+
+
+class BM25RetrievalError(ValueError):
+    """Base error for safe indexing and query validation failures."""
+
+
+class UnsafeDocumentError(BM25RetrievalError):
+    """Raised when a document is not eligible for the safe index."""
+
+
+class BM25QueryError(BM25RetrievalError):
+    """Raised when a BM25 query or filter is invalid."""
+
+
+@dataclass(frozen=True)
+class SearchableDocument:
+    """Internal contract for content that has already been anonymized."""
+
+    document_id: str
+    modality: str
+    anonymized_text: str
+    anonymization_status: str
+    safe_metadata: Mapping[str, Any] = field(default_factory=dict)
+    privacy_validation_status: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class _IndexedDocument:
+    document_id: str
+    modality: str
+    anonymized_text: str
+    safe_metadata: Mapping[str, Any]
+    tokens: Sequence[str]
+    term_frequencies: Mapping[str, int]
+
+
+def tokenize(text: str) -> List[str]:
+    """Tokenize locally while preserving clinical codes and numeric terms."""
+
+    if not isinstance(text, str):
+        raise BM25QueryError("Search text must be a string")
+    return [match.group(0).lower() for match in _TOKEN_PATTERN.finditer(text)]
+
+
+def _normalized_key(key: str) -> str:
+    return "".join(character for character in key.lower() if character.isalnum())
+
+
+def _contains_binary(value: Any) -> bool:
+    if isinstance(value, (bytes, bytearray, memoryview)):
+        return True
+    if isinstance(value, Mapping):
+        return any(
+            _contains_binary(key) or _contains_binary(item)
+            for key, item in value.items()
+        )
+    if isinstance(value, (list, tuple, set, frozenset)):
+        return any(_contains_binary(item) for item in value)
+    return False
+
+
+def _is_unsafe_metadata_key(key: str) -> bool:
+    normalized = _normalized_key(key)
+    return any(part in normalized for part in _UNSAFE_METADATA_KEY_PARTS)
+
+
+def _safe_metadata_value(value: Any) -> Any:
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, (list, tuple)):
+        return [_safe_metadata_value(item) for item in value]
+    raise UnsafeDocumentError(
+        "Safe metadata values must be scalar values or lists of scalar values"
+    )
+
+
+def _validate_safe_metadata(metadata: Any) -> Dict[str, Any]:
+    if metadata is None:
+        return {}
+    if not isinstance(metadata, Mapping):
+        raise UnsafeDocumentError("safe_metadata must be a mapping")
+    if _contains_binary(metadata):
+        raise UnsafeDocumentError("Raw file bytes cannot be indexed")
+
+    validated: Dict[str, Any] = {}
+    for key, value in metadata.items():
+        if not isinstance(key, str) or not key.strip():
+            raise UnsafeDocumentError("Safe metadata keys must be non-empty strings")
+        if _is_unsafe_metadata_key(key):
+            raise UnsafeDocumentError("Unsafe metadata keys cannot be indexed")
+
+        canonical_key = _SAFE_METADATA_KEYS.get(_normalized_key(key))
+        if canonical_key is None:
+            raise UnsafeDocumentError("Metadata key is not approved for BM25 indexing")
+        if canonical_key in validated:
+            raise UnsafeDocumentError("Duplicate normalized metadata keys are not allowed")
+        validated[canonical_key] = _safe_metadata_value(value)
+    return validated
+
+
+def _metadata_text(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, list):
+        return " ".join(_metadata_text(item) for item in value)
+    return str(value)
+
+
+def _document_mapping(
+    document: SearchableDocument | Mapping[str, Any],
+) -> Mapping[str, Any]:
+    if isinstance(document, SearchableDocument):
+        return {
+            "document_id": document.document_id,
+            "modality": document.modality,
+            "anonymized_text": document.anonymized_text,
+            "anonymization_status": document.anonymization_status,
+            "safe_metadata": document.safe_metadata,
+            "privacy_validation_status": document.privacy_validation_status,
+        }
+    if not isinstance(document, Mapping):
+        raise UnsafeDocumentError("Documents must use the safe searchable contract")
+    return document
+
+
+def _prepare_document(
+    document: SearchableDocument | Mapping[str, Any],
+) -> _IndexedDocument:
+    data = _document_mapping(document)
+    if _contains_binary(data):
+        raise UnsafeDocumentError("Raw file bytes cannot be indexed")
+
+    unknown_fields = set(data) - _DOCUMENT_FIELDS
+    if unknown_fields:
+        raise UnsafeDocumentError("Raw or unsupported document fields cannot be indexed")
+    missing_fields = _REQUIRED_DOCUMENT_FIELDS - set(data)
+    if missing_fields:
+        raise UnsafeDocumentError("Anonymization status and safe document fields are required")
+
+    document_id = data["document_id"]
+    modality = data["modality"]
+    anonymized_text = data["anonymized_text"]
+    anonymization_status = data["anonymization_status"]
+    privacy_validation_status = data.get("privacy_validation_status")
+
+    if not isinstance(document_id, str) or not document_id.strip():
+        raise UnsafeDocumentError("document_id must be a non-empty string")
+    if not isinstance(modality, str) or not modality.strip():
+        raise UnsafeDocumentError("modality must be a non-empty string")
+    if not isinstance(anonymized_text, str):
+        raise UnsafeDocumentError("anonymized_text must be a string")
+    if not isinstance(anonymization_status, str):
+        raise UnsafeDocumentError("Anonymization status is required")
+    if anonymization_status.strip().lower() != "completed":
+        raise UnsafeDocumentError("Only completed anonymization outputs can be indexed")
+
+    if privacy_validation_status is not None:
+        if not isinstance(privacy_validation_status, str):
+            raise UnsafeDocumentError("Privacy validation status must be a string")
+        if privacy_validation_status.strip().lower() not in _PASSING_PRIVACY_STATUSES:
+            raise UnsafeDocumentError("Privacy validation must pass before indexing")
+
+    safe_metadata = _validate_safe_metadata(data.get("safe_metadata", {}))
+    searchable_parts = [anonymized_text, modality]
+    searchable_parts.extend(
+        _metadata_text(safe_metadata[key])
+        for key in sorted(safe_metadata)
+    )
+    tokens = tokenize(" ".join(part for part in searchable_parts if part))
+
+    return _IndexedDocument(
+        document_id=document_id.strip(),
+        modality=modality.strip(),
+        anonymized_text=anonymized_text,
+        safe_metadata=safe_metadata,
+        tokens=tokens,
+        term_frequencies=Counter(tokens),
+    )
+
+
+def _snippet(text: str, query_tokens: Sequence[str], limit: int) -> str:
+    normalized_text = " ".join(text.split())
+    if not normalized_text:
+        return ""
+    if len(normalized_text) <= limit:
+        return normalized_text
+
+    lower_text = normalized_text.lower()
+    positions = [lower_text.find(token) for token in query_tokens]
+    positions = [position for position in positions if position >= 0]
+    match_position = min(positions) if positions else 0
+    start = max(0, match_position - (limit // 3))
+    end = min(len(normalized_text), start + limit)
+    start = max(0, end - limit)
+    snippet = normalized_text[start:end]
+    if start:
+        snippet = f"…{snippet}"
+    if end < len(normalized_text):
+        snippet = f"{snippet}…"
+    return snippet
+
+
+class BM25RetrievalService:
+    """Thread-safe, in-memory Okapi BM25 index for safe document records."""
+
+    def __init__(
+        self,
+        k1: float = DEFAULT_K1,
+        b: float = DEFAULT_B,
+        snippet_length: int = DEFAULT_SNIPPET_LENGTH,
+    ) -> None:
+        if k1 <= 0:
+            raise ValueError("k1 must be greater than zero")
+        if not 0 <= b <= 1:
+            raise ValueError("b must be between zero and one")
+        if snippet_length < 1:
+            raise ValueError("snippet_length must be greater than zero")
+
+        self.k1 = float(k1)
+        self.b = float(b)
+        self.snippet_length = snippet_length
+        self._documents: Dict[str, _IndexedDocument] = {}
+        self._document_frequencies: Counter[str] = Counter()
+        self._average_document_length = 0.0
+        self._lock = RLock()
+
+    @property
+    def document_count(self) -> int:
+        with self._lock:
+            return len(self._documents)
+
+    @property
+    def average_document_length(self) -> float:
+        with self._lock:
+            return self._average_document_length
+
+    def _rebuild_statistics(self) -> None:
+        self._document_frequencies = Counter()
+        total_length = 0
+        for document in self._documents.values():
+            total_length += len(document.tokens)
+            self._document_frequencies.update(set(document.tokens))
+        self._average_document_length = (
+            total_length / len(self._documents) if self._documents else 0.0
+        )
+
+    def clear(self) -> None:
+        with self._lock:
+            self._documents = {}
+            self._rebuild_statistics()
+
+    def rebuild(
+        self,
+        documents: Iterable[SearchableDocument | Mapping[str, Any]],
+    ) -> int:
+        prepared: Dict[str, _IndexedDocument] = {}
+        for document in documents:
+            indexed = _prepare_document(document)
+            prepared[indexed.document_id] = indexed
+
+        with self._lock:
+            self._documents = prepared
+            self._rebuild_statistics()
+            return len(self._documents)
+
+    def index_documents(
+        self,
+        documents: Iterable[SearchableDocument | Mapping[str, Any]],
+    ) -> int:
+        prepared = [_prepare_document(document) for document in documents]
+        with self._lock:
+            for indexed in prepared:
+                self._documents[indexed.document_id] = indexed
+            self._rebuild_statistics()
+            return len(prepared)
+
+    def upsert_document(
+        self,
+        document: SearchableDocument | Mapping[str, Any],
+    ) -> None:
+        indexed = _prepare_document(document)
+        with self._lock:
+            self._documents[indexed.document_id] = indexed
+            self._rebuild_statistics()
+
+    def delete_document(self, document_id: str) -> bool:
+        with self._lock:
+            removed = self._documents.pop(document_id, None) is not None
+            if removed:
+                self._rebuild_statistics()
+            return removed
+
+    def _inverse_document_frequency(self, term: str) -> float:
+        document_frequency = self._document_frequencies.get(term, 0)
+        document_count = len(self._documents)
+        if not document_frequency or not document_count:
+            return 0.0
+        return math.log(
+            1.0
+            + (
+                document_count - document_frequency + 0.5
+            )
+            / (document_frequency + 0.5)
+        )
+
+    def search(
+        self,
+        query: str,
+        top_k: int = 10,
+        filters: Optional[Mapping[str, Any]] = None,
+    ) -> List[Dict[str, Any]]:
+        query_tokens = tokenize(query)
+        if not query_tokens:
+            raise BM25QueryError("Search query must contain at least one token")
+        if isinstance(top_k, bool) or not isinstance(top_k, int) or not 1 <= top_k <= 100:
+            raise BM25QueryError("top_k must be between 1 and 100")
+
+        normalized_filters = dict(filters or {})
+        unsupported_filters = set(normalized_filters) - {"modality"}
+        if unsupported_filters:
+            raise BM25QueryError("Unsupported BM25 search filter")
+        modality_filter = normalized_filters.get("modality")
+        if modality_filter is not None:
+            if not isinstance(modality_filter, str) or not modality_filter.strip():
+                raise BM25QueryError("Modality filter must be a non-empty string")
+            modality_filter = modality_filter.strip().lower()
+
+        query_frequencies = Counter(query_tokens)
+        with self._lock:
+            if not self._documents:
+                return []
+
+            scored: List[tuple[float, _IndexedDocument]] = []
+            average_length = self._average_document_length
+            for document in self._documents.values():
+                if modality_filter and document.modality.lower() != modality_filter:
+                    continue
+
+                document_length = len(document.tokens)
+                score = 0.0
+                for term, query_frequency in query_frequencies.items():
+                    term_frequency = document.term_frequencies.get(term, 0)
+                    if not term_frequency:
+                        continue
+                    inverse_document_frequency = self._inverse_document_frequency(term)
+                    if average_length:
+                        length_ratio = document_length / average_length
+                    else:
+                        length_ratio = 0.0
+                    denominator = term_frequency + self.k1 * (
+                        1.0 - self.b + self.b * length_ratio
+                    )
+                    if denominator:
+                        score += query_frequency * inverse_document_frequency * (
+                            term_frequency * (self.k1 + 1.0) / denominator
+                        )
+                if score > 0:
+                    scored.append((score, document))
+
+            scored.sort(key=lambda item: (-item[0], item[1].document_id))
+            results: List[Dict[str, Any]] = []
+            for rank, (score, document) in enumerate(scored[:top_k], start=1):
+                results.append(
+                    {
+                        "document_id": document.document_id,
+                        "rank": rank,
+                        "score": score,
+                        "modality": document.modality,
+                        "safe_metadata": dict(document.safe_metadata),
+                        "snippet": _snippet(
+                            document.anonymized_text,
+                            query_tokens,
+                            self.snippet_length,
+                        ),
+                    }
+                )
+            return results

--- a/python_backend/services/dicom_anonymization.py
+++ b/python_backend/services/dicom_anonymization.py
@@ -103,27 +103,17 @@ def _remove_private_tags(dataset: Any) -> int:
     return removed
 
 
-def anonymize_dicom_metadata(
-    file_bytes: bytes,
-    profile: str = "strict",
-) -> Dict[str, Any]:
-    if pydicom is None:
-        raise DicomAnonymizationError(
-            "DICOM metadata anonymization dependency is not available.",
-            status_code=503,
-        )
-    if not file_bytes:
-        raise DicomAnonymizationError("DICOM file is empty")
-
-    privacy_profile = _normalize_profile(profile)
-
+def _read_dataset(file_bytes: bytes) -> Any:
     try:
-        dataset = pydicom.dcmread(BytesIO(file_bytes), force=False)
+        return pydicom.dcmread(BytesIO(file_bytes), force=False)
     except InvalidDicomError as exc:
         raise DicomAnonymizationError("Invalid DICOM file format") from exc
     except Exception as exc:
         raise DicomAnonymizationError("Invalid DICOM file format") from exc
 
+
+def _anonymize_dataset(dataset: Any, profile: str) -> Dict[str, Any]:
+    privacy_profile = _normalize_profile(profile)
     original_pixel_data = bytes(dataset.PixelData) if "PixelData" in dataset else None
 
     scrubbed = _scrub_dataset(dataset)
@@ -145,3 +135,43 @@ def anonymize_dicom_metadata(
         },
         "pixel_redaction_status": PIXEL_REDACTION_STATUS,
     }
+
+
+def _dataset_to_bytes(dataset: Any) -> bytes:
+    output = BytesIO()
+    dataset.save_as(output, enforce_file_format=True)
+    return output.getvalue()
+
+
+def anonymize_dicom_metadata(
+    file_bytes: bytes,
+    profile: str = "strict",
+) -> Dict[str, Any]:
+    if pydicom is None:
+        raise DicomAnonymizationError(
+            "DICOM metadata anonymization dependency is not available.",
+            status_code=503,
+        )
+    if not file_bytes:
+        raise DicomAnonymizationError("DICOM file is empty")
+
+    dataset = _read_dataset(file_bytes)
+    return _anonymize_dataset(dataset, profile)
+
+
+def anonymize_dicom_file_bytes(
+    file_bytes: bytes,
+    profile: str = "strict",
+) -> Dict[str, Any]:
+    if pydicom is None:
+        raise DicomAnonymizationError(
+            "DICOM metadata anonymization dependency is not available.",
+            status_code=503,
+        )
+    if not file_bytes:
+        raise DicomAnonymizationError("DICOM file is empty")
+
+    dataset = _read_dataset(file_bytes)
+    result = _anonymize_dataset(dataset, profile)
+    result["anonymized_dicom_bytes"] = _dataset_to_bytes(dataset)
+    return result

--- a/python_backend/services/dicom_anonymization.py
+++ b/python_backend/services/dicom_anonymization.py
@@ -1,5 +1,13 @@
+import os
+from datetime import datetime, timedelta
 from io import BytesIO
 from typing import Any, Dict
+
+from services.privacy_profiles import (
+    PrivacyProfileError,
+    get_privacy_profile,
+    validate_privacy_profile,
+)
 
 try:
     import pydicom
@@ -9,8 +17,14 @@ except ImportError:
     InvalidDicomError = Exception
 
 
-SUPPORTED_PROFILES = {"strict", "research"}
 PIXEL_REDACTION_STATUS = "metadata_only"
+TEXT_REDACTION_VALUE = ""
+PERSON_NAME_REDACTION_VALUE = ""
+DATE_REDACTION_VALUE = "19000101"
+TIME_REDACTION_VALUE = "000000"
+AGE_REDACTION_VALUE = "000Y"
+SEX_REDACTION_VALUE = "O"
+STUDY_SALT_ENV_VAR = "BIOBLOCK_STUDY_SALT"
 
 PHI_KEYWORDS = {
     "PatientName",
@@ -44,6 +58,19 @@ PHI_KEYWORDS = {
     "PhysiciansOfRecord",
     "InsurancePlanIdentification",
 }
+TECHNICAL_METADATA_KEYWORDS = {
+    "Modality",
+    "Rows",
+    "Columns",
+    "BitsAllocated",
+    "BitsStored",
+    "PixelSpacing",
+    "SliceThickness",
+    "ManufacturerModelName",
+    "KVP",
+    "RepetitionTime",
+    "EchoTime",
+}
 
 
 class DicomAnonymizationError(ValueError):
@@ -53,38 +80,120 @@ class DicomAnonymizationError(ValueError):
         self.status_code = status_code
 
 
-def _normalize_profile(profile: str) -> str:
-    normalized = (profile or "").strip().lower()
-    if normalized not in SUPPORTED_PROFILES:
-        raise DicomAnonymizationError(
-            "Invalid privacy profile. Supported profiles: strict, research"
-        )
-    return normalized
+def _profile_settings(profile: str) -> tuple[str, Dict[str, Any]]:
+    try:
+        normalized = validate_privacy_profile(profile)
+        return normalized, get_privacy_profile(normalized)
+    except PrivacyProfileError as exc:
+        raise DicomAnonymizationError(exc.detail, status_code=exc.status_code) from exc
 
 
-def _scrub_dataset(dataset: Any) -> Dict[str, Any]:
+def _date_shift_days(dataset: Any) -> int:
+    seed = (
+        os.getenv(STUDY_SALT_ENV_VAR)
+        or str(getattr(dataset, "StudyInstanceUID", ""))
+        or str(getattr(dataset, "SOPInstanceUID", ""))
+        or "bioblock-date-shift"
+    )
+    value = sum((index + 1) * ord(char) for index, char in enumerate(seed))
+    days = value % 731 - 365
+    return days or 17
+
+
+def _shift_dicom_date(value: Any, days: int) -> str:
+    try:
+        shifted = datetime.strptime(str(value), "%Y%m%d") + timedelta(days=days)
+    except (TypeError, ValueError):
+        return DATE_REDACTION_VALUE
+    return shifted.strftime("%Y%m%d")
+
+
+def _generalize_age(value: Any) -> str:
+    match = str(value or "").strip()
+    if len(match) < 4 or not match[:3].isdigit():
+        return AGE_REDACTION_VALUE
+
+    years = int(match[:3])
+    decade = min((years // 10) * 10, 90)
+    return f"{decade:03d}Y"
+
+
+def _safe_patient_sex(value: Any) -> str:
+    normalized = str(value or "").strip().upper()
+    if normalized in {"M", "F", "O"}:
+        return normalized
+    return SEX_REDACTION_VALUE
+
+
+def _redaction_value_for(element: Any, settings: Dict[str, Any], date_shift_days: int) -> tuple[str, str]:
+    keyword = element.keyword
+
+    if element.VR == "PN":
+        return PERSON_NAME_REDACTION_VALUE, "redacted"
+    if element.VR == "DA" or keyword.endswith("Date"):
+        if settings["date_strategy"] == "shift":
+            return _shift_dicom_date(element.value, date_shift_days), "shifted"
+        return DATE_REDACTION_VALUE, "redacted"
+    if element.VR == "TM" or keyword.endswith("Time"):
+        return TIME_REDACTION_VALUE, "redacted"
+    if element.VR == "AS" or keyword.endswith("Age"):
+        if settings["allow_generalized_demographics"]:
+            return _generalize_age(element.value), "generalized"
+        return AGE_REDACTION_VALUE, "redacted"
+    if keyword == "PatientSex":
+        if settings["allow_generalized_demographics"]:
+            return _safe_patient_sex(element.value), "generalized"
+        return SEX_REDACTION_VALUE, "redacted"
+
+    return TEXT_REDACTION_VALUE, "redacted"
+
+
+def _scrub_dataset(dataset: Any, settings: Dict[str, Any], date_shift_days: int) -> Dict[str, Any]:
     scrubbed_elements = 0
+    shifted_dates = 0
+    generalized_demographics = 0
     field_counts: Dict[str, int] = {}
 
     for element in dataset:
         if element.VR == "SQ":
             for item in element.value:
-                nested = _scrub_dataset(item)
+                nested = _scrub_dataset(item, settings, date_shift_days)
                 scrubbed_elements += nested["scrubbed_elements"]
+                shifted_dates += nested["dates_shifted"]
+                generalized_demographics += nested["generalized_demographics"]
                 for keyword, count in nested["scrubbed_field_counts"].items():
                     field_counts[keyword] = field_counts.get(keyword, 0) + count
             continue
 
         keyword = element.keyword
         if keyword in PHI_KEYWORDS:
-            element.value = ""
+            replacement, action = _redaction_value_for(
+                element,
+                settings,
+                date_shift_days,
+            )
+            element.value = replacement
             scrubbed_elements += 1
             field_counts[keyword] = field_counts.get(keyword, 0) + 1
+            if action == "shifted":
+                shifted_dates += 1
+            elif action == "generalized":
+                generalized_demographics += 1
 
     return {
         "scrubbed_elements": scrubbed_elements,
         "scrubbed_field_counts": field_counts,
+        "dates_shifted": shifted_dates,
+        "generalized_demographics": generalized_demographics,
     }
+
+
+def _mark_patient_identity_removed(dataset: Any, profile: str, settings: Dict[str, Any]) -> None:
+    dataset.PatientIdentityRemoved = "YES"
+    private_policy = "rm-private" if settings["remove_dicom_private_tags"] else "keep-private"
+    dataset.DeidentificationMethod = (
+        f"BioBlock {profile}; dates={settings['date_strategy']}; {private_policy}"
+    )
 
 
 def _remove_private_tags(dataset: Any) -> int:
@@ -103,6 +212,41 @@ def _remove_private_tags(dataset: Any) -> int:
     return removed
 
 
+
+def _technical_metadata_present(dataset: Any) -> list[str]:
+    return sorted(
+        keyword
+        for keyword in TECHNICAL_METADATA_KEYWORDS
+        if hasattr(dataset, keyword)
+    )
+
+
+def _anonymize_dataset(dataset: Any, profile: str) -> Dict[str, Any]:
+    privacy_profile, settings = _profile_settings(profile)
+    original_pixel_data = bytes(dataset.PixelData) if "PixelData" in dataset else None
+    technical_metadata_preserved = _technical_metadata_present(dataset)
+
+    scrubbed = _scrub_dataset(dataset, settings, _date_shift_days(dataset))
+    private_tags_removed = 0
+    if settings["remove_dicom_private_tags"]:
+        private_tags_removed = _remove_private_tags(dataset)
+
+    current_pixel_data = bytes(dataset.PixelData) if "PixelData" in dataset else None
+    _mark_patient_identity_removed(dataset, privacy_profile, settings)
+
+    return {
+        "profile": privacy_profile,
+        "settings": settings,
+        "scrubbed": scrubbed,
+        "private_tags_removed": private_tags_removed,
+        "pixel_data_present": original_pixel_data is not None,
+        "pixel_data_preserved": original_pixel_data == current_pixel_data,
+        "technical_metadata_preserved": technical_metadata_preserved
+        if settings["preserve_dicom_technical_metadata"]
+        else [],
+    }
+
+
 def _read_dataset(file_bytes: bytes) -> Any:
     try:
         return pydicom.dcmread(BytesIO(file_bytes), force=False)
@@ -112,28 +256,24 @@ def _read_dataset(file_bytes: bytes) -> Any:
         raise DicomAnonymizationError("Invalid DICOM file format") from exc
 
 
-def _anonymize_dataset(dataset: Any, profile: str) -> Dict[str, Any]:
-    privacy_profile = _normalize_profile(profile)
-    original_pixel_data = bytes(dataset.PixelData) if "PixelData" in dataset else None
-
-    scrubbed = _scrub_dataset(dataset)
-    private_tags_removed = 0
-    if privacy_profile == "strict":
-        private_tags_removed = _remove_private_tags(dataset)
-
-    current_pixel_data = bytes(dataset.PixelData) if "PixelData" in dataset else None
-
+def _metadata_summary(anonymized: Dict[str, Any]) -> Dict[str, Any]:
+    scrubbed = anonymized["scrubbed"]
+    settings = anonymized["settings"]
     return {
-        "anonymization_status": "completed",
-        "metadata_summary": {
-            "profile": privacy_profile,
-            "fields_scrubbed": scrubbed["scrubbed_elements"],
-            "scrubbed_field_counts": scrubbed["scrubbed_field_counts"],
-            "private_tags_removed": private_tags_removed,
-            "pixel_data_present": original_pixel_data is not None,
-            "pixel_data_preserved": original_pixel_data == current_pixel_data,
-        },
-        "pixel_redaction_status": PIXEL_REDACTION_STATUS,
+        "profile": anonymized["profile"],
+        "date_strategy": settings["date_strategy"],
+        "fields_scrubbed": scrubbed["scrubbed_elements"],
+        "scrubbed_field_counts": scrubbed["scrubbed_field_counts"],
+        "dates_shifted": scrubbed["dates_shifted"],
+        "generalized_demographics": scrubbed["generalized_demographics"],
+        "private_tags_removed": anonymized["private_tags_removed"],
+        "remove_dicom_private_tags": settings["remove_dicom_private_tags"],
+        "preserve_dicom_technical_metadata": settings[
+            "preserve_dicom_technical_metadata"
+        ],
+        "technical_metadata_preserved": anonymized["technical_metadata_preserved"],
+        "pixel_data_present": anonymized["pixel_data_present"],
+        "pixel_data_preserved": anonymized["pixel_data_preserved"],
     }
 
 
@@ -156,7 +296,13 @@ def anonymize_dicom_metadata(
         raise DicomAnonymizationError("DICOM file is empty")
 
     dataset = _read_dataset(file_bytes)
-    return _anonymize_dataset(dataset, profile)
+    anonymized = _anonymize_dataset(dataset, profile)
+
+    return {
+        "anonymization_status": "completed",
+        "metadata_summary": _metadata_summary(anonymized),
+        "pixel_redaction_status": PIXEL_REDACTION_STATUS,
+    }
 
 
 def anonymize_dicom_file_bytes(
@@ -172,6 +318,13 @@ def anonymize_dicom_file_bytes(
         raise DicomAnonymizationError("DICOM file is empty")
 
     dataset = _read_dataset(file_bytes)
-    result = _anonymize_dataset(dataset, profile)
-    result["anonymized_dicom_bytes"] = _dataset_to_bytes(dataset)
-    return result
+    anonymized = _anonymize_dataset(dataset, profile)
+
+    return {
+        "anonymization_status": "completed",
+        "anonymized_dicom_bytes": _dataset_to_bytes(dataset),
+        "metadata_summary": _metadata_summary(anonymized),
+        "pixel_redaction_status": PIXEL_REDACTION_STATUS,
+    }
+
+

--- a/python_backend/services/dicom_anonymization.py
+++ b/python_backend/services/dicom_anonymization.py
@@ -10,7 +10,7 @@ except ImportError:
 
 
 SUPPORTED_PROFILES = {"strict", "research"}
-PIXEL_REDACTION_STATUS = "not_started_week4"
+PIXEL_REDACTION_STATUS = "metadata_only"
 
 PHI_KEYWORDS = {
     "PatientName",

--- a/python_backend/services/dicom_anonymization.py
+++ b/python_backend/services/dicom_anonymization.py
@@ -1,0 +1,147 @@
+from io import BytesIO
+from typing import Any, Dict
+
+try:
+    import pydicom
+    from pydicom.errors import InvalidDicomError
+except ImportError:
+    pydicom = None
+    InvalidDicomError = Exception
+
+
+SUPPORTED_PROFILES = {"strict", "research"}
+PIXEL_REDACTION_STATUS = "not_started_week4"
+
+PHI_KEYWORDS = {
+    "PatientName",
+    "PatientID",
+    "PatientBirthDate",
+    "PatientBirthTime",
+    "PatientSex",
+    "PatientAge",
+    "OtherPatientIDs",
+    "OtherPatientNames",
+    "PatientAddress",
+    "PatientTelephoneNumbers",
+    "PatientMotherBirthName",
+    "AccessionNumber",
+    "StudyID",
+    "StudyDate",
+    "StudyTime",
+    "SeriesDate",
+    "SeriesTime",
+    "AcquisitionDate",
+    "AcquisitionTime",
+    "ContentDate",
+    "ContentTime",
+    "InstanceCreationDate",
+    "InstanceCreationTime",
+    "InstitutionName",
+    "InstitutionAddress",
+    "ReferringPhysicianName",
+    "PerformingPhysicianName",
+    "OperatorsName",
+    "PhysiciansOfRecord",
+    "InsurancePlanIdentification",
+}
+
+
+class DicomAnonymizationError(ValueError):
+    def __init__(self, detail: str, status_code: int = 400):
+        super().__init__(detail)
+        self.detail = detail
+        self.status_code = status_code
+
+
+def _normalize_profile(profile: str) -> str:
+    normalized = (profile or "").strip().lower()
+    if normalized not in SUPPORTED_PROFILES:
+        raise DicomAnonymizationError(
+            "Invalid privacy profile. Supported profiles: strict, research"
+        )
+    return normalized
+
+
+def _scrub_dataset(dataset: Any) -> Dict[str, Any]:
+    scrubbed_elements = 0
+    field_counts: Dict[str, int] = {}
+
+    for element in dataset:
+        if element.VR == "SQ":
+            for item in element.value:
+                nested = _scrub_dataset(item)
+                scrubbed_elements += nested["scrubbed_elements"]
+                for keyword, count in nested["scrubbed_field_counts"].items():
+                    field_counts[keyword] = field_counts.get(keyword, 0) + count
+            continue
+
+        keyword = element.keyword
+        if keyword in PHI_KEYWORDS:
+            element.value = ""
+            scrubbed_elements += 1
+            field_counts[keyword] = field_counts.get(keyword, 0) + 1
+
+    return {
+        "scrubbed_elements": scrubbed_elements,
+        "scrubbed_field_counts": field_counts,
+    }
+
+
+def _remove_private_tags(dataset: Any) -> int:
+    removed = 0
+
+    for element in list(dataset):
+        if element.tag.is_private:
+            del dataset[element.tag]
+            removed += 1
+            continue
+
+        if element.VR == "SQ":
+            for item in element.value:
+                removed += _remove_private_tags(item)
+
+    return removed
+
+
+def anonymize_dicom_metadata(
+    file_bytes: bytes,
+    profile: str = "strict",
+) -> Dict[str, Any]:
+    if pydicom is None:
+        raise DicomAnonymizationError(
+            "DICOM metadata anonymization dependency is not available.",
+            status_code=503,
+        )
+    if not file_bytes:
+        raise DicomAnonymizationError("DICOM file is empty")
+
+    privacy_profile = _normalize_profile(profile)
+
+    try:
+        dataset = pydicom.dcmread(BytesIO(file_bytes), force=False)
+    except InvalidDicomError as exc:
+        raise DicomAnonymizationError("Invalid DICOM file format") from exc
+    except Exception as exc:
+        raise DicomAnonymizationError("Invalid DICOM file format") from exc
+
+    original_pixel_data = bytes(dataset.PixelData) if "PixelData" in dataset else None
+
+    scrubbed = _scrub_dataset(dataset)
+    private_tags_removed = 0
+    if privacy_profile == "strict":
+        private_tags_removed = _remove_private_tags(dataset)
+
+    current_pixel_data = bytes(dataset.PixelData) if "PixelData" in dataset else None
+
+    return {
+        "anonymization_status": "completed",
+        "metadata_summary": {
+            "profile": privacy_profile,
+            "fields_scrubbed": scrubbed["scrubbed_elements"],
+            "scrubbed_field_counts": scrubbed["scrubbed_field_counts"],
+            "private_tags_removed": private_tags_removed,
+            "pixel_data_present": original_pixel_data is not None,
+            "pixel_data_preserved": original_pixel_data == current_pixel_data,
+        },
+        "pixel_redaction_status": PIXEL_REDACTION_STATUS,
+    }

--- a/python_backend/services/ingestion.py
+++ b/python_backend/services/ingestion.py
@@ -12,6 +12,8 @@ from services.nifti_anonymization import (
     NiftiAnonymizationError,
     anonymize_nifti_metadata,
 )
+from services.ocr_redaction import redact_dicom_pixels, safe_ocr_response
+from services.wsi_tiling import scan_wsi_bytes
 
 SUPPORTED_PROFILES = {"strict", "research"}
 SUPPORTED_MODALITIES = {"csv", "text", "dicom", "nifti", "wsi"}
@@ -137,17 +139,21 @@ def anonymize_text(
 
 def anonymize_dicom(file_content: bytes, profile: str) -> Dict[str, Any]:
     try:
-        result = anonymize_dicom_metadata(file_content, profile=profile)
+        metadata_result = anonymize_dicom_metadata(file_content, profile=profile)
     except DicomAnonymizationError as exc:
         raise IngestionError(exc.detail, status_code=exc.status_code) from exc
+
+    pixel_result = safe_ocr_response(
+        redact_dicom_pixels(file_content, profile=profile)
+    )
 
     return {
         "handler": "anonymize_dicom",
         "routing_status": "handler_selected",
-        "anonymization_status": result["anonymization_status"],
-        "message": "DICOM metadata anonymization completed.",
-        "metadata_summary": result["metadata_summary"],
-        "pixel_redaction_status": result["pixel_redaction_status"],
+        "anonymization_status": metadata_result["anonymization_status"],
+        "message": "DICOM metadata anonymization and pixel redaction completed.",
+        "metadata_summary": metadata_result["metadata_summary"],
+        **pixel_result,
     }
 
 
@@ -174,8 +180,25 @@ def anonymize_nifti(
     }
 
 
-def anonymize_wsi() -> Dict[str, str]:
-    return _placeholder_result("anonymize_wsi")
+def anonymize_wsi(
+    file_content: bytes,
+    filename: str,
+    profile: str,
+) -> Dict[str, Any]:
+    result = scan_wsi_bytes(file_content, filename=filename)
+    anonymization_status = (
+        "redaction_plan_ready"
+        if result["pixel_redaction_status"] == "redaction_plan_ready"
+        else "pending"
+    )
+
+    return {
+        "handler": "anonymize_wsi",
+        "routing_status": "handler_selected",
+        "anonymization_status": anonymization_status,
+        "message": "WSI priority OCR tiling evaluated.",
+        **result,
+    }
 
 
 HANDLER_REGISTRY: Dict[str, Callable[..., Dict[str, Any]]] = {
@@ -228,6 +251,13 @@ def route_for_ingestion(
                 status_code=500,
             )
         handler_result = handler(file_content, safe_name, privacy_profile)
+    elif modality == "wsi":
+        if file_content is None:
+            raise IngestionError(
+                "WSI content was not provided for OCR scan planning",
+                status_code=500,
+            )
+        handler_result = handler(file_content, safe_name, privacy_profile)
     else:
         handler_result = handler()
 
@@ -255,5 +285,20 @@ def route_for_ingestion(
         response["metadata_summary"] = handler_result["metadata_summary"]
     if "pixel_redaction_status" in handler_result:
         response["pixel_redaction_status"] = handler_result["pixel_redaction_status"]
+    for safe_key in (
+        "ocr_boxes_detected",
+        "boxes_redacted",
+        "frames_processed",
+        "scanned_regions",
+        "ocr_engine_status",
+        "tiles_scanned",
+        "priority_regions_scanned",
+        "image_dimensions",
+        "tile_size",
+        "wsi_rewrite_status",
+        "redaction_plan_boxes",
+    ):
+        if safe_key in handler_result:
+            response[safe_key] = handler_result[safe_key]
 
     return response

--- a/python_backend/services/ingestion.py
+++ b/python_backend/services/ingestion.py
@@ -4,6 +4,14 @@ from services.text_anonymization import (
     TextAnonymizationError,
     anonymize_clinical_text,
 )
+from services.dicom_anonymization import (
+    DicomAnonymizationError,
+    anonymize_dicom_metadata,
+)
+from services.nifti_anonymization import (
+    NiftiAnonymizationError,
+    anonymize_nifti_metadata,
+)
 
 SUPPORTED_PROFILES = {"strict", "research"}
 SUPPORTED_MODALITIES = {"csv", "text", "dicom", "nifti", "wsi"}
@@ -127,12 +135,43 @@ def anonymize_text(
     }
 
 
-def anonymize_dicom() -> Dict[str, str]:
-    return _placeholder_result("anonymize_dicom")
+def anonymize_dicom(file_content: bytes, profile: str) -> Dict[str, Any]:
+    try:
+        result = anonymize_dicom_metadata(file_content, profile=profile)
+    except DicomAnonymizationError as exc:
+        raise IngestionError(exc.detail, status_code=exc.status_code) from exc
+
+    return {
+        "handler": "anonymize_dicom",
+        "routing_status": "handler_selected",
+        "anonymization_status": result["anonymization_status"],
+        "message": "DICOM metadata anonymization completed.",
+        "metadata_summary": result["metadata_summary"],
+        "pixel_redaction_status": result["pixel_redaction_status"],
+    }
 
 
-def anonymize_nifti() -> Dict[str, str]:
-    return _placeholder_result("anonymize_nifti")
+def anonymize_nifti(
+    file_content: bytes,
+    filename: str,
+    profile: str,
+) -> Dict[str, Any]:
+    try:
+        result = anonymize_nifti_metadata(
+            file_content,
+            filename=filename,
+            profile=profile,
+        )
+    except NiftiAnonymizationError as exc:
+        raise IngestionError(exc.detail, status_code=exc.status_code) from exc
+
+    return {
+        "handler": "anonymize_nifti",
+        "routing_status": "handler_selected",
+        "anonymization_status": result["anonymization_status"],
+        "message": "NIfTI metadata anonymization completed.",
+        "metadata_summary": result["metadata_summary"],
+    }
 
 
 def anonymize_wsi() -> Dict[str, str]:
@@ -154,6 +193,7 @@ def route_for_ingestion(
     header: bytes,
     profile: str,
     text_content: Optional[bytes] = None,
+    file_content: Optional[bytes] = None,
     study_salt: Optional[str] = None,
 ) -> Dict[str, Any]:
     safe_name = _safe_filename(filename)
@@ -174,6 +214,20 @@ def route_for_ingestion(
                 status_code=500,
             )
         handler_result = handler(text_content, privacy_profile, study_salt)
+    elif modality == "dicom":
+        if file_content is None:
+            raise IngestionError(
+                "DICOM content was not provided for anonymization",
+                status_code=500,
+            )
+        handler_result = handler(file_content, privacy_profile)
+    elif modality == "nifti":
+        if file_content is None:
+            raise IngestionError(
+                "NIfTI content was not provided for anonymization",
+                status_code=500,
+            )
+        handler_result = handler(file_content, safe_name, privacy_profile)
     else:
         handler_result = handler()
 
@@ -197,5 +251,9 @@ def route_for_ingestion(
         response["anonymized_text"] = handler_result["anonymized_text"]
     if "detected_entities" in handler_result:
         response["detected_entities"] = handler_result["detected_entities"]
+    if "metadata_summary" in handler_result:
+        response["metadata_summary"] = handler_result["metadata_summary"]
+    if "pixel_redaction_status" in handler_result:
+        response["pixel_redaction_status"] = handler_result["pixel_redaction_status"]
 
     return response

--- a/python_backend/services/ingestion.py
+++ b/python_backend/services/ingestion.py
@@ -6,7 +6,7 @@ from services.text_anonymization import (
 )
 from services.dicom_anonymization import (
     DicomAnonymizationError,
-    anonymize_dicom_metadata,
+    anonymize_dicom_file_bytes,
 )
 from services.nifti_anonymization import (
     NiftiAnonymizationError,
@@ -139,12 +139,13 @@ def anonymize_text(
 
 def anonymize_dicom(file_content: bytes, profile: str) -> Dict[str, Any]:
     try:
-        metadata_result = anonymize_dicom_metadata(file_content, profile=profile)
+        metadata_result = anonymize_dicom_file_bytes(file_content, profile=profile)
     except DicomAnonymizationError as exc:
         raise IngestionError(exc.detail, status_code=exc.status_code) from exc
 
+    metadata_scrubbed_content = metadata_result["anonymized_dicom_bytes"]
     pixel_result = safe_ocr_response(
-        redact_dicom_pixels(file_content, profile=profile)
+        redact_dicom_pixels(metadata_scrubbed_content, profile=profile)
     )
 
     return {

--- a/python_backend/services/ingestion.py
+++ b/python_backend/services/ingestion.py
@@ -13,6 +13,10 @@ from services.nifti_anonymization import (
     anonymize_nifti_metadata,
 )
 from services.ocr_redaction import redact_dicom_pixels, safe_ocr_response
+from services.tabular_anonymization import (
+    TabularAnonymizationError,
+    anonymize_tabular_csv,
+)
 from services.wsi_tiling import scan_wsi_bytes
 from services.privacy_profiles import (
     PrivacyProfileError,
@@ -23,6 +27,28 @@ SUPPORTED_PROFILES = {"strict", "research"}
 SUPPORTED_MODALITIES = {"csv", "text", "dicom", "nifti", "wsi"}
 HEADER_READ_LIMIT = 4096
 TEXT_READ_LIMIT_BYTES = 256 * 1024
+TABULAR_SUMMARY_KEYS = (
+    "rows_in",
+    "rows_out",
+    "k",
+    "l",
+    "direct_identifiers_removed",
+    "precise_geography_columns_removed",
+    "columns_removed",
+    "quasi_identifiers_used",
+    "sensitive_column",
+    "output_columns",
+    "safe_harbor_report",
+    "equivalence_classes",
+    "min_group_size",
+    "k_anonymity_satisfied",
+    "l_diversity_satisfied",
+    "generalized_cells_count",
+    "suppressed_cells_count",
+    "generalization_rate",
+    "suppression_rate",
+    "warnings",
+)
 
 
 class IngestionError(ValueError):
@@ -106,8 +132,33 @@ def _placeholder_result(handler_name: str) -> Dict[str, str]:
     }
 
 
-def anonymize_csv() -> Dict[str, str]:
-    return _placeholder_result("anonymize_csv")
+def anonymize_csv(
+    file_content: bytes,
+    k: int = 5,
+    l: int = 2,
+    direct_identifiers: Optional[list[str]] = None,
+    quasi_identifiers: Optional[list[str]] = None,
+    sensitive_column: Optional[str] = None,
+    safe_harbor_mappings: Optional[dict[str, list[str]]] = None,
+) -> Dict[str, Any]:
+    try:
+        result = anonymize_tabular_csv(
+            file_content,
+            k=k,
+            l=l,
+            direct_identifiers=direct_identifiers,
+            quasi_identifiers=quasi_identifiers,
+            sensitive_column=sensitive_column,
+            safe_harbor_mappings=safe_harbor_mappings,
+        )
+    except TabularAnonymizationError as exc:
+        raise IngestionError(exc.detail, status_code=exc.status_code) from exc
+    return {
+        "handler": "anonymize_csv",
+        "routing_status": "handler_selected",
+        "message": "CSV tabular anonymization completed.",
+        **result,
+    }
 
 
 def anonymize_text(
@@ -223,6 +274,12 @@ def route_for_ingestion(
     text_content: Optional[bytes] = None,
     file_content: Optional[bytes] = None,
     study_salt: Optional[str] = None,
+    csv_k: int = 5,
+    csv_l: int = 2,
+    csv_direct_identifiers: Optional[list[str]] = None,
+    csv_quasi_identifiers: Optional[list[str]] = None,
+    csv_sensitive_column: Optional[str] = None,
+    csv_safe_harbor_mappings: Optional[dict[str, list[str]]] = None,
 ) -> Dict[str, Any]:
     safe_name = _safe_filename(filename)
     privacy_profile = validate_privacy_profile(profile)
@@ -235,7 +292,22 @@ def route_for_ingestion(
             status_code=500,
         )
 
-    if modality == "text":
+    if modality == "csv":
+        if file_content is None:
+            raise IngestionError(
+                "CSV content was not provided for anonymization",
+                status_code=500,
+            )
+        handler_result = handler(
+            file_content,
+            csv_k,
+            csv_l,
+            csv_direct_identifiers,
+            csv_quasi_identifiers,
+            csv_sensitive_column,
+            csv_safe_harbor_mappings,
+        )
+    elif modality == "text":
         if text_content is None:
             raise IngestionError(
                 "Text content was not provided for anonymization",
@@ -292,6 +364,12 @@ def route_for_ingestion(
         response["detected_entities"] = handler_result["detected_entities"]
     if "metadata_summary" in handler_result:
         response["metadata_summary"] = handler_result["metadata_summary"]
+    if "rows_in" in handler_result:
+        response["tabular_summary"] = {
+            key: handler_result[key]
+            for key in TABULAR_SUMMARY_KEYS
+            if key in handler_result
+        }
     if "pixel_redaction_status" in handler_result:
         response["pixel_redaction_status"] = handler_result["pixel_redaction_status"]
     for safe_key in (

--- a/python_backend/services/ingestion.py
+++ b/python_backend/services/ingestion.py
@@ -14,6 +14,10 @@ from services.nifti_anonymization import (
 )
 from services.ocr_redaction import redact_dicom_pixels, safe_ocr_response
 from services.wsi_tiling import scan_wsi_bytes
+from services.privacy_profiles import (
+    PrivacyProfileError,
+    validate_privacy_profile as validate_config_privacy_profile,
+)
 
 SUPPORTED_PROFILES = {"strict", "research"}
 SUPPORTED_MODALITIES = {"csv", "text", "dicom", "nifti", "wsi"}
@@ -29,12 +33,10 @@ class IngestionError(ValueError):
 
 
 def validate_privacy_profile(profile: str) -> str:
-    normalized = (profile or "").strip().lower()
-    if normalized not in SUPPORTED_PROFILES:
-        raise IngestionError(
-            "Invalid privacy profile. Supported profiles: strict, research"
-        )
-    return normalized
+    try:
+        return validate_config_privacy_profile(profile)
+    except PrivacyProfileError as exc:
+        raise IngestionError(exc.detail, status_code=exc.status_code) from exc
 
 
 def _safe_filename(filename: str) -> str:
@@ -133,6 +135,8 @@ def anonymize_text(
         "anonymization_status": result["anonymization_status"],
         "message": "Text anonymization completed.",
         "anonymized_text": result["anonymized_text"],
+        "date_strategy": result["date_strategy"],
+        "text_identifier_strategy": result["text_identifier_strategy"],
         "detected_entities": result["detected_entities"],
     }
 
@@ -280,6 +284,10 @@ def route_for_ingestion(
     }
     if "anonymized_text" in handler_result:
         response["anonymized_text"] = handler_result["anonymized_text"]
+    if "date_strategy" in handler_result:
+        response["date_strategy"] = handler_result["date_strategy"]
+    if "text_identifier_strategy" in handler_result:
+        response["text_identifier_strategy"] = handler_result["text_identifier_strategy"]
     if "detected_entities" in handler_result:
         response["detected_entities"] = handler_result["detected_entities"]
     if "metadata_summary" in handler_result:
@@ -292,6 +300,7 @@ def route_for_ingestion(
         "frames_processed",
         "scanned_regions",
         "ocr_engine_status",
+        "ocr_confidence_threshold",
         "tiles_scanned",
         "priority_regions_scanned",
         "image_dimensions",
@@ -303,3 +312,4 @@ def route_for_ingestion(
             response[safe_key] = handler_result[safe_key]
 
     return response
+

--- a/python_backend/services/nifti_anonymization.py
+++ b/python_backend/services/nifti_anonymization.py
@@ -4,13 +4,18 @@ from typing import Any, Dict
 
 import numpy as np
 
+from services.privacy_profiles import (
+    PrivacyProfileError,
+    get_privacy_profile,
+    validate_privacy_profile,
+)
+
 try:
     import nibabel as nib
 except ImportError:
     nib = None
 
 
-SUPPORTED_PROFILES = {"strict", "research"}
 SUPPORTED_EXTENSIONS = {".nii", ".nii.gz"}
 TEXT_HEADER_FIELDS = ("descrip", "aux_file", "intent_name", "db_name")
 
@@ -22,13 +27,12 @@ class NiftiAnonymizationError(ValueError):
         self.status_code = status_code
 
 
-def _normalize_profile(profile: str) -> str:
-    normalized = (profile or "").strip().lower()
-    if normalized not in SUPPORTED_PROFILES:
-        raise NiftiAnonymizationError(
-            "Invalid privacy profile. Supported profiles: strict, research"
-        )
-    return normalized
+def _profile_settings(profile: str) -> tuple[str, Dict[str, Any]]:
+    try:
+        normalized = validate_privacy_profile(profile)
+        return normalized, get_privacy_profile(normalized)
+    except PrivacyProfileError as exc:
+        raise NiftiAnonymizationError(exc.detail, status_code=exc.status_code) from exc
 
 
 def _nifti_suffix(filename: str) -> str:
@@ -100,7 +104,7 @@ def anonymize_nifti_metadata(
     if not file_bytes:
         raise NiftiAnonymizationError("NIfTI file is empty")
 
-    privacy_profile = _normalize_profile(profile)
+    privacy_profile, settings = _profile_settings(profile)
     suffix = _nifti_suffix(filename)
 
     temp_path = None
@@ -113,12 +117,13 @@ def anonymize_nifti_metadata(
         original_shape = tuple(int(dimension) for dimension in image.shape)
         original_affine = np.array(image.affine, copy=True)
         original_dtype = str(image.get_data_dtype())
+        original_extensions = len(image.header.extensions)
 
         scrubbed_header = image.header.copy()
         scrubbed = _scrub_header_fields(scrubbed_header)
 
         extensions_removed = 0
-        if privacy_profile == "strict":
+        if settings["remove_nifti_extensions"]:
             extensions_removed = len(scrubbed_header.extensions)
             scrubbed_header.extensions.clear()
 
@@ -132,9 +137,12 @@ def anonymize_nifti_metadata(
             "anonymization_status": "completed",
             "metadata_summary": {
                 "profile": privacy_profile,
+                "remove_nifti_extensions": settings["remove_nifti_extensions"],
                 "fields_scrubbed": scrubbed["fields_scrubbed"],
                 "scrubbed_field_counts": scrubbed["scrubbed_field_counts"],
+                "extensions_present_before": original_extensions,
                 "extensions_removed": extensions_removed,
+                "extensions_preserved": original_extensions - extensions_removed,
                 "image_shape": list(original_shape),
                 "shape_preserved": tuple(scrubbed_image.shape) == original_shape,
                 "affine_preserved": np.array_equal(
@@ -145,6 +153,12 @@ def anonymize_nifti_metadata(
                     str(scrubbed_image.get_data_dtype()) == original_dtype
                 ),
                 "image_data_preserved": True,
+                "safe_technical_metadata_preserved": [
+                    "shape",
+                    "affine",
+                    "datatype",
+                    "image_data",
+                ],
             },
         }
     finally:

--- a/python_backend/services/nifti_anonymization.py
+++ b/python_backend/services/nifti_anonymization.py
@@ -1,0 +1,152 @@
+import os
+import tempfile
+from typing import Any, Dict
+
+import numpy as np
+
+try:
+    import nibabel as nib
+except ImportError:
+    nib = None
+
+
+SUPPORTED_PROFILES = {"strict", "research"}
+SUPPORTED_EXTENSIONS = {".nii", ".nii.gz"}
+TEXT_HEADER_FIELDS = ("descrip", "aux_file", "intent_name", "db_name")
+
+
+class NiftiAnonymizationError(ValueError):
+    def __init__(self, detail: str, status_code: int = 400):
+        super().__init__(detail)
+        self.detail = detail
+        self.status_code = status_code
+
+
+def _normalize_profile(profile: str) -> str:
+    normalized = (profile or "").strip().lower()
+    if normalized not in SUPPORTED_PROFILES:
+        raise NiftiAnonymizationError(
+            "Invalid privacy profile. Supported profiles: strict, research"
+        )
+    return normalized
+
+
+def _nifti_suffix(filename: str) -> str:
+    lower_name = (filename or "").strip().lower()
+    if lower_name.endswith(".nii.gz"):
+        return ".nii.gz"
+    if lower_name.endswith(".nii"):
+        return ".nii"
+    raise NiftiAnonymizationError("NIfTI uploads must use .nii or .nii.gz")
+
+
+def _header_value_has_text(value: Any) -> bool:
+    if hasattr(value, "tobytes"):
+        raw = value.tobytes()
+    elif isinstance(value, bytes):
+        raw = value
+    else:
+        raw = str(value).encode("utf-8", errors="ignore")
+
+    return bool(raw.replace(b"\x00", b"").strip())
+
+
+def _scrub_header_fields(header: Any) -> Dict[str, Any]:
+    field_counts: Dict[str, int] = {}
+
+    for field_name in TEXT_HEADER_FIELDS:
+        if field_name not in header:
+            continue
+
+        if _header_value_has_text(header[field_name]):
+            field_counts[field_name] = 1
+        header[field_name] = b""
+
+    return {
+        "fields_scrubbed": sum(field_counts.values()),
+        "scrubbed_field_counts": field_counts,
+    }
+
+
+def _load_nifti_from_bytes(file_bytes: bytes, suffix: str):
+    temp_path = None
+    temp_file = tempfile.NamedTemporaryFile(
+        suffix=suffix,
+        prefix="bioblock_nifti_",
+        delete=False,
+    )
+    try:
+        temp_path = temp_file.name
+        temp_file.write(file_bytes)
+        temp_file.close()
+        return nib.load(temp_path), temp_path
+    except Exception:
+        temp_file.close()
+        if temp_path and os.path.exists(temp_path):
+            os.unlink(temp_path)
+        raise
+
+
+def anonymize_nifti_metadata(
+    file_bytes: bytes,
+    filename: str,
+    profile: str = "strict",
+) -> Dict[str, Any]:
+    if nib is None:
+        raise NiftiAnonymizationError(
+            "NIfTI metadata anonymization dependency is not available.",
+            status_code=503,
+        )
+    if not file_bytes:
+        raise NiftiAnonymizationError("NIfTI file is empty")
+
+    privacy_profile = _normalize_profile(profile)
+    suffix = _nifti_suffix(filename)
+
+    temp_path = None
+    try:
+        image, temp_path = _load_nifti_from_bytes(file_bytes, suffix)
+    except Exception as exc:
+        raise NiftiAnonymizationError("Invalid NIfTI file format") from exc
+
+    try:
+        original_shape = tuple(int(dimension) for dimension in image.shape)
+        original_affine = np.array(image.affine, copy=True)
+        original_dtype = str(image.get_data_dtype())
+
+        scrubbed_header = image.header.copy()
+        scrubbed = _scrub_header_fields(scrubbed_header)
+
+        extensions_removed = 0
+        if privacy_profile == "strict":
+            extensions_removed = len(scrubbed_header.extensions)
+            scrubbed_header.extensions.clear()
+
+        scrubbed_image = nib.Nifti1Image(
+            image.dataobj,
+            image.affine.copy(),
+            header=scrubbed_header,
+        )
+
+        return {
+            "anonymization_status": "completed",
+            "metadata_summary": {
+                "profile": privacy_profile,
+                "fields_scrubbed": scrubbed["fields_scrubbed"],
+                "scrubbed_field_counts": scrubbed["scrubbed_field_counts"],
+                "extensions_removed": extensions_removed,
+                "image_shape": list(original_shape),
+                "shape_preserved": tuple(scrubbed_image.shape) == original_shape,
+                "affine_preserved": np.array_equal(
+                    scrubbed_image.affine,
+                    original_affine,
+                ),
+                "datatype_preserved": (
+                    str(scrubbed_image.get_data_dtype()) == original_dtype
+                ),
+                "image_data_preserved": True,
+            },
+        }
+    finally:
+        if temp_path and os.path.exists(temp_path):
+            os.unlink(temp_path)

--- a/python_backend/services/ocr_redaction.py
+++ b/python_backend/services/ocr_redaction.py
@@ -9,6 +9,8 @@ from typing import Any, Dict, Iterable, List, Optional, Protocol, Sequence, Tupl
 import numpy as np
 from PIL import Image, ImageDraw
 
+from services.privacy_profiles import PrivacyProfileError, get_privacy_profile
+
 try:
     import pydicom
     from pydicom.errors import InvalidDicomError
@@ -234,7 +236,7 @@ def redact_dicom_pixels(
     file_bytes: bytes,
     profile: str = "strict",
     ocr_backend: Optional[OCRBackend] = None,
-    min_confidence: float = DEFAULT_MIN_CONFIDENCE,
+    min_confidence: Optional[float] = None,
     include_sanitized_bytes: bool = True,
 ) -> Dict[str, Any]:
     if pydicom is None:
@@ -249,6 +251,21 @@ def redact_dicom_pixels(
             ocr_engine_status="not_applicable",
             include_sanitized_bytes=include_sanitized_bytes,
         )
+
+    try:
+        profile_settings = get_privacy_profile(profile)
+    except PrivacyProfileError:
+        return _dicom_result(
+            pixel_redaction_status="invalid_profile",
+            ocr_engine_status="not_applicable",
+            include_sanitized_bytes=include_sanitized_bytes,
+        )
+
+    effective_min_confidence = (
+        float(min_confidence)
+        if min_confidence is not None
+        else float(profile_settings["ocr_confidence_threshold"])
+    )
 
     backend = ocr_backend or get_default_ocr_backend()
     engine_status = _backend_status(backend)
@@ -308,7 +325,7 @@ def redact_dicom_pixels(
 
             image_width, image_height = ocr_image.size
             for box in boxes:
-                if box.confidence < min_confidence:
+                if box.confidence < effective_min_confidence:
                     continue
 
                 clipped = clip_box_to_image(box, image_width, image_height)
@@ -357,6 +374,7 @@ def redact_dicom_pixels(
         ocr_engine_status=engine_status,
         sanitized_bytes=sanitized_bytes,
         include_sanitized_bytes=include_sanitized_bytes,
+        ocr_confidence_threshold=effective_min_confidence,
     )
 
 
@@ -473,6 +491,7 @@ def _dicom_result(
     ocr_engine_status: str = "not_applicable",
     sanitized_bytes: Optional[bytes] = None,
     include_sanitized_bytes: bool = True,
+    ocr_confidence_threshold: Optional[float] = None,
 ) -> Dict[str, Any]:
     result: Dict[str, Any] = {
         "pixel_redaction_status": pixel_redaction_status,
@@ -482,6 +501,9 @@ def _dicom_result(
         "scanned_regions": scanned_regions,
         "ocr_engine_status": ocr_engine_status,
     }
+    if ocr_confidence_threshold is not None:
+        result["ocr_confidence_threshold"] = ocr_confidence_threshold
     if include_sanitized_bytes and sanitized_bytes is not None:
         result["sanitized_dicom_bytes"] = sanitized_bytes
     return result
+

--- a/python_backend/services/ocr_redaction.py
+++ b/python_backend/services/ocr_redaction.py
@@ -1,0 +1,487 @@
+from __future__ import annotations
+
+import os
+import shutil
+from dataclasses import dataclass
+from io import BytesIO
+from typing import Any, Dict, Iterable, List, Optional, Protocol, Sequence, Tuple
+
+import numpy as np
+from PIL import Image, ImageDraw
+
+try:
+    import pydicom
+    from pydicom.errors import InvalidDicomError
+except ImportError:
+    pydicom = None
+    InvalidDicomError = Exception
+
+
+DEFAULT_MIN_CONFIDENCE = 0.5
+
+
+class OCREngineUnavailable(RuntimeError):
+    pass
+
+
+class OCRBackend(Protocol):
+    ocr_engine_status: str
+
+    def detect_text_boxes(self, image: Image.Image) -> Sequence["OCRBox"]:
+        ...
+
+
+@dataclass(frozen=True)
+class OCRBox:
+    text: str
+    confidence: float
+    x: int
+    y: int
+    width: int
+    height: int
+
+
+@dataclass
+class ImageRedactionResult:
+    image: Image.Image
+    boxes_detected: int
+    boxes_redacted: int
+    redaction_status: str
+    ocr_engine_status: Optional[str] = None
+
+    def safe_summary(self) -> Dict[str, Any]:
+        summary: Dict[str, Any] = {
+            "boxes_detected": self.boxes_detected,
+            "boxes_redacted": self.boxes_redacted,
+            "redaction_status": self.redaction_status,
+        }
+        if self.ocr_engine_status is not None:
+            summary["ocr_engine_status"] = self.ocr_engine_status
+        return summary
+
+
+class UnavailableOCRBackend:
+    ocr_engine_status = "unavailable"
+
+    def detect_text_boxes(self, image: Image.Image) -> Sequence[OCRBox]:
+        raise OCREngineUnavailable("OCR engine is unavailable")
+
+
+class PytesseractOCRBackend:
+    def __init__(self, tesseract_cmd: Optional[str] = None):
+        self._pytesseract = None
+        self._output = None
+        self.ocr_engine_status = "unavailable"
+
+        try:
+            import pytesseract
+            from pytesseract import Output
+        except ImportError:
+            return
+
+        resolved_cmd = _resolve_tesseract_cmd(tesseract_cmd)
+        if not resolved_cmd:
+            return
+
+        pytesseract.pytesseract.tesseract_cmd = resolved_cmd
+        self._pytesseract = pytesseract
+        self._output = Output
+        self.ocr_engine_status = "available"
+
+    def detect_text_boxes(self, image: Image.Image) -> Sequence[OCRBox]:
+        if self.ocr_engine_status != "available" or self._pytesseract is None:
+            raise OCREngineUnavailable("OCR engine is unavailable")
+
+        pil_image = _ensure_pil_image(image)
+        ocr_data = self._pytesseract.image_to_data(
+            pil_image,
+            output_type=self._output.DICT,
+        )
+
+        detections: List[OCRBox] = []
+        for index, text in enumerate(ocr_data.get("text", [])):
+            cleaned_text = str(text).strip()
+            if not cleaned_text:
+                continue
+
+            confidence = _parse_confidence(ocr_data.get("conf", [])[index])
+            if confidence < 0:
+                continue
+
+            detections.append(
+                OCRBox(
+                    text=cleaned_text,
+                    confidence=confidence,
+                    x=int(ocr_data.get("left", [])[index]),
+                    y=int(ocr_data.get("top", [])[index]),
+                    width=int(ocr_data.get("width", [])[index]),
+                    height=int(ocr_data.get("height", [])[index]),
+                )
+            )
+        return detections
+
+
+def get_default_ocr_backend() -> OCRBackend:
+    backend = PytesseractOCRBackend()
+    if backend.ocr_engine_status == "available":
+        return backend
+    return UnavailableOCRBackend()
+
+
+def redact_image_with_backend(
+    image: Any,
+    ocr_backend: Optional[OCRBackend] = None,
+    min_confidence: float = DEFAULT_MIN_CONFIDENCE,
+) -> ImageRedactionResult:
+    backend = ocr_backend or get_default_ocr_backend()
+    engine_status = _backend_status(backend)
+
+    if engine_status == "unavailable":
+        pil_image = _ensure_pil_image(image)
+        return ImageRedactionResult(
+            image=pil_image,
+            boxes_detected=0,
+            boxes_redacted=0,
+            redaction_status="skipped_ocr_unavailable",
+            ocr_engine_status=engine_status,
+        )
+
+    try:
+        boxes = backend.detect_text_boxes(_ensure_pil_image(image))
+    except OCREngineUnavailable:
+        return ImageRedactionResult(
+            image=_ensure_pil_image(image),
+            boxes_detected=0,
+            boxes_redacted=0,
+            redaction_status="skipped_ocr_unavailable",
+            ocr_engine_status="unavailable",
+        )
+    except Exception:
+        return ImageRedactionResult(
+            image=_ensure_pil_image(image),
+            boxes_detected=0,
+            boxes_redacted=0,
+            redaction_status="ocr_failed",
+            ocr_engine_status="error",
+        )
+
+    result = redact_image_regions(
+        image=image,
+        boxes=boxes,
+        min_confidence=min_confidence,
+    )
+    result.ocr_engine_status = engine_status
+    return result
+
+
+def redact_image_regions(
+    image: Any,
+    boxes: Iterable[OCRBox],
+    min_confidence: float = DEFAULT_MIN_CONFIDENCE,
+    fill: Optional[Any] = None,
+) -> ImageRedactionResult:
+    pil_image = _ensure_pil_image(image)
+    redacted = pil_image.copy()
+    draw = ImageDraw.Draw(redacted)
+    image_width, image_height = redacted.size
+    detections = list(boxes)
+    boxes_redacted = 0
+    mask_fill = fill if fill is not None else _black_fill_for_mode(redacted.mode)
+
+    for box in detections:
+        if box.confidence < min_confidence:
+            continue
+
+        clipped = clip_box_to_image(box, image_width, image_height)
+        if clipped is None:
+            continue
+
+        left, top, right, bottom = clipped
+        draw.rectangle((left, top, right - 1, bottom - 1), fill=mask_fill)
+        boxes_redacted += 1
+
+    if boxes_redacted:
+        status = "completed"
+    elif detections:
+        status = "completed_no_boxes_redacted"
+    else:
+        status = "completed_no_boxes"
+
+    return ImageRedactionResult(
+        image=redacted,
+        boxes_detected=len(detections),
+        boxes_redacted=boxes_redacted,
+        redaction_status=status,
+    )
+
+
+def clip_box_to_image(
+    box: OCRBox,
+    image_width: int,
+    image_height: int,
+) -> Optional[Tuple[int, int, int, int]]:
+    left = max(0, int(box.x))
+    top = max(0, int(box.y))
+    right = min(image_width, int(box.x) + max(0, int(box.width)))
+    bottom = min(image_height, int(box.y) + max(0, int(box.height)))
+
+    if right <= left or bottom <= top:
+        return None
+    return left, top, right, bottom
+
+
+def redact_dicom_pixels(
+    file_bytes: bytes,
+    profile: str = "strict",
+    ocr_backend: Optional[OCRBackend] = None,
+    min_confidence: float = DEFAULT_MIN_CONFIDENCE,
+    include_sanitized_bytes: bool = True,
+) -> Dict[str, Any]:
+    if pydicom is None:
+        return _dicom_result(
+            pixel_redaction_status="dependency_unavailable",
+            ocr_engine_status="unavailable",
+            include_sanitized_bytes=include_sanitized_bytes,
+        )
+    if not file_bytes:
+        return _dicom_result(
+            pixel_redaction_status="empty_file",
+            ocr_engine_status="not_applicable",
+            include_sanitized_bytes=include_sanitized_bytes,
+        )
+
+    backend = ocr_backend or get_default_ocr_backend()
+    engine_status = _backend_status(backend)
+    if engine_status == "unavailable":
+        return _dicom_result(
+            pixel_redaction_status="skipped_ocr_unavailable",
+            ocr_engine_status=engine_status,
+            sanitized_bytes=file_bytes,
+            include_sanitized_bytes=include_sanitized_bytes,
+        )
+
+    try:
+        dataset = pydicom.dcmread(BytesIO(file_bytes), force=False)
+    except (InvalidDicomError, Exception):
+        return _dicom_result(
+            pixel_redaction_status="invalid_dicom",
+            ocr_engine_status=engine_status,
+            include_sanitized_bytes=include_sanitized_bytes,
+        )
+
+    if "PixelData" not in dataset:
+        return _dicom_result(
+            pixel_redaction_status="no_pixel_data",
+            ocr_engine_status=engine_status,
+            sanitized_bytes=file_bytes,
+            include_sanitized_bytes=include_sanitized_bytes,
+        )
+
+    try:
+        pixel_array = np.array(dataset.pixel_array, copy=True)
+    except Exception:
+        return _dicom_result(
+            pixel_redaction_status="unsupported_pixel_data",
+            ocr_engine_status=engine_status,
+            sanitized_bytes=file_bytes,
+            include_sanitized_bytes=include_sanitized_bytes,
+        )
+
+    frames = _iter_grayscale_frames(pixel_array, dataset)
+    if frames is None:
+        return _dicom_result(
+            pixel_redaction_status="unsupported_pixel_format",
+            ocr_engine_status=engine_status,
+            sanitized_bytes=file_bytes,
+            include_sanitized_bytes=include_sanitized_bytes,
+        )
+
+    boxes_detected = 0
+    boxes_redacted = 0
+    frames_processed = 0
+
+    try:
+        for frame_index, frame in frames:
+            ocr_image = _frame_to_ocr_image(frame)
+            boxes = list(backend.detect_text_boxes(ocr_image))
+            boxes_detected += len(boxes)
+
+            image_width, image_height = ocr_image.size
+            for box in boxes:
+                if box.confidence < min_confidence:
+                    continue
+
+                clipped = clip_box_to_image(box, image_width, image_height)
+                if clipped is None:
+                    continue
+
+                left, top, right, bottom = clipped
+                frame[top:bottom, left:right] = _redaction_pixel_value(frame)
+                boxes_redacted += 1
+
+            frames_processed += 1
+    except OCREngineUnavailable:
+        return _dicom_result(
+            pixel_redaction_status="skipped_ocr_unavailable",
+            ocr_engine_status="unavailable",
+            sanitized_bytes=file_bytes,
+            include_sanitized_bytes=include_sanitized_bytes,
+        )
+    except Exception:
+        return _dicom_result(
+            pixel_redaction_status="ocr_failed",
+            ocr_engine_status="error",
+            frames_processed=frames_processed,
+            sanitized_bytes=file_bytes,
+            include_sanitized_bytes=include_sanitized_bytes,
+        )
+
+    sanitized_bytes = file_bytes
+    if boxes_redacted:
+        dataset.PixelData = pixel_array.tobytes()
+        sanitized_bytes = _dataset_to_bytes(dataset)
+
+    if boxes_redacted:
+        status = "completed"
+    elif boxes_detected:
+        status = "completed_no_boxes_redacted"
+    else:
+        status = "completed_no_text_detected"
+
+    return _dicom_result(
+        pixel_redaction_status=status,
+        ocr_boxes_detected=boxes_detected,
+        boxes_redacted=boxes_redacted,
+        frames_processed=frames_processed,
+        scanned_regions=frames_processed,
+        ocr_engine_status=engine_status,
+        sanitized_bytes=sanitized_bytes,
+        include_sanitized_bytes=include_sanitized_bytes,
+    )
+
+
+def safe_ocr_response(result: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        key: value
+        for key, value in result.items()
+        if key not in {"sanitized_dicom_bytes", "sanitized_bytes"}
+    }
+
+
+def _resolve_tesseract_cmd(tesseract_cmd: Optional[str]) -> Optional[str]:
+    candidates = [
+        tesseract_cmd,
+        os.getenv("TESSERACT_CMD"),
+        shutil.which("tesseract"),
+        "/opt/homebrew/bin/tesseract",
+        "/usr/local/bin/tesseract",
+        "/usr/bin/tesseract",
+        r"C:\Program Files\Tesseract-OCR\tesseract.exe",
+    ]
+    for candidate in candidates:
+        if not candidate:
+            continue
+        if os.path.isfile(candidate):
+            return candidate
+        resolved = shutil.which(candidate)
+        if resolved:
+            return resolved
+    return None
+
+
+def _parse_confidence(raw_confidence: Any) -> float:
+    try:
+        confidence = float(raw_confidence)
+    except (TypeError, ValueError):
+        return -1.0
+
+    if confidence > 1.0:
+        confidence = confidence / 100.0
+    return confidence
+
+
+def _ensure_pil_image(image: Any) -> Image.Image:
+    if isinstance(image, Image.Image):
+        return image.copy()
+
+    array = np.asarray(image)
+    if array.ndim == 2:
+        return Image.fromarray(array)
+    if array.ndim == 3:
+        return Image.fromarray(array)
+
+    raise ValueError("OCR redaction requires a 2D grayscale or 3D image array")
+
+
+def _black_fill_for_mode(mode: str) -> Any:
+    if mode in {"1", "L", "I", "I;16", "F"}:
+        return 0
+    if mode == "RGBA":
+        return (0, 0, 0, 255)
+    return (0, 0, 0)
+
+
+def _backend_status(backend: OCRBackend) -> str:
+    status = getattr(backend, "ocr_engine_status", "available")
+    if callable(status):
+        status = status()
+    return str(status or "available")
+
+
+def _iter_grayscale_frames(pixel_array: np.ndarray, dataset: Any):
+    samples_per_pixel = int(getattr(dataset, "SamplesPerPixel", 1) or 1)
+
+    if samples_per_pixel != 1:
+        return None
+    if pixel_array.ndim == 2:
+        return [(0, pixel_array)]
+    if pixel_array.ndim == 3:
+        return [(index, pixel_array[index]) for index in range(pixel_array.shape[0])]
+    return None
+
+
+def _frame_to_ocr_image(frame: np.ndarray) -> Image.Image:
+    frame_min = float(np.min(frame))
+    frame_max = float(np.max(frame))
+    if frame_max == frame_min:
+        normalized = np.zeros(frame.shape, dtype=np.uint8)
+    else:
+        normalized = ((frame - frame_min) / (frame_max - frame_min) * 255).astype(
+            np.uint8
+        )
+    return Image.fromarray(normalized, mode="L")
+
+
+def _redaction_pixel_value(frame: np.ndarray) -> Any:
+    if np.issubdtype(frame.dtype, np.integer):
+        return np.iinfo(frame.dtype).min
+    return 0
+
+
+def _dataset_to_bytes(dataset: Any) -> bytes:
+    buffer = BytesIO()
+    dataset.save_as(buffer, enforce_file_format=True)
+    return buffer.getvalue()
+
+
+def _dicom_result(
+    pixel_redaction_status: str,
+    ocr_boxes_detected: int = 0,
+    boxes_redacted: int = 0,
+    frames_processed: int = 0,
+    scanned_regions: int = 0,
+    ocr_engine_status: str = "not_applicable",
+    sanitized_bytes: Optional[bytes] = None,
+    include_sanitized_bytes: bool = True,
+) -> Dict[str, Any]:
+    result: Dict[str, Any] = {
+        "pixel_redaction_status": pixel_redaction_status,
+        "ocr_boxes_detected": ocr_boxes_detected,
+        "boxes_redacted": boxes_redacted,
+        "frames_processed": frames_processed,
+        "scanned_regions": scanned_regions,
+        "ocr_engine_status": ocr_engine_status,
+    }
+    if include_sanitized_bytes and sanitized_bytes is not None:
+        result["sanitized_dicom_bytes"] = sanitized_bytes
+    return result

--- a/python_backend/services/privacy_profiles.py
+++ b/python_backend/services/privacy_profiles.py
@@ -1,0 +1,156 @@
+import json
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Dict
+
+
+PROFILE_CONFIG_PATH = (
+    Path(__file__).resolve().parent.parent / "config" / "privacy_profiles.json"
+)
+REQUIRED_SETTINGS = {
+    "redact_dates",
+    "date_strategy",
+    "text_identifier_strategy",
+    "remove_dicom_private_tags",
+    "preserve_dicom_technical_metadata",
+    "remove_nifti_extensions",
+    "ocr_confidence_threshold",
+    "allow_generalized_demographics",
+}
+REQUIRED_PROFILES = {"strict", "research"}
+DATE_STRATEGIES = {"redact", "shift", "generalize"}
+TEXT_IDENTIFIER_STRATEGIES = {"redact", "pseudonymize"}
+
+
+class PrivacyProfileError(ValueError):
+    def __init__(self, detail: str, status_code: int = 400):
+        super().__init__(detail)
+        self.detail = detail
+        self.status_code = status_code
+
+
+def load_privacy_profiles() -> Dict[str, Dict[str, Any]]:
+    return {name: dict(settings) for name, settings in _load_profiles().items()}
+
+
+def get_privacy_profile(profile: str) -> Dict[str, Any]:
+    profiles = _load_profiles()
+    normalized = _normalize_profile_name(profile, profiles)
+    return dict(profiles[normalized])
+
+
+def validate_privacy_profile(profile: str) -> str:
+    return _normalize_profile_name(profile, _load_profiles())
+
+
+@lru_cache(maxsize=1)
+def _load_profiles() -> Dict[str, Dict[str, Any]]:
+    try:
+        raw_profiles = json.loads(PROFILE_CONFIG_PATH.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise PrivacyProfileError(
+            f"Privacy profile config not found: {PROFILE_CONFIG_PATH}",
+            status_code=500,
+        ) from exc
+    except json.JSONDecodeError as exc:
+        raise PrivacyProfileError(
+            "Privacy profile config is not valid JSON.",
+            status_code=500,
+        ) from exc
+
+    if not isinstance(raw_profiles, dict):
+        raise PrivacyProfileError(
+            "Privacy profile config must be a JSON object.",
+            status_code=500,
+        )
+
+    missing_profiles = REQUIRED_PROFILES - set(raw_profiles)
+    if missing_profiles:
+        missing = ", ".join(sorted(missing_profiles))
+        raise PrivacyProfileError(
+            f"Privacy profile config missing required profiles: {missing}",
+            status_code=500,
+        )
+
+    profiles: Dict[str, Dict[str, Any]] = {}
+    for name, settings in raw_profiles.items():
+        normalized = str(name).strip().lower()
+        if not normalized:
+            raise PrivacyProfileError(
+                "Privacy profile names must not be empty.",
+                status_code=500,
+            )
+        if not isinstance(settings, dict):
+            raise PrivacyProfileError(
+                f"Privacy profile '{normalized}' must be a JSON object.",
+                status_code=500,
+            )
+
+        _validate_settings(normalized, settings)
+        profiles[normalized] = dict(settings)
+
+    return profiles
+
+
+def _normalize_profile_name(
+    profile: str,
+    profiles: Dict[str, Dict[str, Any]],
+) -> str:
+    normalized = (profile or "").strip().lower()
+    if normalized not in profiles:
+        supported = ", ".join(sorted(profiles))
+        raise PrivacyProfileError(
+            f"Invalid privacy profile '{profile}'. Supported profiles: {supported}"
+        )
+    return normalized
+
+
+def _validate_settings(name: str, settings: Dict[str, Any]) -> None:
+    missing_settings = REQUIRED_SETTINGS - set(settings)
+    if missing_settings:
+        missing = ", ".join(sorted(missing_settings))
+        raise PrivacyProfileError(
+            f"Privacy profile '{name}' missing settings: {missing}",
+            status_code=500,
+        )
+
+    for key in (
+        "redact_dates",
+        "remove_dicom_private_tags",
+        "preserve_dicom_technical_metadata",
+        "remove_nifti_extensions",
+        "allow_generalized_demographics",
+    ):
+        if not isinstance(settings[key], bool):
+            raise PrivacyProfileError(
+                f"Privacy profile '{name}' setting '{key}' must be a boolean.",
+                status_code=500,
+            )
+
+    if settings["date_strategy"] not in DATE_STRATEGIES:
+        allowed = ", ".join(sorted(DATE_STRATEGIES))
+        raise PrivacyProfileError(
+            f"Privacy profile '{name}' date_strategy must be one of: {allowed}",
+            status_code=500,
+        )
+
+    if settings["text_identifier_strategy"] not in TEXT_IDENTIFIER_STRATEGIES:
+        allowed = ", ".join(sorted(TEXT_IDENTIFIER_STRATEGIES))
+        raise PrivacyProfileError(
+            (
+                f"Privacy profile '{name}' text_identifier_strategy must be "
+                f"one of: {allowed}"
+            ),
+            status_code=500,
+        )
+
+    threshold = settings["ocr_confidence_threshold"]
+    if not isinstance(threshold, (int, float)) or not 0 <= float(threshold) <= 1:
+        raise PrivacyProfileError(
+            (
+                f"Privacy profile '{name}' ocr_confidence_threshold must be "
+                "between 0 and 1."
+            ),
+            status_code=500,
+        )
+

--- a/python_backend/services/safe_harbor.py
+++ b/python_backend/services/safe_harbor.py
@@ -1,0 +1,584 @@
+from __future__ import annotations
+
+import math
+import re
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Set
+
+from services.text_anonymization import (
+    TextAnonymizationError,
+    detect_clinical_phi,
+)
+
+
+UNKNOWN_VALUE = "UNKNOWN"
+
+CATEGORY_LABELS = {
+    1: "1_names",
+    2: "2_geographic_subdivisions",
+    3: "3_individual_related_dates",
+    4: "4_ages_over_89",
+    5: "5_telephone_numbers",
+    6: "6_fax_numbers",
+    7: "7_email_addresses",
+    8: "8_social_security_numbers",
+    9: "9_medical_record_numbers",
+    10: "10_health_plan_beneficiary_numbers",
+    11: "11_account_numbers",
+    12: "12_certificate_and_licence_numbers",
+    13: "13_vehicle_identifiers",
+    14: "14_device_identifiers",
+    15: "15_urls",
+    16: "16_ip_addresses",
+    17: "17_biometric_identifiers",
+    18: "18_photographs_and_unique_identifiers",
+}
+
+CATEGORY_ALIASES = {
+    1: {
+        "name", "full_name", "patient_name", "first", "first_name",
+        "last", "last_name", "maiden", "maiden_name", "prefix", "suffix",
+        "relative_name", "employer_name", "provider_name", "physician_name",
+        "household_member_name", "guardian_name",
+    },
+    2: {
+        "address", "street", "street_address", "city", "county", "precinct",
+        "zip", "zip_code", "postal_code", "lat", "latitude", "lon",
+        "longitude", "geocode", "geo_code", "birthplace", "birth_place",
+    },
+    3: {
+        "date", "birthdate", "birth_date", "dob", "admission_date",
+        "admit_date", "discharge_date", "service_date", "procedure_date",
+        "diagnosis_date", "deathdate", "death_date", "dod",
+    },
+    4: {"age", "patient_age", "age_years"},
+    5: {"phone", "phone_number", "telephone", "telephone_number", "mobile"},
+    6: {"fax", "fax_number", "facsimile"},
+    7: {"email", "email_address"},
+    8: {"ssn", "social_security_number"},
+    9: {"mrn", "medical_record_number", "chart_number", "hospital_number"},
+    10: {
+        "health_plan_id", "health_plan_number", "beneficiary_number",
+        "beneficiary_id", "insurance_id", "member_id", "subscriber_id",
+        "policy_number",
+    },
+    11: {"account", "account_number", "billing_account", "claim_account"},
+    12: {
+        "certificate_number", "licence_number", "license_number", "drivers",
+        "driver_license", "drivers_license", "professional_license",
+    },
+    13: {
+        "vehicle_id", "vehicle_identifier", "vin", "vehicle_serial_number",
+        "license_plate", "licence_plate", "plate_number",
+    },
+    14: {
+        "device_id", "device_identifier", "device_serial_number",
+        "serial_number", "implant_id", "udi",
+    },
+    15: {"url", "website", "web_address"},
+    16: {"ip", "ip_address", "ipv4", "ipv6"},
+    17: {
+        "biometric", "biometric_id", "fingerprint", "fingerprint_id",
+        "voiceprint", "voiceprint_id", "retina_scan", "iris_scan",
+    },
+    18: {
+        "id", "patient_id", "unique_id", "uuid", "hash", "patient_hash",
+        "source_system_id", "encounter_id", "claim_id", "accession_id",
+        "token", "photo", "photograph", "face_photo", "full_face_photo",
+        "image", "image_reference", "binary", "blob",
+    },
+}
+
+FREE_TEXT_COLUMN_NAMES = {
+    "note", "notes", "comment", "comments", "description", "narrative",
+    "text", "free_text", "reason", "summary",
+}
+
+BIRTH_DATE_COLUMN_NAMES = {"birthdate", "birth_date", "dob"}
+
+KNOWN_ANALYTICAL_COLUMNS = {
+    "gender", "sex", "race", "ethnicity", "marital", "marital_status",
+    "state", "diagnosis", "disease", "condition", "outcome", "lab_result",
+    "healthcare_expenses", "healthcare_coverage",
+}
+
+TEXT_ENTITY_CATEGORIES = {
+    "PERSON": 1,
+    "MEDICAL_RECORD_NUMBER": 9,
+    "PATIENT_ID": 18,
+    "HEALTH_PLAN_ID": 10,
+    "INSURANCE_ID": 10,
+    "ACCESSION_NUMBER": 18,
+    "DEVICE_ID": 14,
+    "EMAIL_ADDRESS": 7,
+    "PHONE_NUMBER": 5,
+    "US_SSN": 8,
+    "SSN": 8,
+    "DATE_TIME": 3,
+}
+
+
+class SafeHarborValidationError(ValueError):
+    def __init__(self, detail: str, status_code: int = 400):
+        super().__init__(detail)
+        self.detail = detail
+        self.status_code = status_code
+
+
+@dataclass
+class SafeHarborPreparation:
+    rows: List[Dict[str, str]]
+    columns_to_remove: List[str]
+    date_columns: List[str]
+    age_columns: List[str]
+    detected_categories: Set[int]
+    removed_categories: Set[int]
+    unresolved_categories: Set[int]
+    column_categories: Dict[str, Set[int]]
+    free_text_scan_status: str
+    unique_code_scan_status: str
+    warnings: List[str]
+
+
+DATE_FORMATS = (
+    "%Y-%m-%d", "%Y/%m/%d", "%m/%d/%Y", "%m/%d/%y", "%d-%m-%Y",
+    "%Y%m%d", "%Y-%m", "%Y",
+)
+
+PATTERN_CATEGORY_RULES = (
+    (6, re.compile(r"\bfax\s*[:#-]?\s*(?:\+?1[\s.-]?)?(?:\(?\d{3}\)?[\s.-]?)\d{3}[\s.-]?\d{4}\b", re.I)),
+    (7, re.compile(r"\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b", re.I)),
+    (8, re.compile(r"\b\d{3}-\d{2}-\d{4}\b")),
+    (15, re.compile(r"\b(?:https?://|www\.)\S+", re.I)),
+    (16, re.compile(r"\b(?:\d{1,3}\.){3}\d{1,3}\b|\b[0-9A-F]{1,4}(?::[0-9A-F]{0,4}){2,7}\b", re.I)),
+    (5, re.compile(r"(?<!\w)(?:\+?1[\s.-]?)?(?:\(?\d{3}\)?[\s.-]?)\d{3}[\s.-]?\d{4}(?!\w)")),
+    (9, re.compile(r"\b(?:MRN|chart|hospital)\s*[:#-]?\s*[A-Z0-9-]{4,}\b", re.I)),
+    (10, re.compile(r"\b(?:member|beneficiary|subscriber|policy|insurance)\s*(?:id|number)?\s*[:#-]?\s*[A-Z0-9-]{5,}\b", re.I)),
+    (11, re.compile(r"\baccount\s*(?:id|number)?\s*[:#-]?\s*[A-Z0-9-]{4,}\b", re.I)),
+    (12, re.compile(r"\b(?:licen[cs]e|certificate)\s*(?:id|number)?\s*[:#-]?\s*[A-Z0-9-]{4,}\b", re.I)),
+    (13, re.compile(r"\b(?:VIN|vehicle|plate)\s*[:#-]?\s*[A-HJ-NPR-Z0-9-]{5,17}\b", re.I)),
+    (14, re.compile(r"\b(?:device|implant|serial|UDI)\s*[:#-]?\s*[A-Z0-9-]{5,}\b", re.I)),
+    (17, re.compile(r"\b(?:fingerprint|voiceprint|retina|iris|biometric)\s*[:#-]?\s*[A-Z0-9+/=-]{4,}\b", re.I)),
+    (18, re.compile(r"\b[0-9A-F]{8}-[0-9A-F]{4}-[1-5][0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}\b", re.I)),
+    (18, re.compile(r"\b[0-9A-F]{16,128}\b", re.I)),
+    (18, re.compile(r"(?:data:image/|\.(?:jpe?g|png|gif|bmp|tiff?)\b)", re.I)),
+    (3, re.compile(r"\b(?:\d{4}-\d{2}-\d{2}|\d{1,2}/\d{1,2}/\d{2,4})\b")),
+    (2, re.compile(r"\b\d{1,6}\s+[A-Z0-9.' -]+\s(?:street|st|avenue|ave|road|rd|lane|ln|drive|dr|boulevard|blvd)\b", re.I)),
+    (2, re.compile(r"\b\d{5}(?:-\d{4})?\b")),
+)
+
+
+def normalize_column_name(column_name: str) -> str:
+    normalized = re.sub(r"[^a-z0-9]+", "_", column_name.strip().lower())
+    return normalized.strip("_")
+
+
+def _category_from_mapping_key(key: Any) -> int:
+    text = str(key).strip().lower()
+    if text.isdigit() and int(text) in CATEGORY_LABELS:
+        return int(text)
+    for category, label in CATEGORY_LABELS.items():
+        if text in {label, label.split("_", 1)[1]}:
+            return category
+    raise SafeHarborValidationError(
+        "Safe Harbor mapping contains an unsupported identifier category"
+    )
+
+
+def _parse_date(value: str):
+    for date_format in DATE_FORMATS:
+        try:
+            return datetime.strptime(value, date_format).date()
+        except (TypeError, ValueError):
+            continue
+    return None
+
+
+def _parse_number(value: str) -> Optional[float]:
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    return number if math.isfinite(number) else None
+
+
+def _pattern_categories(value: str) -> Set[int]:
+    if not value or value == UNKNOWN_VALUE:
+        return set()
+    return {
+        category
+        for category, pattern in PATTERN_CATEGORY_RULES
+        if pattern.search(value)
+    }
+
+
+def _is_free_text_column(column: str, values: Sequence[str]) -> bool:
+    if normalize_column_name(column) in FREE_TEXT_COLUMN_NAMES:
+        return True
+    return any(
+        len(value) >= 40 or len(value.split()) >= 6
+        for value in values
+        if value != UNKNOWN_VALUE
+    )
+
+
+def _looks_like_unknown_unique_code(column: str, values: Sequence[str]) -> bool:
+    normalized = normalize_column_name(column)
+    if normalized in KNOWN_ANALYTICAL_COLUMNS:
+        return False
+    known = [value for value in values if value != UNKNOWN_VALUE]
+    if len(known) < 3:
+        return False
+    if re.search(r"(?:^|_)(?:id|identifier|code|hash|uuid|token|key|number)$", normalized):
+        return True
+    unique_ratio = len(set(known)) / len(known)
+    if all(_parse_number(value) is not None for value in known):
+        return unique_ratio >= 0.9
+    code_like = all(
+        len(value) <= 128 and not re.search(r"\s", value)
+        for value in known
+    )
+    return unique_ratio >= 0.9 and code_like
+
+
+def _looks_like_person_name_values(values: Sequence[str]) -> bool:
+    known = [value for value in values if value != UNKNOWN_VALUE]
+    if len(known) < 2:
+        return False
+    name_pattern = re.compile(
+        r"^[A-Z][A-Za-z'-]+(?:\s+[A-Z][A-Za-z'-]+){1,3}$"
+    )
+    return (
+        len(set(known)) / len(known) >= 0.8
+        and all(name_pattern.fullmatch(value) for value in known)
+    )
+
+
+def prepare_safe_harbor_rows(
+    header: Sequence[str],
+    records: Sequence[Dict[str, str]],
+    configured_mappings: Optional[Mapping[str, Sequence[str]]] = None,
+    configured_direct_columns: Optional[Sequence[str]] = None,
+    reviewed_columns: Optional[Sequence[str]] = None,
+) -> SafeHarborPreparation:
+    rows = [dict(record) for record in records]
+    normalized_columns = {
+        normalize_column_name(column): column
+        for column in header
+    }
+    column_categories: Dict[str, Set[int]] = {
+        column: set()
+        for column in header
+    }
+
+    for column in header:
+        normalized = normalize_column_name(column)
+        for category, aliases in CATEGORY_ALIASES.items():
+            if normalized in aliases:
+                column_categories[column].add(category)
+
+    if configured_mappings:
+        for raw_category, configured_columns in configured_mappings.items():
+            category = _category_from_mapping_key(raw_category)
+            if isinstance(configured_columns, str):
+                configured_columns = [configured_columns]
+            for configured_column in configured_columns:
+                actual = normalized_columns.get(
+                    normalize_column_name(configured_column)
+                )
+                if actual is None:
+                    raise SafeHarborValidationError(
+                        "Configured Safe Harbor mapping references a missing column"
+                    )
+                column_categories[actual].add(category)
+
+    for configured_column in configured_direct_columns or []:
+        actual = normalized_columns.get(normalize_column_name(configured_column))
+        if actual is None:
+            continue
+        if not column_categories[actual]:
+            column_categories[actual].add(18)
+
+    values_by_column = {
+        column: [row.get(column, UNKNOWN_VALUE) for row in rows]
+        for column in header
+    }
+    reviewed_column_set = {
+        actual
+        for column in reviewed_columns or []
+        if (actual := normalized_columns.get(normalize_column_name(column)))
+        is not None
+    }
+    for column, values in values_by_column.items():
+        for value in values:
+            column_categories[column].update(_pattern_categories(value))
+
+        if not column_categories[column] and _looks_like_person_name_values(values):
+            column_categories[column].add(1)
+
+    date_columns = [
+        column for column in header if 3 in column_categories[column]
+    ]
+    current_year = datetime.utcnow().year
+    related_birth_date_columns = [
+        column
+        for column in date_columns
+        if normalize_column_name(column) in BIRTH_DATE_COLUMN_NAMES
+    ]
+    for column in related_birth_date_columns:
+        if any(
+            (parsed := _parse_date(value)) is not None
+            and parsed.year <= current_year - 90
+            for value in values_by_column[column]
+            if value != UNKNOWN_VALUE
+        ):
+            column_categories[column].add(4)
+    age_columns = [
+        column
+        for column in header
+        if normalize_column_name(column) in CATEGORY_ALIASES[4]
+        or (
+            4 in column_categories[column]
+            and 3 not in column_categories[column]
+        )
+    ]
+    for column in age_columns:
+        has_age_over_89 = any(
+            (number := _parse_number(value)) is not None and number > 89
+            for value in values_by_column[column]
+            if value != UNKNOWN_VALUE
+        )
+        if not has_age_over_89:
+            column_categories[column].discard(4)
+    columns_to_remove: Set[str] = {
+        column
+        for column in header
+        if column_categories[column].difference({3, 4})
+    }
+
+    free_text_status = "passed"
+    free_text_columns: Set[str] = set()
+    quarantined_text_columns = 0
+    for column in header:
+        if column in columns_to_remove:
+            continue
+        values = values_by_column[column]
+        if not _is_free_text_column(column, values):
+            continue
+        free_text_columns.add(column)
+
+        detected_in_text: Set[int] = set()
+        try:
+            for value in values:
+                if value == UNKNOWN_VALUE:
+                    continue
+                detected_in_text.update(_pattern_categories(value))
+                entities = detect_clinical_phi(value)
+                detected_in_text.update(
+                    TEXT_ENTITY_CATEGORIES[entity]
+                    for entity in entities
+                    if entity in TEXT_ENTITY_CATEGORIES
+                )
+        except TextAnonymizationError:
+            columns_to_remove.add(column)
+            column_categories[column].add(18)
+            quarantined_text_columns += 1
+            free_text_status = "passed_with_quarantine"
+            continue
+
+        if detected_in_text:
+            column_categories[column].update(detected_in_text)
+            columns_to_remove.add(column)
+
+    unknown_unique_columns = 0
+    for column in header:
+        if (
+            column in columns_to_remove
+            or column in reviewed_column_set
+            or column in free_text_columns
+            or column in date_columns
+            or column in age_columns
+        ):
+            continue
+        if _looks_like_unknown_unique_code(column, values_by_column[column]):
+            column_categories[column].add(18)
+            columns_to_remove.add(column)
+            unknown_unique_columns += 1
+
+    invalid_date_count = 0
+    ages_capped = 0
+    for row in rows:
+        for column in date_columns:
+            if column in columns_to_remove:
+                continue
+            value = row.get(column, UNKNOWN_VALUE)
+            if value == UNKNOWN_VALUE:
+                continue
+            parsed = _parse_date(value)
+            if parsed is None:
+                row[column] = UNKNOWN_VALUE
+                invalid_date_count += 1
+            elif (
+                column in related_birth_date_columns
+                and parsed.year <= current_year - 90
+            ):
+                row[column] = "90+"
+            else:
+                row[column] = f"{parsed.year:04d}"
+
+        row_has_age_over_89 = False
+        for column in age_columns:
+            if column in columns_to_remove:
+                continue
+            value = row.get(column, UNKNOWN_VALUE)
+            if value == UNKNOWN_VALUE:
+                continue
+            parsed_age = _parse_number(value)
+            if parsed_age is None or parsed_age < 0:
+                row[column] = UNKNOWN_VALUE
+            elif parsed_age > 89:
+                row[column] = "90+"
+                ages_capped += 1
+                row_has_age_over_89 = True
+
+        if row_has_age_over_89:
+            for column in related_birth_date_columns:
+                if column not in columns_to_remove:
+                    row[column] = "90+"
+
+    ordered_columns_to_remove = [
+        column for column in header if column in columns_to_remove
+    ]
+    detected_categories = {
+        category
+        for categories in column_categories.values()
+        for category in categories
+    }
+    removed_categories = {
+        category
+        for column in ordered_columns_to_remove
+        for category in column_categories[column]
+    }
+    warnings = [
+        "Organizational and legal review remains required; these are technical checks only."
+    ]
+    if invalid_date_count:
+        warnings.append(
+            f"{invalid_date_count} invalid date value(s) were replaced with UNKNOWN."
+        )
+    if ages_capped:
+        warnings.append(f"{ages_capped} age value(s) were grouped into 90+.")
+    if quarantined_text_columns:
+        warnings.append(
+            f"{quarantined_text_columns} unscannable free-text column(s) were removed."
+        )
+    if unknown_unique_columns:
+        warnings.append(
+            f"{unknown_unique_columns} unknown high-cardinality code column(s) were removed."
+        )
+
+    unique_code_status = (
+        "passed_with_removals" if unknown_unique_columns else "passed"
+    )
+    return SafeHarborPreparation(
+        rows=rows,
+        columns_to_remove=ordered_columns_to_remove,
+        date_columns=date_columns,
+        age_columns=age_columns,
+        detected_categories=detected_categories,
+        removed_categories=removed_categories,
+        unresolved_categories=set(),
+        column_categories=column_categories,
+        free_text_scan_status=free_text_status,
+        unique_code_scan_status=unique_code_status,
+        warnings=warnings,
+    )
+
+
+def build_safe_harbor_report(
+    preparation: SafeHarborPreparation,
+    anonymized_rows: Sequence[Dict[str, str]],
+    output_columns: Sequence[str],
+) -> Dict[str, Any]:
+    unresolved = set(preparation.unresolved_categories)
+    output_column_set = set(output_columns)
+
+    for column, categories in preparation.column_categories.items():
+        if column not in output_column_set:
+            continue
+        unresolved.update(categories.difference({3, 4}))
+
+    exact_date_found = False
+    for row in anonymized_rows:
+        for value in row.values():
+            categories = _pattern_categories(value)
+            direct_patterns = categories.difference({2})
+            if 3 in direct_patterns:
+                exact_date_found = True
+            unresolved.update(direct_patterns.difference({3}))
+
+    exact_age_over_89_found = False
+    for row in anonymized_rows:
+        for column in preparation.age_columns:
+            if column not in output_column_set:
+                continue
+            value = row.get(column, UNKNOWN_VALUE)
+            number = _parse_number(value)
+            if number is not None and number > 89:
+                exact_age_over_89_found = True
+
+    if exact_date_found:
+        unresolved.add(3)
+    if exact_age_over_89_found:
+        unresolved.add(4)
+
+    prohibited_geography_remains = any(
+        2 in preparation.column_categories.get(column, set())
+        for column in output_columns
+    )
+    if prohibited_geography_remains:
+        unresolved.add(2)
+
+    free_text_status = preparation.free_text_scan_status
+    unique_code_status = preparation.unique_code_scan_status
+    if free_text_status == "failed":
+        unresolved.add(18)
+    if unique_code_status == "failed":
+        unresolved.add(18)
+
+    warnings = list(preparation.warnings)
+    validation_status = (
+        "failed"
+        if unresolved
+        else "passed_with_warnings" if warnings else "passed"
+    )
+
+    return {
+        "safe_harbor_validation_status": validation_status,
+        "identifier_categories_detected": _category_labels(
+            preparation.detected_categories
+        ),
+        "identifier_categories_removed": _category_labels(
+            preparation.removed_categories
+        ),
+        "unresolved_identifier_categories": _category_labels(unresolved),
+        "date_compliance_status": "failed" if exact_date_found else "passed",
+        "age_over_89_status": (
+            "failed" if exact_age_over_89_found else "passed"
+        ),
+        "geographic_compliance_status": (
+            "failed" if prohibited_geography_remains else "passed"
+        ),
+        "free_text_scan_status": free_text_status,
+        "unique_code_scan_status": unique_code_status,
+        "actual_knowledge_review_required": True,
+        "warnings": warnings,
+    }
+
+
+def _category_labels(categories: Set[int]) -> List[str]:
+    return [
+        CATEGORY_LABELS[category]
+        for category in sorted(categories)
+    ]

--- a/python_backend/services/tabular_anonymization.py
+++ b/python_backend/services/tabular_anonymization.py
@@ -1,0 +1,1002 @@
+from __future__ import annotations
+
+import csv
+import io
+import math
+import re
+from collections import Counter, defaultdict
+from datetime import datetime
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
+
+from services.safe_harbor import (
+    SafeHarborValidationError,
+    build_safe_harbor_report,
+    prepare_safe_harbor_rows,
+)
+
+
+UNKNOWN_VALUE = "UNKNOWN"
+SUPPRESSED_VALUE = "*"
+
+DEFAULT_DIRECT_IDENTIFIER_COLUMNS = (
+    "name",
+    "full_name",
+    "email",
+    "phone",
+    "mobile",
+    "mrn",
+    "medical_record_number",
+    "patient_id",
+    "id",
+    "ssn",
+    "social_security_number",
+    "drivers",
+    "driver_license",
+    "drivers_license",
+    "licence_number",
+    "license_number",
+    "passport",
+    "passport_number",
+    "prefix",
+    "first",
+    "first_name",
+    "given_name",
+    "last",
+    "last_name",
+    "family_name",
+    "suffix",
+    "maiden",
+    "maiden_name",
+    "address",
+    "street_address",
+)
+
+DEFAULT_QUASI_IDENTIFIER_COLUMNS = (
+    "age",
+    "gender",
+    "sex",
+    "zip",
+    "zip_code",
+    "postal_code",
+    "city",
+    "state",
+    "date",
+    "admission_date",
+    "discharge_date",
+    "diagnosis_date",
+    "birthdate",
+    "birth_date",
+    "deathdate",
+    "death_date",
+    "race",
+    "ethnicity",
+    "marital",
+    "marital_status",
+    "birthplace",
+    "birth_place",
+    "county",
+    "lat",
+    "latitude",
+    "lon",
+    "longitude",
+)
+
+DEFAULT_SENSITIVE_COLUMNS = (
+    "diagnosis",
+    "disease",
+    "condition",
+    "outcome",
+)
+
+DATE_FORMATS = (
+    "%Y-%m-%d",
+    "%Y/%m/%d",
+    "%m/%d/%Y",
+    "%d-%m-%Y",
+    "%Y%m%d",
+    "%Y-%m",
+    "%Y",
+)
+
+DATE_COLUMN_NAMES = {
+    "date",
+    "admission_date",
+    "discharge_date",
+    "diagnosis_date",
+    "birthdate",
+    "birth_date",
+    "deathdate",
+    "death_date",
+}
+
+ZIP_COLUMN_NAMES = {"zip", "zip_code", "postal_code"}
+
+AGE_COLUMN_NAMES = {"age", "patient_age", "age_years"}
+
+PRECISE_GEOGRAPHY_COLUMN_NAMES = {"lat", "latitude", "lon", "longitude"}
+
+NUMERICAL_SENSITIVE_COLUMN_NAMES = {
+    "healthcare_expenses",
+    "healthcare_coverage",
+}
+
+
+class TabularAnonymizationError(ValueError):
+    def __init__(self, detail: str, status_code: int = 400):
+        super().__init__(detail)
+        self.detail = detail
+        self.status_code = status_code
+
+
+def anonymize_tabular_csv(
+    file_bytes: bytes,
+    k: int = 5,
+    l: int = 2,
+    direct_identifiers: Optional[List[str]] = None,
+    quasi_identifiers: Optional[List[str]] = None,
+    sensitive_column: Optional[str] = None,
+    safe_harbor_mappings: Optional[Mapping[str, Sequence[str]]] = None,
+    include_anonymized_csv: bool = False,
+) -> Dict[str, Any]:
+    _validate_thresholds(k, l)
+    header, records = _read_csv(file_bytes)
+    normalized_columns = _build_normalized_column_map(header)
+
+    direct_identifier_columns = _resolve_column_list(
+        available_columns=normalized_columns,
+        requested=direct_identifiers,
+        defaults=DEFAULT_DIRECT_IDENTIFIER_COLUMNS,
+        column_kind="direct identifier",
+    )
+    sensitive_column_name = _resolve_sensitive_column(
+        available_columns=normalized_columns,
+        requested=sensitive_column,
+    )
+    quasi_identifier_columns = _resolve_column_list(
+        available_columns=normalized_columns,
+        requested=quasi_identifiers,
+        defaults=DEFAULT_QUASI_IDENTIFIER_COLUMNS,
+        column_kind="quasi-identifier",
+    )
+
+    try:
+        safe_harbor = prepare_safe_harbor_rows(
+            header=header,
+            records=records,
+            configured_mappings=safe_harbor_mappings,
+            configured_direct_columns=direct_identifier_columns,
+            reviewed_columns=quasi_identifiers,
+        )
+    except SafeHarborValidationError as exc:
+        raise TabularAnonymizationError(
+            exc.detail,
+            status_code=exc.status_code,
+        ) from exc
+    records = safe_harbor.rows
+    precise_geography_columns = [
+        column
+        for column in header
+        if _normalize_column_name(column) in PRECISE_GEOGRAPHY_COLUMN_NAMES
+    ]
+
+    overlap = set(direct_identifier_columns).intersection(quasi_identifier_columns)
+    if overlap:
+        raise TabularAnonymizationError(
+            "Columns cannot be both direct identifiers and quasi-identifiers: "
+            + ", ".join(sorted(overlap))
+        )
+    if sensitive_column_name and sensitive_column_name in direct_identifier_columns:
+        raise TabularAnonymizationError(
+            "Sensitive column cannot also be removed as a direct identifier"
+        )
+    if sensitive_column_name and sensitive_column_name in safe_harbor.columns_to_remove:
+        raise TabularAnonymizationError(
+            "Sensitive column is a Safe Harbor identifier and cannot be retained"
+        )
+
+    safe_harbor_removed_set = set(safe_harbor.columns_to_remove)
+    quasi_identifier_columns = [
+        column
+        for column in quasi_identifier_columns
+        if column not in safe_harbor_removed_set
+    ]
+    if not quasi_identifier_columns:
+        raise TabularAnonymizationError(
+            "At least one quasi-identifier column must remain after Safe "
+            "Harbor identifier removal"
+        )
+    if sensitive_column_name and sensitive_column_name in quasi_identifier_columns:
+        raise TabularAnonymizationError(
+            "Sensitive column cannot also be a quasi-identifier"
+        )
+
+    removed_column_set = set(direct_identifier_columns).union(
+        safe_harbor.columns_to_remove
+    )
+    retained_columns = [
+        column for column in header if column not in removed_column_set
+    ]
+    retained_column_set = set(retained_columns)
+    missing_quasi_after_removal = [
+        column for column in quasi_identifier_columns if column not in retained_column_set
+    ]
+    if missing_quasi_after_removal:
+        raise TabularAnonymizationError(
+            "Missing quasi-identifier column(s): "
+            + ", ".join(missing_quasi_after_removal)
+        )
+
+    working_rows = _remove_direct_identifiers(
+        records=records,
+        retained_columns=retained_columns,
+    )
+    quasi_identifier_types = {
+        column: _infer_column_type(working_rows, column)
+        for column in quasi_identifier_columns
+    }
+    processing_warnings = _normalize_invalid_date_values(
+        rows=working_rows,
+        quasi_identifier_types=quasi_identifier_types,
+    )
+    _validate_sensitive_column_for_l_diversity(
+        rows=working_rows,
+        sensitive_column=sensitive_column_name,
+    )
+
+    partitions = _mondrian_partitions(
+        rows=working_rows,
+        quasi_identifier_types=quasi_identifier_types,
+        k=k,
+        l=l,
+        sensitive_column=sensitive_column_name,
+    )
+    anonymized_rows, generalized_cells, suppressed_cells = _generalize_partitions(
+        rows=working_rows,
+        partitions=partitions,
+        quasi_identifier_types=quasi_identifier_types,
+    )
+
+    equivalence_groups = _equivalence_groups(
+        rows=anonymized_rows,
+        quasi_identifiers=quasi_identifier_columns,
+    )
+    group_sizes = [len(indices) for indices in equivalence_groups.values()]
+    min_group_size = min(group_sizes) if group_sizes else 0
+    k_anonymity_satisfied = bool(group_sizes) and min_group_size >= k
+
+    if not k_anonymity_satisfied:
+        processing_warnings.append(
+            "k-anonymity could not be satisfied; minimum equivalence class "
+            f"size is {min_group_size}."
+        )
+
+    if sensitive_column_name is None:
+        l_diversity_satisfied: Any = "not_applicable"
+        processing_warnings.append(
+            "l-diversity was not evaluated because no sensitive column was "
+            "provided or detected."
+        )
+    else:
+        l_diversity_satisfied = _l_diversity_satisfied(
+            rows=anonymized_rows,
+            equivalence_groups=equivalence_groups,
+            sensitive_column=sensitive_column_name,
+            l=l,
+        )
+        if not l_diversity_satisfied:
+            processing_warnings.append(
+                "l-diversity could not be satisfied for at least one "
+                "equivalence class."
+            )
+
+    safe_harbor_report = build_safe_harbor_report(
+        preparation=safe_harbor,
+        anonymized_rows=anonymized_rows,
+        output_columns=retained_columns,
+    )
+    warnings = [
+        *safe_harbor_report["warnings"],
+        *processing_warnings,
+    ]
+    privacy_requirements_satisfied = (
+        safe_harbor_report["safe_harbor_validation_status"] != "failed"
+        and not safe_harbor_report["unresolved_identifier_categories"]
+        and k_anonymity_satisfied
+        and l_diversity_satisfied in {True, "not_applicable"}
+    )
+    if not privacy_requirements_satisfied:
+        anonymization_status = "failed_privacy_validation"
+    elif warnings:
+        anonymization_status = "completed_with_warnings"
+    else:
+        anonymization_status = "completed"
+    total_quasi_identifier_cells = (
+        len(anonymized_rows) * len(quasi_identifier_columns)
+    )
+    columns_removed = [
+        column for column in header if column in removed_column_set
+    ]
+
+    result: Dict[str, Any] = {
+        "anonymization_status": anonymization_status,
+        "rows_in": len(records),
+        "rows_out": len(anonymized_rows),
+        "k": k,
+        "l": l,
+        "direct_identifiers_removed": direct_identifier_columns,
+        "precise_geography_columns_removed": precise_geography_columns,
+        "columns_removed": columns_removed,
+        "quasi_identifiers_used": quasi_identifier_columns,
+        "sensitive_column": sensitive_column_name,
+        "output_columns": retained_columns,
+        "safe_harbor_report": safe_harbor_report,
+        "equivalence_classes": len(equivalence_groups),
+        "min_group_size": min_group_size,
+        "k_anonymity_satisfied": k_anonymity_satisfied,
+        "l_diversity_satisfied": l_diversity_satisfied,
+        "generalized_cells_count": generalized_cells,
+        "suppressed_cells_count": suppressed_cells,
+        "generalization_rate": _safe_rate(
+            generalized_cells,
+            total_quasi_identifier_cells,
+        ),
+        "suppression_rate": _safe_rate(
+            suppressed_cells,
+            total_quasi_identifier_cells,
+        ),
+        "warnings": warnings,
+    }
+
+    if include_anonymized_csv:
+        result["_internal_anonymized_csv"] = _write_csv(retained_columns, anonymized_rows)
+
+    return result
+
+
+def classify_tabular_columns(header: Sequence[str]) -> Dict[str, List[str]]:
+    normalized_columns = _build_normalized_column_map(header)
+    direct_defaults = set(DEFAULT_DIRECT_IDENTIFIER_COLUMNS)
+    quasi_defaults = set(DEFAULT_QUASI_IDENTIFIER_COLUMNS)
+
+    return {
+        "direct_identifiers": [
+            actual
+            for normalized, actual in normalized_columns.items()
+            if normalized in direct_defaults
+        ],
+        "quasi_identifiers": [
+            actual
+            for normalized, actual in normalized_columns.items()
+            if normalized in quasi_defaults
+        ],
+        "precise_geography": [
+            actual
+            for normalized, actual in normalized_columns.items()
+            if normalized in PRECISE_GEOGRAPHY_COLUMN_NAMES
+        ],
+    }
+
+
+def _validate_thresholds(k: int, l: int) -> None:
+    if not isinstance(k, int) or k < 1:
+        raise TabularAnonymizationError("k must be a positive integer")
+    if not isinstance(l, int) or l < 1:
+        raise TabularAnonymizationError("l must be a positive integer")
+
+
+def _read_csv(file_bytes: bytes) -> Tuple[List[str], List[Dict[str, str]]]:
+    if not file_bytes:
+        raise TabularAnonymizationError("CSV input is empty")
+
+    try:
+        csv_text = file_bytes.decode("utf-8-sig")
+    except UnicodeDecodeError as exc:
+        raise TabularAnonymizationError("CSV uploads must be UTF-8 encoded") from exc
+
+    if not csv_text.strip():
+        raise TabularAnonymizationError("CSV input is empty")
+
+    try:
+        reader = csv.reader(io.StringIO(csv_text), strict=True)
+        raw_rows = [row for row in reader if any(cell.strip() for cell in row)]
+    except csv.Error as exc:
+        raise TabularAnonymizationError("Invalid CSV format") from exc
+
+    if not raw_rows:
+        raise TabularAnonymizationError("CSV input is empty")
+
+    header = [cell.strip() for cell in raw_rows[0]]
+    if not header or not any(header):
+        raise TabularAnonymizationError("CSV header row is missing")
+    if any(not column for column in header):
+        raise TabularAnonymizationError("CSV header row contains empty column names")
+
+    normalized_header = [_normalize_column_name(column) for column in header]
+    if len(set(normalized_header)) != len(normalized_header):
+        raise TabularAnonymizationError("CSV column names must be unique")
+
+    if len(raw_rows) == 1:
+        raise TabularAnonymizationError("CSV input must include at least one data row")
+
+    records: List[Dict[str, str]] = []
+    expected_columns = len(header)
+    for row_number, row in enumerate(raw_rows[1:], start=2):
+        if len(row) != expected_columns:
+            raise TabularAnonymizationError(
+                f"CSV row {row_number} has {len(row)} fields; "
+                f"expected {expected_columns}"
+            )
+        records.append(
+            {
+                column: _clean_cell(value)
+                for column, value in zip(header, row)
+            }
+        )
+
+    if not records:
+        raise TabularAnonymizationError("CSV input must include at least one data row")
+
+    return header, records
+
+
+def _clean_cell(value: Any) -> str:
+    cleaned = str(value).strip()
+    return cleaned if cleaned else UNKNOWN_VALUE
+
+
+def _normalize_column_name(column_name: str) -> str:
+    normalized = re.sub(r"[^a-z0-9]+", "_", column_name.strip().lower())
+    return normalized.strip("_")
+
+
+def _build_normalized_column_map(header: Sequence[str]) -> Dict[str, str]:
+    return {_normalize_column_name(column): column for column in header}
+
+
+def _resolve_column_list(
+    available_columns: Dict[str, str],
+    requested: Optional[List[str]],
+    defaults: Sequence[str],
+    column_kind: str,
+) -> List[str]:
+    if requested is not None:
+        resolved: List[str] = []
+        missing: List[str] = []
+        seen = set()
+        for column in requested:
+            normalized = _normalize_column_name(column)
+            actual_column = available_columns.get(normalized)
+            if actual_column is None:
+                missing.append(column)
+                continue
+            if actual_column not in seen:
+                resolved.append(actual_column)
+                seen.add(actual_column)
+
+        if missing:
+            raise TabularAnonymizationError(
+                f"Missing {column_kind} column(s): " + ", ".join(missing)
+            )
+        if column_kind == "quasi-identifier" and not resolved:
+            raise TabularAnonymizationError(
+                "At least one quasi-identifier column is required"
+            )
+        return resolved
+
+    normalized_defaults = set(defaults)
+    resolved_defaults = [
+        actual_column
+        for normalized, actual_column in available_columns.items()
+        if normalized in normalized_defaults
+    ]
+    if column_kind == "quasi-identifier" and not resolved_defaults:
+        raise TabularAnonymizationError(
+            "No quasi-identifier columns were detected; provide quasi_identifiers"
+        )
+    return resolved_defaults
+
+
+def _resolve_sensitive_column(
+    available_columns: Dict[str, str],
+    requested: Optional[str],
+) -> Optional[str]:
+    if requested:
+        actual_column = available_columns.get(_normalize_column_name(requested))
+        if actual_column is None:
+            raise TabularAnonymizationError(
+                f"Missing sensitive column: {requested}"
+            )
+        return actual_column
+
+    for candidate in DEFAULT_SENSITIVE_COLUMNS:
+        actual_column = available_columns.get(candidate)
+        if actual_column is not None:
+            return actual_column
+    return None
+
+
+def _remove_direct_identifiers(
+    records: Sequence[Dict[str, str]],
+    retained_columns: Sequence[str],
+) -> List[Dict[str, str]]:
+    return [
+        {
+            column: _clean_cell(record.get(column, UNKNOWN_VALUE))
+            for column in retained_columns
+        }
+        for record in records
+    ]
+
+
+def _infer_column_type(rows: Sequence[Dict[str, str]], column: str) -> str:
+    normalized_column = _normalize_column_name(column)
+    if (
+        normalized_column in DATE_COLUMN_NAMES
+        or normalized_column.endswith("_date")
+    ):
+        return "date"
+    if normalized_column in ZIP_COLUMN_NAMES:
+        return "zip"
+    if normalized_column in AGE_COLUMN_NAMES:
+        return "age"
+
+    values = [
+        row[column]
+        for row in rows
+        if row.get(column, UNKNOWN_VALUE) != UNKNOWN_VALUE
+    ]
+    if not values:
+        return "categorical"
+
+    if all(_parse_number(value) is not None for value in values):
+        return "numeric"
+    if all(_parse_date(value) is not None for value in values):
+        return "date"
+    return "categorical"
+
+
+def _normalize_invalid_date_values(
+    rows: Sequence[Dict[str, str]],
+    quasi_identifier_types: Dict[str, str],
+) -> List[str]:
+    warnings: List[str] = []
+    for column, column_type in quasi_identifier_types.items():
+        if column_type != "date":
+            continue
+
+        invalid_count = 0
+        for row in rows:
+            value = row.get(column, UNKNOWN_VALUE)
+            if (
+                value in {UNKNOWN_VALUE, "90+"}
+                or _parse_date(value) is not None
+            ):
+                continue
+            row[column] = UNKNOWN_VALUE
+            invalid_count += 1
+
+        if invalid_count:
+            warnings.append(
+                f"Column {column} contained {invalid_count} invalid date "
+                "value(s); replaced with UNKNOWN before generalization."
+            )
+    return warnings
+
+
+def _validate_sensitive_column_for_l_diversity(
+    rows: Sequence[Dict[str, str]],
+    sensitive_column: Optional[str],
+) -> None:
+    if sensitive_column is None:
+        return
+    if (
+        _normalize_column_name(sensitive_column)
+        not in NUMERICAL_SENSITIVE_COLUMN_NAMES
+    ):
+        return
+
+    values = [
+        row.get(sensitive_column, UNKNOWN_VALUE)
+        for row in rows
+        if row.get(sensitive_column, UNKNOWN_VALUE) != UNKNOWN_VALUE
+    ]
+    if values and all(_parse_number(value) is not None for value in values):
+        raise TabularAnonymizationError(
+            f"Numerical sensitive column {sensitive_column} requires bucketing "
+            "before l-diversity evaluation; provide a pre-bucketed categorical "
+            "sensitive column."
+        )
+
+
+def _parse_number(value: str) -> Optional[float]:
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(number):
+        return None
+    return number
+
+
+def _parse_age(value: str) -> Optional[float]:
+    if value == "90+":
+        return 90.0
+    return _parse_number(value)
+
+
+def _parse_date(value: str):
+    for date_format in DATE_FORMATS:
+        try:
+            return datetime.strptime(value, date_format).date()
+        except (TypeError, ValueError):
+            continue
+    return None
+
+
+def _mondrian_partitions(
+    rows: Sequence[Dict[str, str]],
+    quasi_identifier_types: Dict[str, str],
+    k: int,
+    l: int,
+    sensitive_column: Optional[str],
+) -> List[List[int]]:
+    final_partitions: List[List[int]] = []
+    pending_partitions: List[List[int]] = [list(range(len(rows)))]
+
+    while pending_partitions:
+        indices = pending_partitions.pop()
+        if len(indices) < 2 * k:
+            final_partitions.append(indices)
+            continue
+
+        split = _best_split(
+            rows=rows,
+            indices=indices,
+            quasi_identifier_types=quasi_identifier_types,
+            k=k,
+            l=l,
+            sensitive_column=sensitive_column,
+        )
+        if split is None:
+            final_partitions.append(indices)
+            continue
+
+        left_indices, right_indices = split
+        pending_partitions.append(left_indices)
+        pending_partitions.append(right_indices)
+
+    return final_partitions
+
+
+def _best_split(
+    rows: Sequence[Dict[str, str]],
+    indices: Sequence[int],
+    quasi_identifier_types: Dict[str, str],
+    k: int,
+    l: int,
+    sensitive_column: Optional[str],
+) -> Optional[Tuple[List[int], List[int]]]:
+    best: Optional[Tuple[Tuple[int, float], List[int], List[int]]] = None
+
+    for column, column_type in quasi_identifier_types.items():
+        split = _split_partition(rows, indices, column, column_type)
+        if split is None:
+            continue
+
+        left_indices, right_indices = split
+        if len(left_indices) < k or len(right_indices) < k:
+            continue
+
+        if sensitive_column is not None:
+            if not _partition_l_diverse(rows, left_indices, sensitive_column, l):
+                continue
+            if not _partition_l_diverse(rows, right_indices, sensitive_column, l):
+                continue
+
+        score = _split_score(rows, indices, column, column_type)
+        if best is None or score > best[0]:
+            best = (score, left_indices, right_indices)
+
+    if best is None:
+        return None
+    return best[1], best[2]
+
+
+def _split_partition(
+    rows: Sequence[Dict[str, str]],
+    indices: Sequence[int],
+    column: str,
+    column_type: str,
+) -> Optional[Tuple[List[int], List[int]]]:
+    if column_type in {"numeric", "date", "age"}:
+        return _split_ordered(rows, indices, column, column_type)
+    return _split_categorical(rows, indices, column)
+
+
+def _split_ordered(
+    rows: Sequence[Dict[str, str]],
+    indices: Sequence[int],
+    column: str,
+    column_type: str,
+) -> Optional[Tuple[List[int], List[int]]]:
+    sortable: List[Tuple[bool, float, int]] = []
+    distinct_values = set()
+    for row_index in indices:
+        raw_value = rows[row_index][column]
+        parsed_value: Optional[float]
+        if column_type == "numeric":
+            parsed_value = _parse_number(raw_value)
+        elif column_type == "age":
+            parsed_value = _parse_age(raw_value)
+        else:
+            if raw_value == "90+":
+                parsed_value = -1.0
+            else:
+                parsed_date = _parse_date(raw_value)
+                parsed_value = (
+                    float(parsed_date.toordinal()) if parsed_date else None
+                )
+
+        if parsed_value is None:
+            sortable.append((True, 0.0, row_index))
+        else:
+            sortable.append((False, parsed_value, row_index))
+            distinct_values.add(parsed_value)
+
+    if len(distinct_values) < 2:
+        return None
+
+    sortable.sort(key=lambda item: (item[0], item[1], item[2]))
+    midpoint = len(sortable) // 2
+    left_indices = [item[2] for item in sortable[:midpoint]]
+    right_indices = [item[2] for item in sortable[midpoint:]]
+    return left_indices, right_indices
+
+
+def _split_categorical(
+    rows: Sequence[Dict[str, str]],
+    indices: Sequence[int],
+    column: str,
+) -> Optional[Tuple[List[int], List[int]]]:
+    counts = Counter(rows[row_index][column] for row_index in indices)
+    if len(counts) < 2:
+        return None
+
+    left_categories = set()
+    right_categories = set()
+    left_size = 0
+    right_size = 0
+    for category, count in sorted(counts.items(), key=lambda item: (-item[1], item[0])):
+        if left_size <= right_size:
+            left_categories.add(category)
+            left_size += count
+        else:
+            right_categories.add(category)
+            right_size += count
+
+    left_indices = [
+        row_index
+        for row_index in indices
+        if rows[row_index][column] in left_categories
+    ]
+    right_indices = [
+        row_index
+        for row_index in indices
+        if rows[row_index][column] in right_categories
+    ]
+    if not left_indices or not right_indices:
+        return None
+    return left_indices, right_indices
+
+
+def _split_score(
+    rows: Sequence[Dict[str, str]],
+    indices: Sequence[int],
+    column: str,
+    column_type: str,
+) -> Tuple[int, float]:
+    if column_type in {"numeric", "age"}:
+        numbers = [
+            (
+                _parse_age(rows[row_index][column])
+                if column_type == "age"
+                else _parse_number(rows[row_index][column])
+            )
+            for row_index in indices
+        ]
+        known_numbers = [number for number in numbers if number is not None]
+        if len(known_numbers) < 2:
+            return (0, 0.0)
+        return (2, max(known_numbers) - min(known_numbers))
+
+    if column_type == "date":
+        known_ordinals = [
+            (
+                -1.0
+                if rows[row_index][column] == "90+"
+                else float(parsed_date.toordinal())
+            )
+            for row_index in indices
+            if (
+                (parsed_date := _parse_date(rows[row_index][column]))
+                is not None
+                or rows[row_index][column] == "90+"
+            )
+        ]
+        if len(known_ordinals) < 2:
+            return (0, 0.0)
+        return (2, max(known_ordinals) - min(known_ordinals))
+
+    unique_values = {rows[row_index][column] for row_index in indices}
+    return (1, float(len(unique_values)))
+
+
+def _partition_l_diverse(
+    rows: Sequence[Dict[str, str]],
+    indices: Sequence[int],
+    sensitive_column: str,
+    l: int,
+) -> bool:
+    sensitive_values = {
+        rows[row_index].get(sensitive_column, UNKNOWN_VALUE)
+        for row_index in indices
+    }
+    return len(sensitive_values) >= l
+
+
+def _generalize_partitions(
+    rows: Sequence[Dict[str, str]],
+    partitions: Sequence[Sequence[int]],
+    quasi_identifier_types: Dict[str, str],
+) -> Tuple[List[Dict[str, str]], int, int]:
+    anonymized_rows = [dict(row) for row in rows]
+    generalized_cells = 0
+    suppressed_cells = 0
+
+    for partition in partitions:
+        for column, column_type in quasi_identifier_types.items():
+            generalized_value, is_suppressed = _generalized_value(
+                rows=rows,
+                partition=partition,
+                column=column,
+                column_type=column_type,
+            )
+            for row_index in partition:
+                original_value = anonymized_rows[row_index][column]
+                anonymized_rows[row_index][column] = generalized_value
+                if original_value != generalized_value:
+                    generalized_cells += 1
+                if is_suppressed:
+                    suppressed_cells += 1
+
+    return anonymized_rows, generalized_cells, suppressed_cells
+
+
+def _generalized_value(
+    rows: Sequence[Dict[str, str]],
+    partition: Sequence[int],
+    column: str,
+    column_type: str,
+) -> Tuple[str, bool]:
+    values = [rows[row_index][column] for row_index in partition]
+    if any(value == UNKNOWN_VALUE for value in values):
+        return UNKNOWN_VALUE, True
+
+    if column_type == "numeric":
+        numbers = [_parse_number(value) for value in values]
+        known_numbers = [number for number in numbers if number is not None]
+        if not known_numbers:
+            return UNKNOWN_VALUE, True
+        return (_format_numeric_range(known_numbers), False)
+
+    if column_type == "age":
+        ages = [_parse_age(value) for value in values]
+        known_ages = [age for age in ages if age is not None]
+        if not known_ages:
+            return UNKNOWN_VALUE, True
+        minimum = min(known_ages)
+        maximum = max(known_ages)
+        if minimum >= 90:
+            return "90+", False
+        if maximum >= 90:
+            return f"{_format_number(minimum)}-90+", False
+        return (_format_numeric_range(known_ages), False)
+
+    if column_type == "date":
+        if "90+" in values:
+            return "90+", False
+        dates = [_parse_date(value) for value in values]
+        known_dates = [parsed_date for parsed_date in dates if parsed_date is not None]
+        if not known_dates:
+            return UNKNOWN_VALUE, True
+        min_date = min(known_dates)
+        max_date = max(known_dates)
+        if min_date.year == max_date.year and min_date.month == max_date.month:
+            return f"{min_date.year:04d}-{min_date.month:02d}", False
+        if min_date.year == max_date.year:
+            return f"{min_date.year:04d}", False
+        return f"{min_date.year:04d}-{max_date.year:04d}", False
+
+    if column_type == "zip":
+        return _generalize_zip(values)
+
+    return SUPPRESSED_VALUE, True
+
+
+def _generalize_zip(values: Sequence[str]) -> Tuple[str, bool]:
+    if any(value == UNKNOWN_VALUE for value in values):
+        return UNKNOWN_VALUE, True
+
+    normalized_values = [re.sub(r"[^0-9]", "", value) for value in values]
+    if not normalized_values or any(len(value) < 5 for value in normalized_values):
+        return SUPPRESSED_VALUE, True
+
+    prefixes = {value[:3] for value in normalized_values}
+    if len(prefixes) == 1:
+        return f"{next(iter(prefixes))}**", False
+    return SUPPRESSED_VALUE, True
+
+
+def _format_number(number: float) -> str:
+    if number.is_integer():
+        return str(int(number))
+    return f"{number:.2f}".rstrip("0").rstrip(".")
+
+
+def _format_numeric_range(numbers: Sequence[float]) -> str:
+    minimum = min(numbers)
+    maximum = max(numbers)
+    separator = " to " if minimum < 0 or maximum < 0 else "-"
+    return f"{_format_number(minimum)}{separator}{_format_number(maximum)}"
+
+
+def _safe_rate(numerator: int, denominator: int) -> float:
+    if denominator <= 0:
+        return 0.0
+    return round(numerator / denominator, 6)
+
+
+def _equivalence_groups(
+    rows: Sequence[Dict[str, str]],
+    quasi_identifiers: Sequence[str],
+) -> Dict[Tuple[str, ...], List[int]]:
+    groups: Dict[Tuple[str, ...], List[int]] = defaultdict(list)
+    for row_index, row in enumerate(rows):
+        key = tuple(row[column] for column in quasi_identifiers)
+        groups[key].append(row_index)
+    return dict(groups)
+
+
+def _l_diversity_satisfied(
+    rows: Sequence[Dict[str, str]],
+    equivalence_groups: Dict[Tuple[str, ...], List[int]],
+    sensitive_column: str,
+    l: int,
+) -> bool:
+    if not equivalence_groups:
+        return False
+
+    for row_indices in equivalence_groups.values():
+        sensitive_values = {
+            rows[row_index].get(sensitive_column, UNKNOWN_VALUE)
+            for row_index in row_indices
+        }
+        if len(sensitive_values) < l:
+            return False
+    return True
+
+
+def _write_csv(
+    retained_columns: Sequence[str],
+    anonymized_rows: Sequence[Dict[str, str]],
+) -> str:
+    buffer = io.StringIO()
+    writer = csv.DictWriter(
+        buffer,
+        fieldnames=list(retained_columns),
+        lineterminator="\n",
+    )
+    writer.writeheader()
+    for row in anonymized_rows:
+        writer.writerow(row)
+    return buffer.getvalue()

--- a/python_backend/services/text_anonymization.py
+++ b/python_backend/services/text_anonymization.py
@@ -1,9 +1,16 @@
 import hashlib
 import os
 import re
+from datetime import datetime, timedelta
 from functools import lru_cache
 from pathlib import Path
 from typing import Any, Dict, Iterable, Iterator, List, Tuple
+
+from services.privacy_profiles import (
+    PrivacyProfileError,
+    get_privacy_profile,
+    validate_privacy_profile,
+)
 
 SUPPORTED_PROFILES = {"strict", "research"}
 STUDY_SALT_ENV_VAR = "BIOBLOCK_STUDY_SALT"
@@ -18,6 +25,16 @@ _ID_ENTITY_TYPES = {
     "DEVICE_ID",
 }
 _IDENTIFIER_AT_END = re.compile(r"([A-Z0-9][A-Z0-9-]{3,30})\b", re.IGNORECASE)
+DIRECT_IDENTIFIER_REDACTIONS = {
+    "PERSON": "<REDACTED_NAME>",
+    "MEDICAL_RECORD_NUMBER": "<REDACTED_MRN>",
+    "PATIENT_ID": "<REDACTED_PATIENT_ID>",
+    "HEALTH_PLAN_ID": "<REDACTED_HEALTH_PLAN>",
+    "INSURANCE_ID": "<REDACTED_HEALTH_PLAN>",
+    "ACCESSION_NUMBER": "<REDACTED_ACCESSION>",
+    "DEVICE_ID": "<REDACTED_DEVICE_ID>",
+}
+
 
 
 class TextAnonymizationError(ValueError):
@@ -242,6 +259,18 @@ def _common_phi_recognizers() -> List[Any]:
 
     return [
         PatternRecognizer(
+            supported_entity="PERSON",
+            name="Patient Context Name Recognizer",
+            patterns=[
+                _pattern(
+                    "patient_context_name",
+                    r"(?<=\bPatient\s)(?-i:[A-Z][a-z]+(?:\s+[A-Z][a-z]+){1,3})\b",
+                    0.75,
+                )
+            ],
+            context=["patient", "name"],
+        ),
+        PatternRecognizer(
             supported_entity="EMAIL_ADDRESS",
             name="Email Address Recognizer",
             patterns=[
@@ -316,13 +345,16 @@ def _get_analyzer():
         ) from exc
 
 
+def _profile_settings(profile: str) -> tuple[str, Dict[str, Any]]:
+    try:
+        normalized = validate_privacy_profile(profile)
+        return normalized, get_privacy_profile(normalized)
+    except PrivacyProfileError as exc:
+        raise TextAnonymizationError(exc.detail, status_code=exc.status_code) from exc
+
+
 def _normalize_profile(profile: str) -> str:
-    normalized = (profile or "").strip().lower()
-    if normalized not in SUPPORTED_PROFILES:
-        raise TextAnonymizationError(
-            "Invalid privacy profile. Supported profiles: strict, research"
-        )
-    return normalized
+    return _profile_settings(profile)[0]
 
 
 def _select_non_overlapping(results: Iterable[Any]) -> List[Any]:
@@ -359,7 +391,41 @@ def _hash_value(entity_type: str, value: str) -> str:
     return value
 
 
-def _replacement_for(entity_type: str, value: str, salt: str) -> str:
+def _date_shift_days(salt: str) -> int:
+    value = int(stable_hash("date-shift", salt, length=6), 16)
+    days = value % 731 - 365
+    return days or 17
+
+
+def _shift_date_text(value: str, salt: str) -> str:
+    cleaned = value.strip()
+    formats = [
+        ("%Y-%m-%d", "%Y-%m-%d"),
+        ("%m/%d/%Y", "%m/%d/%Y"),
+        ("%m/%d/%y", "%m/%d/%Y"),
+    ]
+    for input_format, output_format in formats:
+        try:
+            shifted = datetime.strptime(cleaned, input_format) + timedelta(
+                days=_date_shift_days(salt)
+            )
+            return shifted.strftime(output_format)
+        except ValueError:
+            continue
+    return "<REDACTED_DATE>"
+
+def _replacement_for(
+    entity_type: str,
+    value: str,
+    salt: str,
+    settings: Dict[str, Any],
+) -> str:
+    if (
+        entity_type in DIRECT_IDENTIFIER_REDACTIONS
+        and settings["text_identifier_strategy"] == "redact"
+    ):
+        return DIRECT_IDENTIFIER_REDACTIONS[entity_type]
+
     hash_value = _hash_value(entity_type, value)
     if entity_type == "PERSON":
         return pseudonymize_person(hash_value, salt)
@@ -380,11 +446,18 @@ def _replacement_for(entity_type: str, value: str, salt: str) -> str:
     if entity_type in {"US_SSN", "SSN"}:
         return "<REDACTED_SSN>"
     if entity_type == "DATE_TIME":
+        if settings["date_strategy"] == "shift":
+            return _shift_date_text(value, salt)
         return "<REDACTED_DATE>"
     return f"<REDACTED_{entity_type}>"
 
 
-def _replace_entities(text: str, results: List[Any], salt: str) -> str:
+def _replace_entities(
+    text: str,
+    results: List[Any],
+    salt: str,
+    settings: Dict[str, Any],
+) -> str:
     anonymized_parts = []
     cursor = 0
 
@@ -392,7 +465,7 @@ def _replace_entities(text: str, results: List[Any], salt: str) -> str:
         anonymized_parts.append(text[cursor : result.start])
         original_value = text[result.start : result.end]
         anonymized_parts.append(
-            _replacement_for(result.entity_type, original_value, salt)
+            _replacement_for(result.entity_type, original_value, salt, settings)
         )
         cursor = result.end
 
@@ -448,7 +521,7 @@ def anonymize_clinical_text(
     if not text.strip():
         raise TextAnonymizationError("Text input is empty")
 
-    _normalize_profile(profile)
+    privacy_profile, settings = _profile_settings(profile)
     salt = _resolve_study_salt(study_salt)
 
     analyzer = _get_analyzer()
@@ -479,6 +552,13 @@ def anonymize_clinical_text(
     selected_results = _select_non_overlapping(results)
     return {
         "anonymization_status": "completed",
-        "anonymized_text": _replace_entities(text, selected_results, salt),
+        "privacy_profile": privacy_profile,
+        "date_strategy": settings["date_strategy"],
+        "text_identifier_strategy": settings["text_identifier_strategy"],
+        "anonymized_text": _replace_entities(text, selected_results, salt, settings),
         "detected_entities": _entity_summary(selected_results),
     }
+
+
+
+

--- a/python_backend/services/text_anonymization.py
+++ b/python_backend/services/text_anonymization.py
@@ -35,6 +35,19 @@ DIRECT_IDENTIFIER_REDACTIONS = {
     "DEVICE_ID": "<REDACTED_DEVICE_ID>",
 }
 
+CLINICAL_PHI_ENTITY_TYPES = (
+    "PERSON",
+    "MEDICAL_RECORD_NUMBER",
+    "PATIENT_ID",
+    "HEALTH_PLAN_ID",
+    "ACCESSION_NUMBER",
+    "DEVICE_ID",
+    "EMAIL_ADDRESS",
+    "PHONE_NUMBER",
+    "US_SSN",
+    "DATE_TIME",
+)
+
 
 
 class TextAnonymizationError(ValueError):
@@ -511,6 +524,31 @@ def _resolve_study_salt(study_salt: str | None) -> str:
     )
 
 
+def _analyze_clinical_phi(text: str) -> List[Any]:
+    if not isinstance(text, str):
+        raise TextAnonymizationError("Text input must be a string")
+    if not text.strip():
+        return []
+
+    analyzer = _get_analyzer()
+    try:
+        results = analyzer.analyze(
+            text=text,
+            language="en",
+            entities=list(CLINICAL_PHI_ENTITY_TYPES),
+        )
+    except Exception as exc:
+        raise TextAnonymizationError(
+            "Text PHI detection failed", status_code=500
+        ) from exc
+    return _select_non_overlapping(results)
+
+
+def detect_clinical_phi(text: str) -> Dict[str, int]:
+    """Return safe entity counts without returning source text or offsets."""
+    return _entity_summary(_analyze_clinical_phi(text))
+
+
 def anonymize_clinical_text(
     text: str,
     profile: str = "strict",
@@ -524,32 +562,7 @@ def anonymize_clinical_text(
     privacy_profile, settings = _profile_settings(profile)
     salt = _resolve_study_salt(study_salt)
 
-    analyzer = _get_analyzer()
-    try:
-        results = analyzer.analyze(
-            text=text,
-            language="en",
-            entities=[
-                "PERSON",
-                "MEDICAL_RECORD_NUMBER",
-                "PATIENT_ID",
-                "HEALTH_PLAN_ID",
-                "INSURANCE_ID",
-                "ACCESSION_NUMBER",
-                "DEVICE_ID",
-                "EMAIL_ADDRESS",
-                "PHONE_NUMBER",
-                "US_SSN",
-                "SSN",
-                "DATE_TIME",
-            ],
-        )
-    except Exception as exc:
-        raise TextAnonymizationError(
-            "Text anonymization failed", status_code=500
-        ) from exc
-
-    selected_results = _select_non_overlapping(results)
+    selected_results = _analyze_clinical_phi(text)
     return {
         "anonymization_status": "completed",
         "privacy_profile": privacy_profile,

--- a/python_backend/services/wsi_tiling.py
+++ b/python_backend/services/wsi_tiling.py
@@ -1,0 +1,350 @@
+from __future__ import annotations
+
+import os
+import tempfile
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+
+from PIL import Image
+
+from services.ocr_redaction import (
+    OCRBackend,
+    OCRBox,
+    OCREngineUnavailable,
+    get_default_ocr_backend,
+)
+
+
+DEFAULT_TILE_SIZE = 1024
+DEFAULT_BORDER_FRACTION = 0.15
+
+
+@dataclass(frozen=True)
+class TileCoordinate:
+    x: int
+    y: int
+    width: int
+    height: int
+    priority_region: str
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "x": self.x,
+            "y": self.y,
+            "width": self.width,
+            "height": self.height,
+            "priority_region": self.priority_region,
+        }
+
+
+def generate_priority_tiles(
+    width: int,
+    height: int,
+    tile_size: int = DEFAULT_TILE_SIZE,
+    border_fraction: float = DEFAULT_BORDER_FRACTION,
+) -> List[TileCoordinate]:
+    if width <= 0 or height <= 0:
+        raise ValueError("Image dimensions must be positive")
+    if tile_size <= 0:
+        raise ValueError("Tile size must be positive")
+    if border_fraction <= 0:
+        raise ValueError("Border fraction must be positive")
+
+    tiles: List[TileCoordinate] = []
+    seen = set()
+
+    def add_tile(x: int, y: int, region: str):
+        clamped_x = _clamp_start(x, width, tile_size)
+        clamped_y = _clamp_start(y, height, tile_size)
+        tile_width = min(tile_size, width - clamped_x)
+        tile_height = min(tile_size, height - clamped_y)
+        key = (clamped_x, clamped_y, tile_width, tile_height)
+        if key in seen:
+            return
+        seen.add(key)
+        tiles.append(
+            TileCoordinate(
+                x=clamped_x,
+                y=clamped_y,
+                width=tile_width,
+                height=tile_height,
+                priority_region=region,
+            )
+        )
+
+    right_x = max(0, width - tile_size)
+    bottom_y = max(0, height - tile_size)
+
+    add_tile(0, 0, "corner_top_left")
+    add_tile(right_x, 0, "corner_top_right")
+    add_tile(0, bottom_y, "corner_bottom_left")
+    add_tile(right_x, bottom_y, "corner_bottom_right")
+
+    border_depth_x = max(1, int(round(width * border_fraction)))
+    border_depth_y = max(1, int(round(height * border_fraction)))
+    x_positions = _axis_tile_positions(width, tile_size)
+    y_positions = _axis_tile_positions(height, tile_size)
+
+    for y in _leading_border_positions(height, tile_size, border_depth_y):
+        for x in x_positions:
+            add_tile(x, y, "top_border")
+
+    for y in _trailing_border_positions(height, tile_size, border_depth_y):
+        for x in x_positions:
+            add_tile(x, y, "bottom_border")
+
+    for x in _leading_border_positions(width, tile_size, border_depth_x):
+        for y in y_positions:
+            add_tile(x, y, "left_border")
+
+    for x in _trailing_border_positions(width, tile_size, border_depth_x):
+        for y in y_positions:
+            add_tile(x, y, "right_border")
+
+    return tiles
+
+
+def map_tile_boxes_to_slide(
+    tile: TileCoordinate,
+    boxes: Iterable[OCRBox],
+) -> List[OCRBox]:
+    return [
+        OCRBox(
+            text=box.text,
+            confidence=box.confidence,
+            x=tile.x + box.x,
+            y=tile.y + box.y,
+            width=box.width,
+            height=box.height,
+        )
+        for box in boxes
+    ]
+
+
+def scan_wsi_slide(
+    slide: Any,
+    ocr_backend: Optional[OCRBackend] = None,
+    tile_size: int = DEFAULT_TILE_SIZE,
+    border_fraction: float = DEFAULT_BORDER_FRACTION,
+) -> Dict[str, Any]:
+    width, height = _slide_dimensions(slide)
+    tiles = generate_priority_tiles(
+        width=width,
+        height=height,
+        tile_size=tile_size,
+        border_fraction=border_fraction,
+    )
+
+    backend = ocr_backend or get_default_ocr_backend()
+    engine_status = _backend_status(backend)
+    if engine_status == "unavailable":
+        return _wsi_result(
+            pixel_redaction_status="skipped_ocr_unavailable",
+            ocr_engine_status=engine_status,
+            image_dimensions={"width": width, "height": height},
+            tile_size=tile_size,
+        )
+
+    boxes_detected = 0
+    tiles_scanned = 0
+    priority_regions: List[str] = []
+
+    try:
+        for tile in tiles:
+            tile_image = slide.read_region(
+                (tile.x, tile.y),
+                0,
+                (tile.width, tile.height),
+            )
+            if isinstance(tile_image, Image.Image) and tile_image.mode == "RGBA":
+                tile_image = tile_image.convert("RGB")
+
+            boxes = list(backend.detect_text_boxes(tile_image))
+            boxes_detected += len(map_tile_boxes_to_slide(tile, boxes))
+            tiles_scanned += 1
+            if tile.priority_region not in priority_regions:
+                priority_regions.append(tile.priority_region)
+    except OCREngineUnavailable:
+        return _wsi_result(
+            pixel_redaction_status="skipped_ocr_unavailable",
+            ocr_engine_status="unavailable",
+            image_dimensions={"width": width, "height": height},
+            tile_size=tile_size,
+            tiles_scanned=tiles_scanned,
+            priority_regions_scanned=priority_regions,
+        )
+    except Exception:
+        return _wsi_result(
+            pixel_redaction_status="ocr_failed",
+            ocr_engine_status="error",
+            image_dimensions={"width": width, "height": height},
+            tile_size=tile_size,
+            tiles_scanned=tiles_scanned,
+            priority_regions_scanned=priority_regions,
+        )
+
+    return _wsi_result(
+        pixel_redaction_status="redaction_plan_ready",
+        ocr_boxes_detected=boxes_detected,
+        boxes_redacted=0,
+        redaction_plan_boxes=boxes_detected,
+        ocr_engine_status=engine_status,
+        image_dimensions={"width": width, "height": height},
+        tile_size=tile_size,
+        tiles_scanned=tiles_scanned,
+        priority_regions_scanned=priority_regions,
+    )
+
+
+def scan_wsi_bytes(
+    file_bytes: bytes,
+    filename: str,
+    ocr_backend: Optional[OCRBackend] = None,
+    tile_size: int = DEFAULT_TILE_SIZE,
+    border_fraction: float = DEFAULT_BORDER_FRACTION,
+) -> Dict[str, Any]:
+    openslide_module = _load_openslide_module()
+    if openslide_module is None:
+        return _wsi_result(
+            pixel_redaction_status="redaction_plan_unavailable",
+            ocr_engine_status=_backend_status(ocr_backend or get_default_ocr_backend()),
+            tile_size=tile_size,
+        )
+
+    suffix = _safe_suffix(filename)
+    temp_path = None
+    try:
+        temp_file = tempfile.NamedTemporaryFile(
+            suffix=suffix,
+            prefix="bioblock_wsi_",
+            delete=False,
+        )
+        temp_path = temp_file.name
+        with temp_file:
+            temp_file.write(file_bytes)
+
+        slide = openslide_module.OpenSlide(temp_path)
+    except Exception:
+        if temp_path and os.path.exists(temp_path):
+            os.unlink(temp_path)
+        return _wsi_result(
+            pixel_redaction_status="unsupported_wsi_format",
+            ocr_engine_status=_backend_status(ocr_backend or get_default_ocr_backend()),
+            tile_size=tile_size,
+        )
+
+    try:
+        return scan_wsi_slide(
+            slide=slide,
+            ocr_backend=ocr_backend,
+            tile_size=tile_size,
+            border_fraction=border_fraction,
+        )
+    finally:
+        try:
+            slide.close()
+        finally:
+            if temp_path and os.path.exists(temp_path):
+                os.unlink(temp_path)
+
+
+def _axis_tile_positions(length: int, tile_size: int) -> List[int]:
+    if length <= tile_size:
+        return [0]
+
+    positions = list(range(0, length, tile_size))
+    final_start = max(0, length - tile_size)
+    if positions[-1] != final_start:
+        positions.append(final_start)
+    return positions
+
+
+def _leading_border_positions(length: int, tile_size: int, depth: int) -> List[int]:
+    positions = []
+    current = 0
+    limit = min(depth, length)
+    while current < limit:
+        positions.append(_clamp_start(current, length, tile_size))
+        current += tile_size
+    return _dedupe_preserve_order(positions)
+
+
+def _trailing_border_positions(length: int, tile_size: int, depth: int) -> List[int]:
+    positions = []
+    current = _clamp_start(length - tile_size, length, tile_size)
+    limit = max(0, length - depth)
+    while current + min(tile_size, length - current) > limit:
+        positions.append(_clamp_start(current, length, tile_size))
+        current -= tile_size
+        if current < 0:
+            break
+    return _dedupe_preserve_order(positions)
+
+
+def _clamp_start(start: int, length: int, tile_size: int) -> int:
+    return max(0, min(int(start), max(0, length - tile_size)))
+
+
+def _dedupe_preserve_order(values: Sequence[int]) -> List[int]:
+    seen = set()
+    result = []
+    for value in values:
+        if value in seen:
+            continue
+        seen.add(value)
+        result.append(value)
+    return result
+
+
+def _slide_dimensions(slide: Any) -> Tuple[int, int]:
+    dimensions = getattr(slide, "dimensions", None)
+    if not dimensions or len(dimensions) != 2:
+        raise ValueError("WSI slide must expose width and height dimensions")
+    return int(dimensions[0]), int(dimensions[1])
+
+
+def _backend_status(backend: OCRBackend) -> str:
+    status = getattr(backend, "ocr_engine_status", "available")
+    if callable(status):
+        status = status()
+    return str(status or "available")
+
+
+def _load_openslide_module():
+    try:
+        import openslide
+    except Exception:
+        return None
+    return openslide
+
+
+def _safe_suffix(filename: str) -> str:
+    _, extension = os.path.splitext(filename or "")
+    if not extension:
+        return ".svs"
+    return extension.lower()
+
+
+def _wsi_result(
+    pixel_redaction_status: str,
+    ocr_boxes_detected: int = 0,
+    boxes_redacted: int = 0,
+    redaction_plan_boxes: int = 0,
+    tiles_scanned: int = 0,
+    priority_regions_scanned: Optional[List[str]] = None,
+    image_dimensions: Optional[Dict[str, int]] = None,
+    tile_size: int = DEFAULT_TILE_SIZE,
+    ocr_engine_status: str = "not_applicable",
+) -> Dict[str, Any]:
+    return {
+        "pixel_redaction_status": pixel_redaction_status,
+        "ocr_boxes_detected": ocr_boxes_detected,
+        "boxes_redacted": boxes_redacted,
+        "redaction_plan_boxes": redaction_plan_boxes,
+        "tiles_scanned": tiles_scanned,
+        "priority_regions_scanned": priority_regions_scanned or [],
+        "image_dimensions": image_dimensions,
+        "tile_size": tile_size,
+        "ocr_engine_status": ocr_engine_status,
+        "wsi_rewrite_status": "not_supported_yet",
+    }

--- a/python_backend/tests/test_api.py
+++ b/python_backend/tests/test_api.py
@@ -2,6 +2,7 @@ import unittest
 from fastapi.testclient import TestClient
 import sys
 import os
+from io import BytesIO
 
 # Add parent directory to path to import main
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -176,7 +177,7 @@ class TestAPI(unittest.TestCase):
         self.assertEqual(resp.status_code, 400)
 
     def test_anonymize_dicom_with_phi(self):
-        """Test DICOM anonymization strips PHI metadata tags"""
+        """Test DICOM anonymization replaces PHI metadata tags with safe placeholders"""
         try:
             import pydicom
             from pydicom.dataset import Dataset, FileDataset
@@ -205,14 +206,19 @@ class TestAPI(unittest.TestCase):
             os.unlink(tmp.name)
 
             self.assertEqual(resp.status_code, 200)
-            result = resp.json()
-            self.assertIn("fields_stripped", result)
-            self.assertGreater(result["fields_stripped"], 0)
-            # Verify known PHI fields were stripped
-            stripped_names = [s["field"] for s in result["stripped_details"]]
-            self.assertIn("PatientName", stripped_names)
-            self.assertIn("PatientID", stripped_names)
-            self.assertIn("PatientBirthDate", stripped_names)
+            self.assertTrue(resp.headers["content-type"].startswith("application/dicom"))
+            self.assertIn("anonymized_test.dcm", resp.headers["content-disposition"])
+            self.assertGreater(int(resp.headers["x-bioblock-fields-scrubbed"]), 0)
+
+            downloaded = pydicom.dcmread(BytesIO(resp.content), force=False)
+            self.assertEqual(str(downloaded.PatientName), "")
+            self.assertEqual(str(downloaded.PatientID), "")
+            self.assertEqual(str(downloaded.PatientBirthDate), "19000101")
+            self.assertEqual(str(downloaded.ReferringPhysicianName), "")
+            self.assertEqual(str(downloaded.InstitutionName), "")
+            self.assertEqual(str(downloaded.PatientIdentityRemoved), "YES")
+            self.assertNotIn(b"John Smith", resp.content)
+            self.assertNotIn(b"PAT12345", resp.content)
         except ImportError:
             self.skipTest("pydicom not installed, skipping DICOM test")
 
@@ -241,10 +247,15 @@ class TestAPI(unittest.TestCase):
             os.unlink(tmp.name)
 
             self.assertEqual(resp.status_code, 200)
-            result = resp.json()
-            self.assertEqual(result["fields_stripped"], 0)
+            self.assertTrue(resp.headers["content-type"].startswith("application/dicom"))
+            self.assertIn("anonymized_clean.dcm", resp.headers["content-disposition"])
+            self.assertEqual(int(resp.headers["x-bioblock-fields-scrubbed"]), 0)
+
+            downloaded = pydicom.dcmread(BytesIO(resp.content), force=False)
+            self.assertEqual(downloaded.Modality, "CT")
         except ImportError:
             self.skipTest("pydicom not installed, skipping DICOM test")
 
 if __name__ == "__main__":
     unittest.main()
+

--- a/python_backend/tests/test_bm25_retrieval.py
+++ b/python_backend/tests/test_bm25_retrieval.py
@@ -1,0 +1,562 @@
+import logging
+import os
+import sys
+
+import pytest
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from services.bm25_retrieval import BM25QueryError  # noqa: E402
+from services.bm25_retrieval import BM25RetrievalService  # noqa: E402
+from services.bm25_retrieval import SearchableDocument  # noqa: E402
+from services.bm25_retrieval import UnsafeDocumentError  # noqa: E402
+from services.bm25_retrieval import tokenize  # noqa: E402
+
+
+def _document(
+    document_id,
+    text,
+    *,
+    modality="text",
+    metadata=None,
+    anonymization_status="completed",
+    privacy_validation_status="passed",
+):
+    return SearchableDocument(
+        document_id=document_id,
+        modality=modality,
+        anonymized_text=text,
+        anonymization_status=anonymization_status,
+        safe_metadata=metadata or {},
+        privacy_validation_status=privacy_validation_status,
+    )
+
+
+def test_tokenizer_is_case_insensitive_and_preserves_clinical_tokens():
+    assert tokenize("  HbA1c, E11.9; COVID-19 and type 2 diabetes  ") == [
+        "hba1c",
+        "e11.9",
+        "covid-19",
+        "and",
+        "type",
+        "2",
+        "diabetes",
+    ]
+
+
+def test_relevant_document_ranks_first():
+    service = BM25RetrievalService()
+    service.index_documents(
+        [
+            _document("doc-unrelated", "Routine respiratory follow-up."),
+            _document("doc-diabetes", "Type 2 diabetes care with HbA1c review."),
+        ]
+    )
+
+    results = service.search("type 2 diabetes")
+
+    assert results[0]["document_id"] == "doc-diabetes"
+    assert results[0]["rank"] == 1
+    assert results[0]["score"] > 0
+
+
+def test_rare_term_has_more_weight_than_common_term():
+    service = BM25RetrievalService()
+    service.index_documents(
+        [
+            _document("doc-rare", "common rareterm"),
+            _document("doc-common-a", "common routine"),
+            _document("doc-common-b", "common standard"),
+        ]
+    )
+
+    rare_score = service.search("rareterm")[0]["score"]
+    common_score = next(
+        result["score"]
+        for result in service.search("common")
+        if result["document_id"] == "doc-rare"
+    )
+
+    assert rare_score > common_score
+
+
+def test_search_is_case_insensitive():
+    service = BM25RetrievalService()
+    service.upsert_document(_document("doc-1", "Hypertension medication review."))
+
+    assert service.search("HYPERTENSION")[0]["document_id"] == "doc-1"
+
+
+@pytest.mark.parametrize("query", ["E11.9", "e11.9"])
+def test_clinical_code_search_handles_punctuation(query):
+    service = BM25RetrievalService()
+    service.upsert_document(
+        _document(
+            "doc-code",
+            "Diabetes assessment.",
+            metadata={"clinical_codes": ["E11.9"]},
+        )
+    )
+
+    assert service.search(query)[0]["document_id"] == "doc-code"
+
+
+def test_hyphenated_term_search():
+    service = BM25RetrievalService()
+    service.upsert_document(_document("doc-covid", "COVID-19 follow-up completed."))
+
+    assert service.search("covid-19")[0]["document_id"] == "doc-covid"
+
+
+def test_repeated_query_terms_contribute_repeatedly():
+    service = BM25RetrievalService()
+    service.upsert_document(_document("doc-1", "asthma management"))
+
+    single_score = service.search("asthma")[0]["score"]
+    repeated_score = service.search("asthma asthma")[0]["score"]
+
+    assert repeated_score == pytest.approx(single_score * 2)
+
+
+def test_empty_query_is_rejected():
+    service = BM25RetrievalService()
+
+    with pytest.raises(BM25QueryError):
+        service.search("   ...   ")
+
+
+@pytest.mark.parametrize("top_k", [0, 101, True])
+def test_top_k_is_validated(top_k):
+    service = BM25RetrievalService()
+
+    with pytest.raises(BM25QueryError):
+        service.search("asthma", top_k=top_k)
+
+
+def test_empty_index_returns_no_results():
+    assert BM25RetrievalService().search("diabetes") == []
+
+
+def test_no_match_returns_empty_results():
+    service = BM25RetrievalService()
+    service.upsert_document(_document("doc-1", "asthma review"))
+
+    assert service.search("nonexistentterm") == []
+
+
+def test_ties_are_deterministic_by_document_id():
+    service = BM25RetrievalService()
+    service.index_documents(
+        [
+            _document("doc-b", "same clinical text"),
+            _document("doc-a", "same clinical text"),
+        ]
+    )
+
+    assert [result["document_id"] for result in service.search("clinical")] == [
+        "doc-a",
+        "doc-b",
+    ]
+
+
+def test_modality_filter_is_applied_before_top_k():
+    service = BM25RetrievalService()
+    service.index_documents(
+        [
+            _document("doc-text", "MRI brain finding", modality="text"),
+            _document("doc-mri", "MRI brain finding", modality="MRI"),
+        ]
+    )
+
+    results = service.search("MRI brain", top_k=1, filters={"modality": "mri"})
+
+    assert [result["document_id"] for result in results] == ["doc-mri"]
+
+
+def test_unsupported_filter_is_rejected():
+    with pytest.raises(BM25QueryError):
+        BM25RetrievalService().search("asthma", filters={"owner": "value"})
+
+
+def test_duplicate_id_upsert_replaces_document():
+    service = BM25RetrievalService()
+    service.upsert_document(_document("doc-1", "asthma"))
+    service.upsert_document(_document("doc-1", "hypertension"))
+
+    assert service.document_count == 1
+    assert service.search("asthma") == []
+    assert service.search("hypertension")[0]["document_id"] == "doc-1"
+
+
+def test_rebuild_replaces_the_existing_index():
+    service = BM25RetrievalService()
+    service.upsert_document(_document("old", "asthma"))
+
+    count = service.rebuild(
+        [
+            _document("new-a", "diabetes"),
+            _document("new-b", "hypertension"),
+        ]
+    )
+
+    assert count == 2
+    assert service.search("asthma") == []
+    assert service.search("diabetes")[0]["document_id"] == "new-a"
+
+
+def test_rebuild_is_atomic_when_a_document_is_unsafe():
+    service = BM25RetrievalService()
+    service.upsert_document(_document("existing", "asthma"))
+
+    with pytest.raises(UnsafeDocumentError):
+        service.rebuild(
+            [
+                _document("safe", "diabetes"),
+                _document("unsafe", "content", anonymization_status="failed"),
+            ]
+        )
+
+    assert service.document_count == 1
+    assert service.search("asthma")[0]["document_id"] == "existing"
+
+
+def test_term_frequency_contributes_to_ranking():
+    service = BM25RetrievalService()
+    service.index_documents(
+        [
+            _document("frequent", "asthma asthma asthma"),
+            _document("single", "asthma"),
+        ]
+    )
+
+    assert service.search("asthma")[0]["document_id"] == "frequent"
+
+
+def test_document_length_normalization_favors_concise_match():
+    service = BM25RetrievalService()
+    service.index_documents(
+        [
+            _document("short", "asthma plan"),
+            _document("long", "asthma " + "unrelated " * 30),
+        ]
+    )
+
+    assert service.search("asthma")[0]["document_id"] == "short"
+
+
+def test_zero_average_document_length_is_safe():
+    service = BM25RetrievalService()
+    service.upsert_document(_document("empty", "", modality="---"))
+
+    assert service.average_document_length == 0
+    assert service.search("asthma") == []
+
+
+def test_snippet_comes_only_from_anonymized_text():
+    service = BM25RetrievalService(snippet_length=60)
+    service.upsert_document(
+        _document(
+            "doc-1",
+            "Anonymized diabetes summary " + "safe " * 30,
+            metadata={"clinical_terms": ["metadata-only-term"]},
+        )
+    )
+
+    result = service.search("metadata-only-term")[0]
+
+    assert "Anonymized diabetes summary" in result["snippet"]
+    assert "metadata-only-term" not in result["snippet"]
+    assert len(result["snippet"]) <= 62
+
+
+def test_document_id_is_returned_but_not_searchable():
+    service = BM25RetrievalService()
+    service.upsert_document(_document("secret-id-token", "asthma summary"))
+
+    assert service.search("secret-id-token") == []
+    assert service.search("asthma")[0]["document_id"] == "secret-id-token"
+
+
+def test_approved_safe_metadata_is_searchable_and_canonicalized():
+    service = BM25RetrievalService()
+    service.upsert_document(
+        _document(
+            "doc-1",
+            "Clinical review.",
+            metadata={"Document-Type": "radiology", "disease tags": ["oncology"]},
+        )
+    )
+
+    result = service.search("oncology")[0]
+
+    assert result["safe_metadata"] == {
+        "document_type": "radiology",
+        "disease_tags": ["oncology"],
+    }
+
+
+@pytest.mark.parametrize(
+    "status",
+    ["failed", "pending", "completed_with_warnings", ""],
+)
+def test_non_completed_anonymization_is_rejected(status):
+    service = BM25RetrievalService()
+
+    with pytest.raises(UnsafeDocumentError):
+        service.upsert_document(
+            _document("doc-1", "asthma", anonymization_status=status)
+        )
+
+
+def test_missing_anonymization_status_is_rejected():
+    service = BM25RetrievalService()
+
+    with pytest.raises(UnsafeDocumentError):
+        service.upsert_document(
+            {
+                "document_id": "doc-1",
+                "modality": "text",
+                "anonymized_text": "asthma",
+            }
+        )
+
+
+@pytest.mark.parametrize("status", ["failed", "failed_privacy_validation", "pending"])
+def test_failed_privacy_validation_is_rejected(status):
+    service = BM25RetrievalService()
+
+    with pytest.raises(UnsafeDocumentError):
+        service.upsert_document(
+            _document("doc-1", "asthma", privacy_validation_status=status)
+        )
+
+
+@pytest.mark.parametrize(
+    "unsafe_key",
+    [
+        "Patient_Name",
+        "patient-id",
+        "SSN",
+        "MRN",
+        "original.filename",
+        "raw DICOM metadata",
+        "temporary-path",
+        "exact_coordinates",
+        "email_address",
+    ],
+)
+def test_unsafe_metadata_keys_are_rejected_separator_insensitively(unsafe_key):
+    service = BM25RetrievalService()
+
+    with pytest.raises(UnsafeDocumentError):
+        service.upsert_document(
+            _document("doc-1", "asthma", metadata={unsafe_key: "unsafe-value"})
+        )
+
+
+def test_unapproved_metadata_is_rejected():
+    with pytest.raises(UnsafeDocumentError):
+        BM25RetrievalService().upsert_document(
+            _document("doc-1", "asthma", metadata={"arbitrary_field": "value"})
+        )
+
+
+def test_raw_bytes_are_rejected_at_any_document_boundary():
+    service = BM25RetrievalService()
+
+    with pytest.raises(UnsafeDocumentError):
+        service.upsert_document(
+            {
+                "document_id": "doc-1",
+                "modality": "text",
+                "anonymized_text": "asthma",
+                "anonymization_status": "completed",
+                "file_bytes": b"synthetic-bytes",
+            }
+        )
+    with pytest.raises(UnsafeDocumentError):
+        service.upsert_document(
+            _document(
+                "doc-2",
+                "asthma",
+                metadata={"clinical_terms": [b"synthetic-bytes"]},
+            )
+        )
+
+
+def test_raw_content_fields_are_rejected():
+    with pytest.raises(UnsafeDocumentError):
+        BM25RetrievalService().upsert_document(
+            {
+                "document_id": "doc-1",
+                "modality": "text",
+                "anonymized_text": "safe summary",
+                "anonymization_status": "completed",
+                "raw_content": "not eligible",
+            }
+        )
+
+
+def test_delete_document_and_clear():
+    service = BM25RetrievalService()
+    service.upsert_document(_document("doc-1", "asthma"))
+
+    assert service.delete_document("doc-1") is True
+    assert service.delete_document("doc-1") is False
+    assert service.document_count == 0
+
+    service.upsert_document(_document("doc-2", "diabetes"))
+    service.clear()
+    assert service.document_count == 0
+
+
+@pytest.fixture
+def api_context():
+    import main
+
+    main.bm25_retrieval_service.clear()
+    yield main, TestClient(main.app)
+    main.bm25_retrieval_service.clear()
+
+
+def test_bm25_endpoint_returns_ranked_safe_results(api_context):
+    main, client = api_context
+    main.bm25_retrieval_service.index_documents(
+        [
+            _document("doc-other", "Routine asthma review.", modality="text"),
+            _document(
+                "doc-diabetes",
+                "Type 2 diabetes assessment with E11.9.",
+                modality="report",
+                metadata={"document_type": "clinical-summary"},
+            ),
+        ]
+    )
+
+    response = client.post(
+        "/api/v1/search/bm25",
+        json={"query": "type 2 diabetes", "top_k": 5},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["search_type"] == "bm25"
+    assert body["query_metadata"] == {"token_count": 3}
+    assert body["result_count"] == 1
+    assert body["index_document_count"] == 2
+    assert body["retrieval_status"] == "completed"
+    result = body["results"][0]
+    assert result["document_id"] == "doc-diabetes"
+    assert set(result) == {
+        "document_id",
+        "rank",
+        "score",
+        "modality",
+        "safe_metadata",
+        "snippet",
+    }
+    serialized = response.text.lower()
+    for forbidden in (
+        "patientname",
+        "original_filename",
+        "raw_content",
+        "file_bytes",
+        "temporary_path",
+    ):
+        assert forbidden not in serialized
+
+
+def test_bm25_endpoint_modality_filter(api_context):
+    main, client = api_context
+    main.bm25_retrieval_service.index_documents(
+        [
+            _document("text-doc", "MRI brain", modality="text"),
+            _document("mri-doc", "MRI brain", modality="MRI"),
+        ]
+    )
+
+    response = client.post(
+        "/api/v1/search/bm25",
+        json={"query": "MRI brain", "modality": "mri"},
+    )
+
+    assert response.status_code == 200
+    assert [item["document_id"] for item in response.json()["results"]] == [
+        "mri-doc"
+    ]
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"query": ""},
+        {"query": "   "},
+        {"query": "asthma", "top_k": 0},
+        {"query": "asthma", "top_k": 101},
+        {"query": "asthma", "owner": "unsupported"},
+    ],
+)
+def test_bm25_endpoint_rejects_invalid_requests(api_context, payload):
+    _, client = api_context
+
+    response = client.post("/api/v1/search/bm25", json=payload)
+
+    assert response.status_code == 422
+    assert "traceback" not in response.text.lower()
+
+
+def test_bm25_endpoint_no_match_is_empty(api_context):
+    main, client = api_context
+    main.bm25_retrieval_service.upsert_document(_document("doc-1", "asthma"))
+
+    response = client.post(
+        "/api/v1/search/bm25",
+        json={"query": "nonexistentterm"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["results"] == []
+    assert response.json()["result_count"] == 0
+    assert response.json()["retrieval_status"] == "no_matches"
+
+
+def test_bm25_endpoint_empty_index_is_clean(api_context):
+    _, client = api_context
+
+    response = client.post("/api/v1/search/bm25", json={"query": "asthma"})
+
+    assert response.status_code == 200
+    assert response.json()["results"] == []
+    assert response.json()["index_document_count"] == 0
+    assert response.json()["retrieval_status"] == "empty_index"
+
+
+def test_bm25_endpoint_does_not_log_raw_query(api_context, caplog):
+    main, client = api_context
+    main.bm25_retrieval_service.upsert_document(_document("doc-1", "asthma"))
+    sensitive_query = "synthetic-sensitive-query-value"
+
+    with caplog.at_level(logging.INFO, logger="main"):
+        response = client.post(
+            "/api/v1/search/bm25",
+            json={"query": sensitive_query},
+        )
+
+    assert response.status_code == 200
+    assert sensitive_query not in caplog.text
+    assert "query_length=" in caplog.text
+
+
+def test_bm25_endpoint_hides_internal_errors(api_context, monkeypatch):
+    main, client = api_context
+
+    def fail_search(*args, **kwargs):
+        raise RuntimeError("synthetic internal path must stay private")
+
+    monkeypatch.setattr(main.bm25_retrieval_service, "search", fail_search)
+    response = client.post("/api/v1/search/bm25", json={"query": "asthma"})
+
+    assert response.status_code == 500
+    assert response.json() == {"detail": "BM25 search failed"}
+    assert "internal path" not in response.text.lower()

--- a/python_backend/tests/test_dicom_anonymization.py
+++ b/python_backend/tests/test_dicom_anonymization.py
@@ -115,10 +115,23 @@ def test_dicom_pixel_data_is_not_modified():
 
     assert result["metadata_summary"]["pixel_data_present"] is True
     assert result["metadata_summary"]["pixel_data_preserved"] is True
-    assert result["pixel_redaction_status"] == "not_started_week4"
+    assert result["pixel_redaction_status"] == "metadata_only"
 
 
-def test_dicom_api_returns_completed_without_raw_phi():
+def test_dicom_api_returns_completed_without_raw_phi(monkeypatch):
+    monkeypatch.setattr(
+        "services.ingestion.redact_dicom_pixels",
+        lambda file_content, profile="strict": {
+            "pixel_redaction_status": "completed",
+            "ocr_boxes_detected": 1,
+            "boxes_redacted": 1,
+            "frames_processed": 1,
+            "scanned_regions": 1,
+            "ocr_engine_status": "available",
+            "sanitized_dicom_bytes": b"internal-only",
+        },
+    )
+
     response = client.post(
         "/api/v1/ingest",
         files={
@@ -136,7 +149,12 @@ def test_dicom_api_returns_completed_without_raw_phi():
     assert body["detected_modality"] == "dicom"
     assert body["handler"] == "anonymize_dicom"
     assert body["anonymization_status"] == "completed"
-    assert body["pixel_redaction_status"] == "not_started_week4"
+    assert body["pixel_redaction_status"] == "completed"
+    assert body["ocr_boxes_detected"] == 1
+    assert body["boxes_redacted"] == 1
+    assert body["ocr_engine_status"] == "available"
     assert TOP_LEVEL_NAME not in response_text
     assert PATIENT_ID not in response_text
+    assert "BURNED_IN_LABEL" not in response_text
+    assert "sanitized_dicom_bytes" not in body
     assert "file_bytes" not in body

--- a/python_backend/tests/test_dicom_anonymization.py
+++ b/python_backend/tests/test_dicom_anonymization.py
@@ -3,6 +3,7 @@ import os
 import sys
 from io import BytesIO
 
+import pydicom
 import pytest
 from fastapi.testclient import TestClient
 from pydicom.dataset import Dataset, FileDataset, FileMetaDataset
@@ -14,6 +15,7 @@ os.environ.setdefault("BIOBLOCK_STUDY_SALT", "week3-test-salt")
 
 from main import app  # noqa: E402
 from services.dicom_anonymization import (  # noqa: E402
+    anonymize_dicom_file_bytes,
     DicomAnonymizationError,
     anonymize_dicom_metadata,
 )
@@ -118,10 +120,29 @@ def test_dicom_pixel_data_is_not_modified():
     assert result["pixel_redaction_status"] == "metadata_only"
 
 
+def test_dicom_file_bytes_are_metadata_scrubbed_and_readable():
+    result = anonymize_dicom_file_bytes(build_dicom_bytes())
+    safe_result = {
+        key: value
+        for key, value in result.items()
+        if key != "anonymized_dicom_bytes"
+    }
+    dataset = pydicom.dcmread(BytesIO(result["anonymized_dicom_bytes"]))
+
+    assert dataset.PatientName == ""
+    assert dataset.PatientID == ""
+    assert dataset.PixelData == PIXEL_BYTES
+    assert TOP_LEVEL_NAME not in json.dumps(safe_result)
+    assert PATIENT_ID not in json.dumps(safe_result)
+    assert result["metadata_summary"]["pixel_data_preserved"] is True
+
 def test_dicom_api_returns_completed_without_raw_phi(monkeypatch):
-    monkeypatch.setattr(
-        "services.ingestion.redact_dicom_pixels",
-        lambda file_content, profile="strict": {
+    def fake_pixel_redaction(file_content, profile="strict"):
+        dataset = pydicom.dcmread(BytesIO(file_content))
+        assert dataset.PatientName == ""
+        assert dataset.PatientID == ""
+        assert dataset.PixelData == PIXEL_BYTES
+        return {
             "pixel_redaction_status": "completed",
             "ocr_boxes_detected": 1,
             "boxes_redacted": 1,
@@ -129,7 +150,11 @@ def test_dicom_api_returns_completed_without_raw_phi(monkeypatch):
             "scanned_regions": 1,
             "ocr_engine_status": "available",
             "sanitized_dicom_bytes": b"internal-only",
-        },
+        }
+
+    monkeypatch.setattr(
+        "services.ingestion.redact_dicom_pixels",
+        fake_pixel_redaction,
     )
 
     response = client.post(

--- a/python_backend/tests/test_dicom_anonymization.py
+++ b/python_backend/tests/test_dicom_anonymization.py
@@ -1,0 +1,142 @@
+import json
+import os
+import sys
+from io import BytesIO
+
+import pytest
+from fastapi.testclient import TestClient
+from pydicom.dataset import Dataset, FileDataset, FileMetaDataset
+from pydicom.sequence import Sequence
+from pydicom.uid import ExplicitVRLittleEndian, SecondaryCaptureImageStorage
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+os.environ.setdefault("BIOBLOCK_STUDY_SALT", "week3-test-salt")
+
+from main import app  # noqa: E402
+from services.dicom_anonymization import (  # noqa: E402
+    DicomAnonymizationError,
+    anonymize_dicom_metadata,
+)
+
+
+client = TestClient(app)
+
+TOP_LEVEL_NAME = "SYNTHETIC^PERSON"
+NESTED_NAME = "NESTED^SYNTH"
+PATIENT_ID = "SYN-PAT-001"
+PRIVATE_VALUE = "SYN_PRIV"
+PIXEL_BYTES = b"\x01\x02\x03\x04"
+
+
+def build_dicom_bytes() -> bytes:
+    file_meta = FileMetaDataset()
+    file_meta.TransferSyntaxUID = ExplicitVRLittleEndian
+    file_meta.MediaStorageSOPClassUID = SecondaryCaptureImageStorage
+    file_meta.MediaStorageSOPInstanceUID = "1.2.826.0.1.3680043.8.498.1"
+    file_meta.ImplementationClassUID = "1.2.826.0.1.3680043.8.498.2"
+
+    dataset = FileDataset(
+        None,
+        {},
+        file_meta=file_meta,
+        preamble=b"\0" * 128,
+    )
+    dataset.SOPClassUID = SecondaryCaptureImageStorage
+    dataset.SOPInstanceUID = file_meta.MediaStorageSOPInstanceUID
+    dataset.PatientName = TOP_LEVEL_NAME
+    dataset.PatientID = PATIENT_ID
+    dataset.PatientBirthDate = "19600101"
+    dataset.AccessionNumber = "SYN-ACC-01"
+    dataset.StudyDate = "20240101"
+    dataset.InstitutionName = "SYN_INST"
+
+    nested_item = Dataset()
+    nested_item.PatientName = NESTED_NAME
+    nested_item.PatientID = "NEST-ID-01"
+    dataset.ReferencedPatientSequence = Sequence([nested_item])
+
+    dataset.add_new((0x0043, 0x0010), "LO", "SYN_CREATOR")
+    dataset.add_new((0x0043, 0x1010), "LO", PRIVATE_VALUE)
+
+    dataset.Rows = 2
+    dataset.Columns = 2
+    dataset.SamplesPerPixel = 1
+    dataset.PhotometricInterpretation = "MONOCHROME2"
+    dataset.BitsAllocated = 8
+    dataset.BitsStored = 8
+    dataset.HighBit = 7
+    dataset.PixelRepresentation = 0
+    dataset.PixelData = PIXEL_BYTES
+
+    buffer = BytesIO()
+    dataset.save_as(buffer, enforce_file_format=True)
+    return buffer.getvalue()
+
+
+def test_dicom_phi_scrubbing_returns_safe_summary_only():
+    result = anonymize_dicom_metadata(build_dicom_bytes())
+    response_text = json.dumps(result)
+    summary = result["metadata_summary"]
+
+    assert result["anonymization_status"] == "completed"
+    assert summary["fields_scrubbed"] >= 6
+    assert summary["scrubbed_field_counts"]["PatientName"] == 2
+    assert summary["scrubbed_field_counts"]["PatientID"] == 2
+    assert TOP_LEVEL_NAME not in response_text
+    assert PATIENT_ID not in response_text
+    assert "SYN_INST" not in response_text
+
+
+def test_dicom_nested_sequence_scrubbing_is_counted():
+    result = anonymize_dicom_metadata(build_dicom_bytes())
+
+    assert result["metadata_summary"]["scrubbed_field_counts"]["PatientName"] == 2
+    assert result["metadata_summary"]["scrubbed_field_counts"]["PatientID"] == 2
+
+
+def test_dicom_private_tags_removed_in_strict_mode():
+    result = anonymize_dicom_metadata(build_dicom_bytes(), profile="strict")
+    response_text = json.dumps(result)
+
+    assert result["metadata_summary"]["private_tags_removed"] == 2
+    assert PRIVATE_VALUE not in response_text
+
+
+def test_invalid_dicom_is_rejected():
+    with pytest.raises(DicomAnonymizationError) as exc:
+        anonymize_dicom_metadata(b"not a dicom file")
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "Invalid DICOM file format"
+
+
+def test_dicom_pixel_data_is_not_modified():
+    result = anonymize_dicom_metadata(build_dicom_bytes())
+
+    assert result["metadata_summary"]["pixel_data_present"] is True
+    assert result["metadata_summary"]["pixel_data_preserved"] is True
+    assert result["pixel_redaction_status"] == "not_started_week4"
+
+
+def test_dicom_api_returns_completed_without_raw_phi():
+    response = client.post(
+        "/api/v1/ingest",
+        files={
+            "file": (
+                "scan.dcm",
+                BytesIO(build_dicom_bytes()),
+                "application/dicom",
+            )
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    response_text = json.dumps(body)
+    assert body["detected_modality"] == "dicom"
+    assert body["handler"] == "anonymize_dicom"
+    assert body["anonymization_status"] == "completed"
+    assert body["pixel_redaction_status"] == "not_started_week4"
+    assert TOP_LEVEL_NAME not in response_text
+    assert PATIENT_ID not in response_text
+    assert "file_bytes" not in body

--- a/python_backend/tests/test_dicom_anonymization.py
+++ b/python_backend/tests/test_dicom_anonymization.py
@@ -18,6 +18,7 @@ from services.dicom_anonymization import (  # noqa: E402
     anonymize_dicom_file_bytes,
     DicomAnonymizationError,
     anonymize_dicom_metadata,
+    anonymize_dicom_file_bytes,
 )
 
 
@@ -48,6 +49,8 @@ def build_dicom_bytes() -> bytes:
     dataset.PatientName = TOP_LEVEL_NAME
     dataset.PatientID = PATIENT_ID
     dataset.PatientBirthDate = "19600101"
+    dataset.PatientAge = "045Y"
+    dataset.PatientSex = "F"
     dataset.AccessionNumber = "SYN-ACC-01"
     dataset.StudyDate = "20240101"
     dataset.InstitutionName = "SYN_INST"
@@ -183,3 +186,72 @@ def test_dicom_api_returns_completed_without_raw_phi(monkeypatch):
     assert "BURNED_IN_LABEL" not in response_text
     assert "sanitized_dicom_bytes" not in body
     assert "file_bytes" not in body
+
+def test_dicom_download_endpoint_returns_readable_anonymized_file(monkeypatch):
+    monkeypatch.setattr(
+        "main.audit_logger.log_operation",
+        lambda *args, **kwargs: None,
+    )
+
+    response = client.post(
+        "/anonymize_dicom",
+        files={
+            "file": (
+                "scan.dcm",
+                BytesIO(build_dicom_bytes()),
+                "application/dicom",
+            )
+        },
+        data={"profile": "strict"},
+    )
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("application/dicom")
+    assert "anonymized_scan.dcm" in response.headers["content-disposition"]
+    assert response.headers["x-bioblock-anonymization-status"] == "completed"
+    assert int(response.headers["x-bioblock-fields-scrubbed"]) >= 6
+    assert int(response.headers["x-bioblock-private-tags-removed"]) == 2
+
+    import pydicom
+
+    downloaded = pydicom.dcmread(BytesIO(response.content), force=False)
+    assert str(downloaded.PatientName) == ""
+    assert str(downloaded.PatientID) == ""
+    assert str(downloaded.PatientBirthDate) == "19000101"
+    assert str(downloaded.ReferencedPatientSequence[0].PatientName) == ""
+    assert str(downloaded.ReferencedPatientSequence[0].PatientID) == ""
+    assert str(downloaded.PatientIdentityRemoved) == "YES"
+    assert (0x0043, 0x1010) not in downloaded
+    assert bytes(downloaded.PixelData) == PIXEL_BYTES
+    assert TOP_LEVEL_NAME.encode("utf-8") not in response.content
+    assert PATIENT_ID.encode("utf-8") not in response.content
+
+
+
+def test_dicom_research_shifts_dates_generalizes_demographics_and_removes_private_tags():
+    result = anonymize_dicom_file_bytes(build_dicom_bytes(), profile="research")
+    summary = result["metadata_summary"]
+
+    assert summary["profile"] == "research"
+    assert summary["date_strategy"] == "shift"
+    assert summary["dates_shifted"] >= 2
+    assert summary["generalized_demographics"] == 2
+    assert summary["private_tags_removed"] == 2
+    assert summary["preserve_dicom_technical_metadata"] is True
+    assert "Rows" in summary["technical_metadata_preserved"]
+    assert "Columns" in summary["technical_metadata_preserved"]
+
+    import pydicom
+
+    downloaded = pydicom.dcmread(BytesIO(result["anonymized_dicom_bytes"]), force=False)
+    assert str(downloaded.PatientName) == ""
+    assert str(downloaded.PatientID) == ""
+    assert str(downloaded.PatientBirthDate) not in {"19600101", "19000101"}
+    assert str(downloaded.StudyDate) not in {"20240101", "19000101"}
+    assert str(downloaded.PatientAge) == "040Y"
+    assert str(downloaded.PatientSex) == "F"
+    assert (0x0043, 0x1010) not in downloaded
+
+
+
+

--- a/python_backend/tests/test_ingestion.py
+++ b/python_backend/tests/test_ingestion.py
@@ -170,9 +170,197 @@ class TestIngestionRouting(unittest.TestCase):
         self.assertEqual(body["downstream"]["metadata_indexing"], "pending")
         self.assertEqual(body["downstream"]["blockchain_transaction"], "pending")
 
-    def test_csv_routes_to_csv_handler(self):
-        response = upload_file("sample.csv", b"age,diagnosis\n42,test\n", "text/csv")
-        self.assert_routes_to(response, "csv", "anonymize_csv")
+    def test_csv_upload_returns_completed_safe_tabular_summary(self):
+        csv_content = (
+            b"name,email,phone,mrn,age,gender,diagnosis\n"
+            b"Alice Adams,alice@example.com,555-111-2222,MRN-001,31,F,flu\n"
+            b"Bob Baker,bob@example.com,555-111-3333,MRN-002,32,F,cold\n"
+            b"Carol Chen,carol@example.com,555-111-4444,MRN-003,33,M,flu\n"
+            b"Dan Diaz,dan@example.com,555-111-5555,MRN-004,34,M,cold\n"
+            b"Eve Evans,eve@example.com,555-111-6666,MRN-005,35,F,flu\n"
+        )
+        response = upload_file("sample.csv", csv_content, "text/csv")
+        self.assertEqual(response.status_code, 200)
+        body = response.json()
+        response_text = json.dumps(body)
+        self.assertEqual(body["status"], "success")
+        self.assertEqual(body["detected_modality"], "csv")
+        self.assertEqual(body["handler"], "anonymize_csv")
+        self.assertEqual(body["routing_status"], "handler_selected")
+        self.assertEqual(
+            body["anonymization_status"],
+            "completed_with_warnings",
+        )
+        self.assertNotIn("placeholder", response_text.lower())
+        self.assertIn("tabular_summary", body)
+        summary = body["tabular_summary"]
+        self.assertEqual(summary["rows_in"], 5)
+        self.assertEqual(summary["rows_out"], 5)
+        self.assertEqual(summary["k"], 5)
+        self.assertEqual(summary["l"], 2)
+        self.assertEqual(
+            summary["direct_identifiers_removed"],
+            ["name", "email", "phone", "mrn"],
+        )
+        self.assertEqual(summary["quasi_identifiers_used"], ["age", "gender"])
+        self.assertEqual(summary["sensitive_column"], "diagnosis")
+        self.assertTrue(summary["k_anonymity_satisfied"])
+        self.assertTrue(summary["l_diversity_satisfied"])
+        self.assertEqual(
+            summary["safe_harbor_report"]["safe_harbor_validation_status"],
+            "passed_with_warnings",
+        )
+        self.assertEqual(
+            summary["safe_harbor_report"]["unresolved_identifier_categories"],
+            [],
+        )
+        self.assertEqual(body["downstream"]["ipfs_chunking"], "pending")
+        self.assertEqual(body["downstream"]["cid_encryption"], "pending")
+        self.assertEqual(body["downstream"]["metadata_indexing"], "pending")
+        self.assertEqual(body["downstream"]["blockchain_transaction"], "pending")
+        for raw_value in (
+            "Alice Adams",
+            "alice@example.com",
+            "555-111-2222",
+            "MRN-001",
+            "flu",
+            "cold",
+        ):
+            self.assertNotIn(raw_value, response_text)
+        self.assertNotIn("_internal_anonymized_csv", body)
+        self.assertNotIn("file_bytes", body)
+
+    def test_synthea_csv_ingestion_summary_is_safe_and_complete(self):
+        csv_content = (
+            b"Id,BIRTHDATE,SSN,DRIVERS,PASSPORT,FIRST,LAST,ADDRESS,"
+            b"GENDER,ZIP,LAT,LON,HEALTHCARE_EXPENSES\n"
+            b"uuid-a,1980-01-01,111-22-3333,DL-A,P-A,Alice,Alpha,1 Fake St,"
+            b"F,02139,42.3601,-71.0589,1000\n"
+            b"uuid-b,1981-01-02,222-33-4444,DL-B,P-B,Bob,Beta,2 Fake St,"
+            b"M,02140,42.3611,-71.0599,1100\n"
+            b"uuid-c,1982-01-03,333-44-5555,DL-C,P-C,Carol,Gamma,3 Fake St,"
+            b"F,02141,42.3621,-71.0609,1200\n"
+            b"uuid-d,1983-01-04,444-55-6666,DL-D,P-D,Dan,Delta,4 Fake St,"
+            b"M,02142,42.3631,-71.0619,1300\n"
+            b"uuid-e,1984-01-05,555-66-7777,DL-E,P-E,Eve,Epsilon,5 Fake St,"
+            b"F,02143,42.3641,-71.0629,1400\n"
+        )
+
+        response = upload_file("patients.csv", csv_content, "text/csv")
+        body = response.json()
+        response_text = json.dumps(body)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            body["anonymization_status"],
+            "completed_with_warnings",
+        )
+        self.assertEqual(
+            body["tabular_summary"]["precise_geography_columns_removed"],
+            ["LAT", "LON"],
+        )
+        self.assertNotIn("LAT", body["tabular_summary"]["output_columns"])
+        self.assertNotIn("LON", body["tabular_summary"]["output_columns"])
+        self.assertNotIn("ZIP", body["tabular_summary"]["output_columns"])
+        for raw_value in (
+            "uuid-a",
+            "111-22-3333",
+            "DL-A",
+            "P-A",
+            "Alice",
+            "1 Fake St",
+            "1980-01-01",
+            "42.3601",
+            "-71.0589",
+            "1000",
+        ):
+            self.assertNotIn(raw_value, response_text)
+
+    def test_csv_ingestion_does_not_report_completed_when_k_fails(self):
+        csv_content = b"Id,age,gender\na,30,F\nb,31,M\n"
+
+        response = upload_file("small.csv", csv_content, "text/csv")
+        body = response.json()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            body["anonymization_status"],
+            "failed_privacy_validation",
+        )
+        self.assertFalse(body["tabular_summary"]["k_anonymity_satisfied"])
+        self.assertEqual(body["tabular_summary"]["min_group_size"], 2)
+
+    def test_csv_download_endpoint_returns_anonymized_csv_file(self):
+        csv_content = (
+            b"name,email,phone,mrn,age,gender,diagnosis\n"
+            b"Alice Adams,alice@example.com,555-111-2222,MRN-001,31,F,flu\n"
+            b"Bob Baker,bob@example.com,555-111-3333,MRN-002,32,F,cold\n"
+            b"Carol Chen,carol@example.com,555-111-4444,MRN-003,33,M,flu\n"
+            b"Dan Diaz,dan@example.com,555-111-5555,MRN-004,34,M,cold\n"
+        )
+
+        with patch("main.audit_logger.log_operation", lambda *args, **kwargs: None):
+            response = client.post(
+                "/anonymize_csv",
+                files={"file": ("sample.csv", BytesIO(csv_content), "text/csv")},
+                data={"k": "2", "l": "2"},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.headers["content-type"].startswith("text/csv"))
+        self.assertIn("anonymized_dataset.csv", response.headers["content-disposition"])
+        self.assertEqual(
+            response.headers["x-bioblock-anonymization-status"],
+            "completed_with_warnings",
+        )
+        self.assertEqual(response.headers["x-bioblock-k-anonymity-satisfied"], "true")
+        self.assertEqual(response.headers["x-bioblock-l-diversity-satisfied"], "true")
+
+        downloaded = response.content.decode("utf-8")
+        self.assertIn("age,gender,diagnosis", downloaded)
+        self.assertIn("31-32,*,flu", downloaded)
+        self.assertNotIn("name", downloaded.splitlines()[0])
+        self.assertNotIn("email", downloaded.splitlines()[0])
+        for raw_identifier in (
+            "Alice Adams",
+            "alice@example.com",
+            "555-111-2222",
+            "MRN-001",
+        ):
+            self.assertNotIn(raw_identifier, downloaded)
+
+    def test_csv_download_endpoint_ignores_swagger_placeholder_strings(self):
+        csv_content = (
+            b"name,email,phone,mrn,age,gender,diagnosis\n"
+            b"Alice Adams,alice@example.com,555-111-2222,MRN-001,31,F,flu\n"
+            b"Bob Baker,bob@example.com,555-111-3333,MRN-002,32,F,cold\n"
+            b"Carol Chen,carol@example.com,555-111-4444,MRN-003,33,M,flu\n"
+            b"Dan Diaz,dan@example.com,555-111-5555,MRN-004,34,M,cold\n"
+        )
+
+        with patch("main.audit_logger.log_operation", lambda *args, **kwargs: None):
+            response = client.post(
+                "/anonymize_csv",
+                files={"file": ("sample.csv", BytesIO(csv_content), "text/csv")},
+                data={
+                    "k": "2",
+                    "l": "2",
+                    "direct_identifiers": "string",
+                    "quasi_identifiers": "string",
+                    "sensitive_column": "string",
+                },
+            )
+
+        self.assertEqual(response.status_code, 200)
+        downloaded = response.content.decode("utf-8")
+        self.assertIn("31-32,*,flu", downloaded)
+        self.assertNotIn("Alice Adams", downloaded)
+
+    def test_openapi_includes_csv_download_endpoint(self):
+        response = client.get("/openapi.json")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("/anonymize_csv", response.json()["paths"])
 
     def test_text_routes_to_text_handler(self):
         response = upload_file(
@@ -316,10 +504,16 @@ class TestIngestionRouting(unittest.TestCase):
 
         result = asyncio.run(ingest_file(file=fake_file, profile="strict"))
 
-        self.assertEqual(fake_file.seek_offsets, [0])
+        self.assertEqual(fake_file.seek_offsets, [0, 0])
         self.assertEqual(fake_file.position, 0)
         self.assertEqual(result["detected_modality"], "csv")
         self.assertEqual(result["handler"], "anonymize_csv")
+        self.assertEqual(
+            result["anonymization_status"],
+            "failed_privacy_validation",
+        )
+        self.assertFalse(result["tabular_summary"]["k_anonymity_satisfied"])
+        self.assertIn("tabular_summary", result)
 
 
 if __name__ == "__main__":

--- a/python_backend/tests/test_ingestion.py
+++ b/python_backend/tests/test_ingestion.py
@@ -1,9 +1,11 @@
 import asyncio
+import json
 import os
 import sys
 import tempfile
 import unittest
 from io import BytesIO
+from unittest.mock import patch
 
 import nibabel as nib
 import numpy as np
@@ -19,6 +21,36 @@ from main import app, ingest_file  # noqa: E402
 from services.ingestion import TEXT_READ_LIMIT_BYTES  # noqa: E402
 
 client = TestClient(app)
+
+
+def fake_dicom_pixel_redaction(file_content, profile="strict"):
+    return {
+        "pixel_redaction_status": "completed",
+        "ocr_boxes_detected": 1,
+        "boxes_redacted": 1,
+        "frames_processed": 1,
+        "scanned_regions": 1,
+        "ocr_engine_status": "available",
+        "sanitized_dicom_bytes": b"internal-only",
+    }
+
+
+def fake_wsi_scan(file_content, filename):
+    return {
+        "pixel_redaction_status": "redaction_plan_ready",
+        "ocr_boxes_detected": 2,
+        "boxes_redacted": 0,
+        "redaction_plan_boxes": 2,
+        "tiles_scanned": 4,
+        "priority_regions_scanned": [
+            "corner_top_left",
+            "corner_top_right",
+        ],
+        "image_dimensions": {"width": 2048, "height": 2048},
+        "tile_size": 1024,
+        "ocr_engine_status": "available",
+        "wsi_rewrite_status": "not_supported_yet",
+    }
 
 
 class FakeUploadFile:
@@ -183,16 +215,23 @@ class TestIngestionRouting(unittest.TestCase):
         self.assertIn("PATIENT_ID_", body["anonymized_text"])
 
     def test_dicom_extension_routes_to_dicom_handler(self):
-        response = upload_file("scan.dcm", build_dicom_bytes())
+        with patch("services.ingestion.redact_dicom_pixels", fake_dicom_pixel_redaction):
+            response = upload_file("scan.dcm", build_dicom_bytes())
         self.assert_completed_metadata_route(response, "dicom", "anonymize_dicom")
+        body = response.json()
+        self.assertEqual(body["pixel_redaction_status"], "completed")
+        self.assertEqual(body["ocr_boxes_detected"], 1)
+        self.assertNotIn("sanitized_dicom_bytes", body)
 
     def test_dicom_octet_stream_routes_by_extension(self):
-        response = upload_file(
-            "scan.dcm",
-            build_dicom_bytes(),
-            "application/octet-stream",
-        )
+        with patch("services.ingestion.redact_dicom_pixels", fake_dicom_pixel_redaction):
+            response = upload_file(
+                "scan.dcm",
+                build_dicom_bytes(),
+                "application/octet-stream",
+            )
         self.assert_completed_metadata_route(response, "dicom", "anonymize_dicom")
+        self.assertEqual(response.json()["pixel_redaction_status"], "completed")
 
     def test_nifti_nii_routes_to_nifti_handler(self):
         response = upload_file("brain.nii", build_nifti_bytes(".nii"))
@@ -203,8 +242,21 @@ class TestIngestionRouting(unittest.TestCase):
         self.assert_completed_metadata_route(response, "nifti", "anonymize_nifti")
 
     def test_wsi_routes_to_wsi_handler(self):
-        response = upload_file("slide.svs", b"wsi routing scaffold")
-        self.assert_routes_to(response, "wsi", "anonymize_wsi")
+        with patch("services.ingestion.scan_wsi_bytes", fake_wsi_scan):
+            response = upload_file("slide.svs", b"wsi routing scaffold")
+
+        self.assertEqual(response.status_code, 200)
+        body = response.json()
+        self.assertEqual(body["status"], "success")
+        self.assertEqual(body["detected_modality"], "wsi")
+        self.assertEqual(body["handler"], "anonymize_wsi")
+        self.assertEqual(body["routing_status"], "handler_selected")
+        self.assertEqual(body["anonymization_status"], "redaction_plan_ready")
+        self.assertEqual(body["pixel_redaction_status"], "redaction_plan_ready")
+        self.assertEqual(body["tiles_scanned"], 4)
+        self.assertEqual(body["boxes_redacted"], 0)
+        self.assertEqual(body["wsi_rewrite_status"], "not_supported_yet")
+        self.assertNotIn("ocr_text", json.dumps(body).lower())
 
     def test_unsupported_file_type_is_rejected(self):
         response = upload_file("archive.zip", b"zip scaffold")
@@ -241,12 +293,17 @@ class TestIngestionRouting(unittest.TestCase):
         self.assertIn("Text uploads must be", response.json()["detail"])
 
     def test_dicom_preamble_detection_routes_to_dicom_handler(self):
-        response = upload_file(
-            "scan.bin",
-            build_dicom_bytes(),
-            "application/octet-stream",
-        )
+        with patch("services.ingestion.redact_dicom_pixels", fake_dicom_pixel_redaction):
+            response = upload_file(
+                "scan.bin",
+                build_dicom_bytes(),
+                "application/octet-stream",
+            )
         self.assert_completed_metadata_route(response, "dicom", "anonymize_dicom")
+        self.assertNotEqual(
+            response.json()["pixel_redaction_status"],
+            "not_started_week4",
+        )
 
     def test_endpoint_resets_upload_stream_after_header_read(self):
         fake_file = FakeUploadFile(

--- a/python_backend/tests/test_ingestion.py
+++ b/python_backend/tests/test_ingestion.py
@@ -1,10 +1,16 @@
 import asyncio
 import os
 import sys
+import tempfile
 import unittest
 from io import BytesIO
 
+import nibabel as nib
+import numpy as np
 from fastapi.testclient import TestClient
+from pydicom.dataset import Dataset, FileDataset, FileMetaDataset
+from pydicom.sequence import Sequence
+from pydicom.uid import ExplicitVRLittleEndian, SecondaryCaptureImageStorage
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 os.environ.setdefault("BIOBLOCK_STUDY_SALT", "week2-test-salt")
@@ -51,6 +57,59 @@ def upload_file(
     )
 
 
+def build_dicom_bytes():
+    file_meta = FileMetaDataset()
+    file_meta.TransferSyntaxUID = ExplicitVRLittleEndian
+    file_meta.MediaStorageSOPClassUID = SecondaryCaptureImageStorage
+    file_meta.MediaStorageSOPInstanceUID = "1.2.826.0.1.3680043.8.498.11"
+    file_meta.ImplementationClassUID = "1.2.826.0.1.3680043.8.498.12"
+
+    dataset = FileDataset(
+        None,
+        {},
+        file_meta=file_meta,
+        preamble=b"\0" * 128,
+    )
+    dataset.SOPClassUID = SecondaryCaptureImageStorage
+    dataset.SOPInstanceUID = file_meta.MediaStorageSOPInstanceUID
+    dataset.PatientName = "SYN^ROUTE"
+    dataset.PatientID = "SYN-ROUTE-ID"
+
+    nested_item = Dataset()
+    nested_item.PatientName = "NEST^ROUTE"
+    dataset.ReferencedPatientSequence = Sequence([nested_item])
+
+    dataset.Rows = 2
+    dataset.Columns = 2
+    dataset.SamplesPerPixel = 1
+    dataset.PhotometricInterpretation = "MONOCHROME2"
+    dataset.BitsAllocated = 8
+    dataset.BitsStored = 8
+    dataset.HighBit = 7
+    dataset.PixelRepresentation = 0
+    dataset.PixelData = b"\x01\x02\x03\x04"
+
+    buffer = BytesIO()
+    dataset.save_as(buffer, enforce_file_format=True)
+    return buffer.getvalue()
+
+
+def build_nifti_bytes(suffix=".nii"):
+    data = np.arange(8, dtype=np.int16).reshape((2, 2, 2))
+    image = nib.Nifti1Image(data, np.eye(4))
+    image.header["descrip"] = b"SYNTHETIC_ROUTING_HEADER"
+
+    with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as temp_file:
+        temp_path = temp_file.name
+
+    try:
+        nib.save(image, temp_path)
+        with open(temp_path, "rb") as saved_file:
+            return saved_file.read()
+    finally:
+        os.unlink(temp_path)
+
+
 class TestIngestionRouting(unittest.TestCase):
     def assert_routes_to(self, response, modality, handler):
         self.assertEqual(response.status_code, 200)
@@ -60,6 +119,20 @@ class TestIngestionRouting(unittest.TestCase):
         self.assertEqual(body["handler"], handler)
         self.assertEqual(body["routing_status"], "handler_selected")
         self.assertEqual(body["anonymization_status"], "placeholder")
+        self.assertEqual(body["downstream"]["ipfs_chunking"], "pending")
+        self.assertEqual(body["downstream"]["cid_encryption"], "pending")
+        self.assertEqual(body["downstream"]["metadata_indexing"], "pending")
+        self.assertEqual(body["downstream"]["blockchain_transaction"], "pending")
+
+    def assert_completed_metadata_route(self, response, modality, handler):
+        self.assertEqual(response.status_code, 200)
+        body = response.json()
+        self.assertEqual(body["status"], "success")
+        self.assertEqual(body["detected_modality"], modality)
+        self.assertEqual(body["handler"], handler)
+        self.assertEqual(body["routing_status"], "handler_selected")
+        self.assertEqual(body["anonymization_status"], "completed")
+        self.assertIn("metadata_summary", body)
         self.assertEqual(body["downstream"]["ipfs_chunking"], "pending")
         self.assertEqual(body["downstream"]["cid_encryption"], "pending")
         self.assertEqual(body["downstream"]["metadata_indexing"], "pending")
@@ -110,24 +183,24 @@ class TestIngestionRouting(unittest.TestCase):
         self.assertIn("PATIENT_ID_", body["anonymized_text"])
 
     def test_dicom_extension_routes_to_dicom_handler(self):
-        response = upload_file("scan.dcm", b"not-real-dicom-routing-only")
-        self.assert_routes_to(response, "dicom", "anonymize_dicom")
+        response = upload_file("scan.dcm", build_dicom_bytes())
+        self.assert_completed_metadata_route(response, "dicom", "anonymize_dicom")
 
     def test_dicom_octet_stream_routes_by_extension(self):
         response = upload_file(
             "scan.dcm",
-            b"dicom routing scaffold",
+            build_dicom_bytes(),
             "application/octet-stream",
         )
-        self.assert_routes_to(response, "dicom", "anonymize_dicom")
+        self.assert_completed_metadata_route(response, "dicom", "anonymize_dicom")
 
     def test_nifti_nii_routes_to_nifti_handler(self):
-        response = upload_file("brain.nii", b"nifti routing scaffold")
-        self.assert_routes_to(response, "nifti", "anonymize_nifti")
+        response = upload_file("brain.nii", build_nifti_bytes(".nii"))
+        self.assert_completed_metadata_route(response, "nifti", "anonymize_nifti")
 
     def test_nifti_nii_gz_routes_to_nifti_handler(self):
-        response = upload_file("brain.nii.gz", b"compressed nifti scaffold")
-        self.assert_routes_to(response, "nifti", "anonymize_nifti")
+        response = upload_file("brain.nii.gz", build_nifti_bytes(".nii.gz"))
+        self.assert_completed_metadata_route(response, "nifti", "anonymize_nifti")
 
     def test_wsi_routes_to_wsi_handler(self):
         response = upload_file("slide.svs", b"wsi routing scaffold")
@@ -168,9 +241,12 @@ class TestIngestionRouting(unittest.TestCase):
         self.assertIn("Text uploads must be", response.json()["detail"])
 
     def test_dicom_preamble_detection_routes_to_dicom_handler(self):
-        dicom_header = b"\x00" * 128 + b"DICM" + b"routing scaffold"
-        response = upload_file("scan.bin", dicom_header, "application/octet-stream")
-        self.assert_routes_to(response, "dicom", "anonymize_dicom")
+        response = upload_file(
+            "scan.bin",
+            build_dicom_bytes(),
+            "application/octet-stream",
+        )
+        self.assert_completed_metadata_route(response, "dicom", "anonymize_dicom")
 
     def test_endpoint_resets_upload_stream_after_header_read(self):
         fake_file = FakeUploadFile(

--- a/python_backend/tests/test_ingestion.py
+++ b/python_backend/tests/test_ingestion.py
@@ -190,7 +190,9 @@ class TestIngestionRouting(unittest.TestCase):
         self.assertEqual(body["anonymization_status"], "completed")
         self.assertNotIn("123456", body["anonymized_text"])
         self.assertNotIn("john.doe@example.com", body["anonymized_text"])
-        self.assertIn("MRN_", body["anonymized_text"])
+        self.assertEqual(body["date_strategy"], "redact")
+        self.assertEqual(body["text_identifier_strategy"], "redact")
+        self.assertIn("<REDACTED_MRN>", body["anonymized_text"])
         self.assertIn("<REDACTED_EMAIL>", body["anonymized_text"])
         self.assertIn("diabetes", body["anonymized_text"])
         self.assertEqual(body["detected_entities"]["MEDICAL_RECORD_NUMBER"], 1)
@@ -212,7 +214,7 @@ class TestIngestionRouting(unittest.TestCase):
         self.assertEqual(body["detected_modality"], "text")
         self.assertEqual(body["anonymization_status"], "completed")
         self.assertNotIn("PT-1001", body["anonymized_text"])
-        self.assertIn("PATIENT_ID_", body["anonymized_text"])
+        self.assertIn("<REDACTED_PATIENT_ID>", body["anonymized_text"])
 
     def test_dicom_extension_routes_to_dicom_handler(self):
         with patch("services.ingestion.redact_dicom_pixels", fake_dicom_pixel_redaction):
@@ -322,3 +324,5 @@ class TestIngestionRouting(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+

--- a/python_backend/tests/test_nifti_anonymization.py
+++ b/python_backend/tests/test_nifti_anonymization.py
@@ -107,3 +107,22 @@ def test_nifti_api_returns_completed_for_supported_extensions(filename, suffix):
     assert HEADER_TEXT.decode("ascii") not in response_text
     assert AUX_TEXT.decode("ascii") not in response_text
     assert "file_bytes" not in body
+
+
+def test_nifti_research_profile_removes_extensions_and_preserves_safe_metadata():
+    result = anonymize_nifti_metadata(
+        build_nifti_bytes(".nii"),
+        "scan.nii",
+        profile="research",
+    )
+    summary = result["metadata_summary"]
+
+    assert summary["profile"] == "research"
+    assert summary["remove_nifti_extensions"] is True
+    assert summary["extensions_removed"] == 1
+    assert summary["extensions_preserved"] == 0
+    assert summary["shape_preserved"] is True
+    assert summary["affine_preserved"] is True
+    assert summary["datatype_preserved"] is True
+
+

--- a/python_backend/tests/test_nifti_anonymization.py
+++ b/python_backend/tests/test_nifti_anonymization.py
@@ -1,0 +1,109 @@
+import json
+import os
+import sys
+import tempfile
+from io import BytesIO
+
+import nibabel as nib
+import numpy as np
+import pytest
+from fastapi.testclient import TestClient
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+os.environ.setdefault("BIOBLOCK_STUDY_SALT", "week3-test-salt")
+
+from main import app  # noqa: E402
+from services.nifti_anonymization import (  # noqa: E402
+    NiftiAnonymizationError,
+    anonymize_nifti_metadata,
+)
+
+
+client = TestClient(app)
+
+HEADER_TEXT = b"SYNTHETIC_NIFTI_HEADER_TEXT"
+AUX_TEXT = b"SYNTHETIC_AUX_FILE"
+INTENT_TEXT = b"SYNTHETIC_INTENT_NAME"
+EXTENSION_TEXT = b"SYNTHETIC_EXTENSION_TEXT"
+
+
+def build_nifti_bytes(suffix: str = ".nii") -> bytes:
+    data = np.arange(8, dtype=np.int16).reshape((2, 2, 2))
+    affine = np.eye(4)
+    image = nib.Nifti1Image(data, affine)
+    image.header["descrip"] = HEADER_TEXT
+    image.header["aux_file"] = AUX_TEXT
+    image.header["intent_name"] = INTENT_TEXT
+    image.header.extensions.append(nib.nifti1.Nifti1Extension(6, EXTENSION_TEXT))
+
+    with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as temp_file:
+        temp_path = temp_file.name
+
+    try:
+        nib.save(image, temp_path)
+        with open(temp_path, "rb") as saved_file:
+            return saved_file.read()
+    finally:
+        os.unlink(temp_path)
+
+
+def test_nifti_header_scrubbing_preserves_image_properties():
+    result = anonymize_nifti_metadata(build_nifti_bytes(".nii"), "scan.nii")
+    response_text = json.dumps(result)
+    summary = result["metadata_summary"]
+
+    assert result["anonymization_status"] == "completed"
+    assert summary["fields_scrubbed"] == 3
+    assert summary["scrubbed_field_counts"] == {
+        "descrip": 1,
+        "aux_file": 1,
+        "intent_name": 1,
+    }
+    assert summary["extensions_removed"] == 1
+    assert summary["image_shape"] == [2, 2, 2]
+    assert summary["shape_preserved"] is True
+    assert summary["affine_preserved"] is True
+    assert summary["datatype_preserved"] is True
+    assert summary["image_data_preserved"] is True
+    assert HEADER_TEXT.decode("ascii") not in response_text
+    assert AUX_TEXT.decode("ascii") not in response_text
+    assert EXTENSION_TEXT.decode("ascii") not in response_text
+
+
+def test_invalid_nifti_is_rejected():
+    with pytest.raises(NiftiAnonymizationError) as exc:
+        anonymize_nifti_metadata(b"not nifti", "scan.nii")
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "Invalid NIfTI file format"
+
+
+@pytest.mark.parametrize(
+    ("filename", "suffix"),
+    [
+        ("scan.nii", ".nii"),
+        ("scan.nii.gz", ".nii.gz"),
+    ],
+)
+def test_nifti_api_returns_completed_for_supported_extensions(filename, suffix):
+    response = client.post(
+        "/api/v1/ingest",
+        files={
+            "file": (
+                filename,
+                BytesIO(build_nifti_bytes(suffix)),
+                "application/octet-stream",
+            )
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    response_text = json.dumps(body)
+    assert body["detected_modality"] == "nifti"
+    assert body["handler"] == "anonymize_nifti"
+    assert body["anonymization_status"] == "completed"
+    assert body["metadata_summary"]["fields_scrubbed"] == 3
+    assert HEADER_TEXT.decode("ascii") not in response_text
+    assert AUX_TEXT.decode("ascii") not in response_text
+    assert "file_bytes" not in body

--- a/python_backend/tests/test_ocr_redaction.py
+++ b/python_backend/tests/test_ocr_redaction.py
@@ -1,0 +1,173 @@
+import json
+import os
+import sys
+from io import BytesIO
+
+import numpy as np
+from PIL import Image
+from pydicom.dataset import FileDataset, FileMetaDataset
+from pydicom.uid import ExplicitVRLittleEndian, SecondaryCaptureImageStorage
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from services.ocr_redaction import (  # noqa: E402
+    OCRBox,
+    redact_dicom_pixels,
+    redact_image_regions,
+    redact_image_with_backend,
+    safe_ocr_response,
+)
+
+
+RAW_OCR_TEXT = "PATIENT^BURNED"
+
+
+class FakeOCRBackend:
+    ocr_engine_status = "available"
+
+    def __init__(self, boxes):
+        self.boxes = boxes
+
+    def detect_text_boxes(self, image):
+        return self.boxes
+
+
+def build_grayscale_dicom(pixel_array: np.ndarray) -> bytes:
+    file_meta = FileMetaDataset()
+    file_meta.TransferSyntaxUID = ExplicitVRLittleEndian
+    file_meta.MediaStorageSOPClassUID = SecondaryCaptureImageStorage
+    file_meta.MediaStorageSOPInstanceUID = "1.2.826.0.1.3680043.8.498.41"
+    file_meta.ImplementationClassUID = "1.2.826.0.1.3680043.8.498.42"
+
+    dataset = FileDataset(
+        None,
+        {},
+        file_meta=file_meta,
+        preamble=b"\0" * 128,
+    )
+    dataset.SOPClassUID = SecondaryCaptureImageStorage
+    dataset.SOPInstanceUID = file_meta.MediaStorageSOPInstanceUID
+    dataset.PatientName = RAW_OCR_TEXT
+    dataset.PatientID = "OCR-PAT-001"
+    dataset.Rows = int(pixel_array.shape[0])
+    dataset.Columns = int(pixel_array.shape[1])
+    dataset.SamplesPerPixel = 1
+    dataset.PhotometricInterpretation = "MONOCHROME2"
+    dataset.BitsAllocated = 8
+    dataset.BitsStored = 8
+    dataset.HighBit = 7
+    dataset.PixelRepresentation = 0
+    dataset.PixelData = pixel_array.astype(np.uint8).tobytes()
+
+    buffer = BytesIO()
+    dataset.save_as(buffer, enforce_file_format=True)
+    return buffer.getvalue()
+
+
+def test_fake_ocr_box_gets_redacted():
+    image = Image.fromarray(np.full((6, 6), 255, dtype=np.uint8), mode="L")
+    result = redact_image_with_backend(
+        image,
+        ocr_backend=FakeOCRBackend([OCRBox(RAW_OCR_TEXT, 0.98, 1, 1, 3, 2)]),
+    )
+    pixels = np.asarray(result.image)
+
+    assert result.boxes_detected == 1
+    assert result.boxes_redacted == 1
+    assert pixels[1:3, 1:4].max() == 0
+
+
+def test_no_ocr_boxes_leaves_image_unchanged():
+    image = np.full((5, 5), 127, dtype=np.uint8)
+    result = redact_image_regions(image, [])
+
+    assert result.boxes_detected == 0
+    assert result.boxes_redacted == 0
+    assert np.array_equal(np.asarray(result.image), image)
+
+
+def test_low_confidence_boxes_are_skipped():
+    image = np.full((5, 5), 255, dtype=np.uint8)
+    result = redact_image_regions(
+        image,
+        [OCRBox(RAW_OCR_TEXT, 0.2, 0, 0, 3, 3)],
+        min_confidence=0.5,
+    )
+
+    assert result.boxes_detected == 1
+    assert result.boxes_redacted == 0
+    assert np.asarray(result.image).min() == 255
+
+
+def test_redaction_summary_does_not_contain_raw_ocr_text():
+    result = redact_image_regions(
+        np.full((5, 5), 255, dtype=np.uint8),
+        [OCRBox(RAW_OCR_TEXT, 0.9, 0, 0, 2, 2)],
+    )
+
+    assert RAW_OCR_TEXT not in json.dumps(result.safe_summary())
+
+
+def test_box_clipping_redacts_boundary_intersection():
+    image = np.full((4, 4), 255, dtype=np.uint8)
+    result = redact_image_regions(
+        image,
+        [OCRBox(RAW_OCR_TEXT, 0.99, 2, 2, 10, 10)],
+    )
+    pixels = np.asarray(result.image)
+
+    assert result.boxes_redacted == 1
+    assert pixels[2:, 2:].max() == 0
+    assert pixels[:2, :].min() == 255
+    assert pixels[:, :2].min() == 255
+
+
+def test_dicom_pixel_redaction_changes_only_detected_region():
+    pixels = np.full((8, 8), 20, dtype=np.uint8)
+    pixels[0:2, 0:4] = 250
+    dicom_bytes = build_grayscale_dicom(pixels)
+
+    result = redact_dicom_pixels(
+        dicom_bytes,
+        ocr_backend=FakeOCRBackend([OCRBox(RAW_OCR_TEXT, 0.99, 0, 0, 4, 2)]),
+    )
+    sanitized = result["sanitized_dicom_bytes"]
+
+    import pydicom
+
+    dataset = pydicom.dcmread(BytesIO(sanitized))
+    redacted_pixels = dataset.pixel_array
+
+    assert result["pixel_redaction_status"] == "completed"
+    assert result["ocr_boxes_detected"] == 1
+    assert result["boxes_redacted"] == 1
+    assert redacted_pixels[0:2, 0:4].max() == 0
+    assert np.array_equal(redacted_pixels[2:, :], pixels[2:, :])
+    assert np.array_equal(redacted_pixels[:, 4:], pixels[:, 4:])
+
+
+def test_dicom_pixel_data_remains_valid_after_redaction():
+    pixels = np.full((4, 4), 100, dtype=np.uint8)
+    dicom_bytes = build_grayscale_dicom(pixels)
+
+    result = redact_dicom_pixels(
+        dicom_bytes,
+        ocr_backend=FakeOCRBackend([OCRBox(RAW_OCR_TEXT, 0.99, 1, 1, 2, 2)]),
+    )
+
+    import pydicom
+
+    dataset = pydicom.dcmread(BytesIO(result["sanitized_dicom_bytes"]))
+    assert dataset.PixelData
+    assert dataset.pixel_array.shape == (4, 4)
+
+
+def test_dicom_safe_response_does_not_expose_ocr_text_or_bytes():
+    result = redact_dicom_pixels(
+        build_grayscale_dicom(np.full((4, 4), 100, dtype=np.uint8)),
+        ocr_backend=FakeOCRBackend([OCRBox(RAW_OCR_TEXT, 0.99, 0, 0, 2, 2)]),
+    )
+    safe = safe_ocr_response(result)
+
+    assert "sanitized_dicom_bytes" not in safe
+    assert RAW_OCR_TEXT not in json.dumps(safe)

--- a/python_backend/tests/test_ocr_redaction.py
+++ b/python_backend/tests/test_ocr_redaction.py
@@ -171,3 +171,24 @@ def test_dicom_safe_response_does_not_expose_ocr_text_or_bytes():
 
     assert "sanitized_dicom_bytes" not in safe
     assert RAW_OCR_TEXT not in json.dumps(safe)
+
+
+def test_dicom_pixel_redaction_uses_profile_confidence_thresholds():
+    dicom_bytes = build_grayscale_dicom(np.full((6, 6), 255, dtype=np.uint8))
+    backend = FakeOCRBackend([OCRBox(RAW_OCR_TEXT, 0.4, 1, 1, 3, 3)])
+
+    strict = redact_dicom_pixels(
+        dicom_bytes,
+        profile="strict",
+        ocr_backend=backend,
+    )
+    research = redact_dicom_pixels(
+        dicom_bytes,
+        profile="research",
+        ocr_backend=backend,
+    )
+
+    assert strict["ocr_confidence_threshold"] == 0.3
+    assert strict["boxes_redacted"] == 1
+    assert research["ocr_confidence_threshold"] == 0.5
+    assert research["boxes_redacted"] == 0

--- a/python_backend/tests/test_privacy_profiles.py
+++ b/python_backend/tests/test_privacy_profiles.py
@@ -1,0 +1,50 @@
+import os
+import sys
+
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from services.privacy_profiles import (  # noqa: E402
+    PrivacyProfileError,
+    get_privacy_profile,
+    load_privacy_profiles,
+    validate_privacy_profile,
+)
+
+
+def test_strict_and_research_profiles_load():
+    profiles = load_privacy_profiles()
+
+    assert set(profiles) >= {"strict", "research"}
+    assert profiles["strict"]["date_strategy"] == "redact"
+    assert profiles["strict"]["text_identifier_strategy"] == "redact"
+    assert profiles["strict"]["remove_dicom_private_tags"] is True
+    assert profiles["research"]["date_strategy"] == "shift"
+    assert profiles["research"]["text_identifier_strategy"] == "pseudonymize"
+    assert profiles["research"]["preserve_dicom_technical_metadata"] is True
+    assert profiles["research"]["remove_nifti_extensions"] is True
+
+
+def test_profile_name_validation_is_case_insensitive():
+    assert validate_privacy_profile(" Strict ") == "strict"
+    assert validate_privacy_profile("RESEARCH") == "research"
+
+
+def test_profile_settings_are_returned_as_a_copy():
+    strict_settings = get_privacy_profile("strict")
+    strict_settings["redact_dates"] = False
+
+    assert get_privacy_profile("strict")["redact_dates"] is True
+
+
+def test_invalid_profile_fails_clearly():
+    with pytest.raises(PrivacyProfileError) as exc:
+        get_privacy_profile("public")
+
+    assert exc.value.status_code == 400
+    assert "Invalid privacy profile" in exc.value.detail
+    assert "strict" in exc.value.detail
+    assert "research" in exc.value.detail
+
+

--- a/python_backend/tests/test_safe_harbor.py
+++ b/python_backend/tests/test_safe_harbor.py
@@ -1,0 +1,521 @@
+import csv
+import io
+import json
+import os
+import sys
+from io import BytesIO
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from main import app  # noqa: E402
+from services.tabular_anonymization import anonymize_tabular_csv  # noqa: E402
+
+client = TestClient(app)
+
+
+REPORT_KEYS = {
+    "safe_harbor_validation_status",
+    "identifier_categories_detected",
+    "identifier_categories_removed",
+    "unresolved_identifier_categories",
+    "date_compliance_status",
+    "age_over_89_status",
+    "geographic_compliance_status",
+    "free_text_scan_status",
+    "unique_code_scan_status",
+    "actual_knowledge_review_required",
+    "warnings",
+}
+
+DIRECT_CATEGORY_CASES = (
+    ("relative_name", ["Alice Alpha", "Bob Beta", "Carol Gamma", "Dan Delta"], "1_names"),
+    ("city", ["Boston", "Cambridge", "Quincy", "Salem"], "2_geographic_subdivisions"),
+    ("telephone_number", ["617-555-0101", "617-555-0102", "617-555-0103", "617-555-0104"], "5_telephone_numbers"),
+    ("fax_number", ["617-555-0201", "617-555-0202", "617-555-0203", "617-555-0204"], "6_fax_numbers"),
+    ("email_address", ["a@example.test", "b@example.test", "c@example.test", "d@example.test"], "7_email_addresses"),
+    ("ssn", ["111-22-3333", "222-33-4444", "333-44-5555", "444-55-6666"], "8_social_security_numbers"),
+    ("mrn", ["MRN-A001", "MRN-B002", "MRN-C003", "MRN-D004"], "9_medical_record_numbers"),
+    ("beneficiary_number", ["PLAN-A001", "PLAN-B002", "PLAN-C003", "PLAN-D004"], "10_health_plan_beneficiary_numbers"),
+    ("account_number", ["ACCT-A001", "ACCT-B002", "ACCT-C003", "ACCT-D004"], "11_account_numbers"),
+    ("license_number", ["LIC-A001", "LIC-B002", "LIC-C003", "LIC-D004"], "12_certificate_and_licence_numbers"),
+    ("vin", ["1HGCM82633A004351", "1HGCM82633A004352", "1HGCM82633A004353", "1HGCM82633A004354"], "13_vehicle_identifiers"),
+    ("device_serial_number", ["DEV-A001", "DEV-B002", "DEV-C003", "DEV-D004"], "14_device_identifiers"),
+    ("url", ["https://one.test/a", "https://two.test/b", "https://three.test/c", "https://four.test/d"], "15_urls"),
+    ("ip_address", ["192.0.2.1", "192.0.2.2", "192.0.2.3", "192.0.2.4"], "16_ip_addresses"),
+    ("fingerprint_id", ["BIO-A001", "BIO-B002", "BIO-C003", "BIO-D004"], "17_biometric_identifiers"),
+    ("unique_id", ["550e8400-e29b-41d4-a716-446655440001", "550e8400-e29b-41d4-a716-446655440002", "550e8400-e29b-41d4-a716-446655440003", "550e8400-e29b-41d4-a716-446655440004"], "18_photographs_and_unique_identifiers"),
+)
+
+
+def make_csv(extra_column, values, include_sensitive=True):
+    buffer = io.StringIO()
+    columns = [extra_column]
+    if extra_column != "age":
+        columns.append("age")
+    columns.append("gender")
+    if include_sensitive:
+        columns.append("diagnosis")
+    writer = csv.writer(buffer, lineterminator="\n")
+    writer.writerow(columns)
+    for index, value in enumerate(values):
+        row = [value]
+        if extra_column != "age":
+            row.append(30 + index)
+        row.append("F" if index % 2 == 0 else "M")
+        if include_sensitive:
+            row.append("alpha" if index % 2 == 0 else "beta")
+        writer.writerow(row)
+    return buffer.getvalue().encode("utf-8")
+
+
+def output_rows(result):
+    return list(csv.DictReader(io.StringIO(result["_internal_anonymized_csv"])))
+
+
+@pytest.mark.parametrize("column,values,category", DIRECT_CATEGORY_CASES)
+def test_each_direct_safe_harbor_category_is_removed(column, values, category):
+    result = anonymize_tabular_csv(
+        make_csv(column, values),
+        k=2,
+        l=2,
+        include_anonymized_csv=True,
+    )
+    report = result["safe_harbor_report"]
+    serialized = json.dumps(result)
+
+    assert column not in result["output_columns"]
+    assert category in report["identifier_categories_detected"]
+    assert category in report["identifier_categories_removed"]
+    assert report["unresolved_identifier_categories"] == []
+    assert result["anonymization_status"] == "completed_with_warnings"
+    for value in values:
+        assert value not in serialized
+
+
+def test_safe_harbor_column_matching_is_case_insensitive():
+    values = ["a@example.test", "b@example.test", "c@example.test", "d@example.test"]
+    result = anonymize_tabular_csv(
+        make_csv("EMAIL_ADDRESS", values),
+        k=2,
+        include_anonymized_csv=True,
+    )
+
+    assert "EMAIL_ADDRESS" not in result["output_columns"]
+    assert "7_email_addresses" in result["safe_harbor_report"][
+        "identifier_categories_removed"
+    ]
+
+
+@pytest.mark.parametrize(
+    "column",
+    [
+        "patient_name",
+        "relative_name",
+        "employer_name",
+        "provider_name",
+        "household_member_name",
+    ],
+)
+def test_all_subject_identifying_name_aliases_are_removed(column):
+    values = ["Alice Alpha", "Bob Beta", "Carol Gamma", "Dan Delta"]
+    result = anonymize_tabular_csv(
+        make_csv(column, values),
+        k=2,
+        include_anonymized_csv=True,
+    )
+
+    assert column not in result["output_columns"]
+    assert "1_names" in result["safe_harbor_report"][
+        "identifier_categories_removed"
+    ]
+
+
+@pytest.mark.parametrize(
+    "column,values",
+    [
+        ("address", ["1 Main Street", "2 Main Street", "3 Main Street", "4 Main Street"]),
+        ("city", ["Boston", "Quincy", "Salem", "Cambridge"]),
+        ("county", ["Suffolk", "Norfolk", "Essex", "Middlesex"]),
+        ("precinct", ["P-01", "P-02", "P-03", "P-04"]),
+        ("zip", ["02139", "02140", "94107", "94110"]),
+        ("latitude", ["42.1", "42.2", "42.3", "42.4"]),
+        ("longitude", ["-71.1", "-71.2", "-71.3", "-71.4"]),
+        ("geocode", ["GEO-A", "GEO-B", "GEO-C", "GEO-D"]),
+        ("birthplace", ["Boston MA", "Quincy MA", "Salem MA", "Cambridge MA"]),
+    ],
+)
+def test_prohibited_geographic_detail_is_removed(column, values):
+    result = anonymize_tabular_csv(
+        make_csv(column, values),
+        k=2,
+        include_anonymized_csv=True,
+    )
+
+    assert column not in result["output_columns"]
+    assert result["safe_harbor_report"]["geographic_compliance_status"] == "passed"
+    for value in values:
+        assert value not in result["_internal_anonymized_csv"]
+
+
+def test_state_may_be_retained_but_is_still_generalized_for_k_anonymity():
+    result = anonymize_tabular_csv(
+        make_csv("state", ["MA", "MA", "CA", "CA"]),
+        k=2,
+        include_anonymized_csv=True,
+    )
+
+    assert "state" in result["output_columns"]
+    assert set(row["state"] for row in output_rows(result)) == {"*"}
+    assert result["safe_harbor_report"]["geographic_compliance_status"] == "passed"
+
+
+@pytest.mark.parametrize(
+    "column",
+    [
+        "birth_date",
+        "admission_date",
+        "discharge_date",
+        "service_date",
+        "procedure_date",
+        "death_date",
+    ],
+)
+def test_individual_related_dates_retain_year_only(column):
+    exact_dates = ["1970-01-02", "1980-03-04", "1990-05-06", "2000-07-08"]
+    result = anonymize_tabular_csv(
+        make_csv(column, exact_dates),
+        k=2,
+        include_anonymized_csv=True,
+    )
+    output = result["_internal_anonymized_csv"]
+    report = result["safe_harbor_report"]
+
+    assert column in result["output_columns"]
+    assert report["date_compliance_status"] == "passed"
+    assert "3_individual_related_dates" in report["identifier_categories_detected"]
+    for exact_date in exact_dates:
+        assert exact_date not in output
+    assert all(
+        value == "UNKNOWN" or not value.count("-") == 2
+        for value in (row[column] for row in output_rows(result))
+    )
+
+
+def test_ages_over_89_are_grouped_as_90_plus():
+    values = ["45", "88", "91", "103"]
+    result = anonymize_tabular_csv(
+        make_csv("age", values),
+        k=2,
+        include_anonymized_csv=True,
+    )
+    output = result["_internal_anonymized_csv"]
+    report = result["safe_harbor_report"]
+
+    assert "90+" in output
+    assert "91" not in output
+    assert "103" not in output
+    assert report["age_over_89_status"] == "passed"
+    assert "4_ages_over_89" in report["identifier_categories_detected"]
+
+
+def test_birth_year_revealing_age_over_89_is_grouped_as_90_plus():
+    csv_bytes = (
+        b"birth_date,age,gender\n"
+        b"1920-01-02,95,F\n"
+        b"1925-03-04,101,M\n"
+        b"1980-05-06,45,F\n"
+        b"1981-07-08,44,M\n"
+    )
+    result = anonymize_tabular_csv(
+        csv_bytes,
+        k=2,
+        include_anonymized_csv=True,
+    )
+    output = result["_internal_anonymized_csv"]
+
+    assert "90+" in output
+    assert "1920" not in output
+    assert "1925" not in output
+    assert "95" not in output
+    assert "101" not in output
+    assert result["safe_harbor_report"]["age_over_89_status"] == "passed"
+
+
+@pytest.mark.parametrize(
+    "values,category",
+    [
+        (["a@one.test", "b@two.test", "c@three.test", "d@four.test"], "7_email_addresses"),
+        (["617-555-0101", "617-555-0102", "617-555-0103", "617-555-0104"], "5_telephone_numbers"),
+        (["111-22-3333", "222-33-4444", "333-44-5555", "444-55-6666"], "8_social_security_numbers"),
+        (["https://one.test", "https://two.test", "https://three.test", "https://four.test"], "15_urls"),
+        (["192.0.2.1", "192.0.2.2", "192.0.2.3", "192.0.2.4"], "16_ip_addresses"),
+        (["550e8400-e29b-41d4-a716-446655440001", "550e8400-e29b-41d4-a716-446655440002", "550e8400-e29b-41d4-a716-446655440003", "550e8400-e29b-41d4-a716-446655440004"], "18_photographs_and_unique_identifiers"),
+        (["1 Main Street", "2 Main Street", "3 Main Street", "4 Main Street"], "2_geographic_subdivisions"),
+        (["1970-01-02", "1980-03-04", "1990-05-06", "2000-07-08"], "3_individual_related_dates"),
+    ],
+)
+def test_data_patterns_are_detected_with_unfamiliar_column_names(values, category):
+    result = anonymize_tabular_csv(
+        make_csv("unfamiliar_field", values),
+        k=2,
+        include_anonymized_csv=True,
+    )
+    serialized = json.dumps(result)
+
+    assert category in result["safe_harbor_report"][
+        "identifier_categories_detected"
+    ]
+    for value in values:
+        assert value not in serialized
+
+
+def test_unfamiliar_title_case_name_column_is_removed_by_value_pattern():
+    values = ["Alice Alpha", "Bob Beta", "Carol Gamma", "Dan Delta"]
+    result = anonymize_tabular_csv(
+        make_csv("unfamiliar_field", values),
+        k=2,
+        include_anonymized_csv=True,
+    )
+
+    assert "unfamiliar_field" not in result["output_columns"]
+    assert "1_names" in result["safe_harbor_report"][
+        "identifier_categories_removed"
+    ]
+
+
+def test_configured_mapping_removes_custom_identifier_column():
+    values = ["REF-A", "REF-B", "REF-C", "REF-D"]
+    result = anonymize_tabular_csv(
+        make_csv("custom_reference", values),
+        k=2,
+        safe_harbor_mappings={"11_account_numbers": ["custom_reference"]},
+        include_anonymized_csv=True,
+    )
+
+    assert "custom_reference" not in result["output_columns"]
+    assert "11_account_numbers" in result["safe_harbor_report"][
+        "identifier_categories_removed"
+    ]
+
+
+def test_free_text_with_phi_is_removed_after_existing_text_service_scan():
+    values = [
+        "Patient Alice Alpha phone 617-555-0101",
+        "Patient Bob Beta phone 617-555-0102",
+        "Patient Carol Gamma phone 617-555-0103",
+        "Patient Dan Delta phone 617-555-0104",
+    ]
+    result = anonymize_tabular_csv(
+        make_csv("notes", values),
+        k=2,
+        include_anonymized_csv=True,
+    )
+    serialized = json.dumps(result)
+
+    assert "notes" not in result["output_columns"]
+    assert result["safe_harbor_report"]["free_text_scan_status"] == "passed"
+    for value in values:
+        assert value not in serialized
+
+
+def test_scanned_free_text_without_detected_phi_may_be_preserved():
+    values = [
+        "routine follow up stable",
+        "routine follow up improving",
+        "routine follow up unchanged",
+        "routine follow up complete",
+    ]
+    result = anonymize_tabular_csv(
+        make_csv("notes", values),
+        k=2,
+        include_anonymized_csv=True,
+    )
+
+    assert "notes" in result["output_columns"]
+    assert result["safe_harbor_report"]["free_text_scan_status"] == "passed"
+
+
+def test_unknown_high_cardinality_code_is_removed_for_review():
+    values = ["ZXA-001", "ZXA-002", "ZXA-003", "ZXA-004"]
+    result = anonymize_tabular_csv(
+        make_csv("unfamiliar_code_field", values),
+        k=2,
+        include_anonymized_csv=True,
+    )
+    report = result["safe_harbor_report"]
+
+    assert "unfamiliar_code_field" not in result["output_columns"]
+    assert report["unique_code_scan_status"] == "passed_with_removals"
+    assert report["actual_knowledge_review_required"] is True
+    assert "18_photographs_and_unique_identifiers" in report[
+        "identifier_categories_removed"
+    ]
+
+
+def test_unknown_high_cardinality_numeric_identifier_is_removed():
+    result = anonymize_tabular_csv(
+        make_csv("unfamiliar_numeric_field", ["101", "202", "303", "404"]),
+        k=2,
+        include_anonymized_csv=True,
+    )
+
+    assert "unfamiliar_numeric_field" not in result["output_columns"]
+    assert result["safe_harbor_report"][
+        "unique_code_scan_status"
+    ] == "passed_with_removals"
+
+
+@pytest.mark.parametrize(
+    "column,values,category",
+    [
+        ("binary", ["opaque-a", "opaque-b", "opaque-c", "opaque-d"], "18_photographs_and_unique_identifiers"),
+        ("voiceprint_id", ["VOICE-A", "VOICE-B", "VOICE-C", "VOICE-D"], "17_biometric_identifiers"),
+        ("unknown_blob", ["data:image/png;base64,AAAA", "data:image/png;base64,BBBB", "data:image/png;base64,CCCC", "data:image/png;base64,DDDD"], "18_photographs_and_unique_identifiers"),
+    ],
+)
+def test_binary_image_and_biometric_columns_are_quarantined(column, values, category):
+    result = anonymize_tabular_csv(
+        make_csv(column, values),
+        k=2,
+        include_anonymized_csv=True,
+    )
+
+    assert column not in result["output_columns"]
+    assert category in result["safe_harbor_report"][
+        "identifier_categories_removed"
+    ]
+
+
+def test_unavailable_free_text_scanner_removes_column_instead_of_preserving_it():
+    from services.text_anonymization import TextAnonymizationError
+
+    with patch(
+        "services.safe_harbor.detect_clinical_phi",
+        side_effect=TextAnonymizationError("scanner unavailable", status_code=503),
+    ):
+        result = anonymize_tabular_csv(
+            make_csv("notes", ["safe a", "safe b", "safe c", "safe d"]),
+            k=2,
+            include_anonymized_csv=True,
+        )
+
+    assert "notes" not in result["output_columns"]
+    assert result["safe_harbor_report"][
+        "free_text_scan_status"
+    ] == "passed_with_quarantine"
+
+
+def test_safe_harbor_report_contains_only_safe_metadata_fields():
+    raw_values = ["111-22-3333", "222-33-4444", "333-44-5555", "444-55-6666"]
+    result = anonymize_tabular_csv(make_csv("ssn", raw_values), k=2)
+    report = result["safe_harbor_report"]
+    serialized = json.dumps(report)
+
+    assert set(report) == REPORT_KEYS
+    assert report["safe_harbor_validation_status"] == "passed_with_warnings"
+    assert report["actual_knowledge_review_required"] is True
+    assert any("legal review" in warning for warning in report["warnings"])
+    for value in raw_values:
+        assert value not in serialized
+
+
+def test_failed_k_or_l_never_reports_completed():
+    k_failure = anonymize_tabular_csv(
+        b"age,gender\n30,F\n31,M\n",
+        k=5,
+    )
+    l_failure = anonymize_tabular_csv(
+        b"age,gender,diagnosis\n30,F,alpha\n31,F,alpha\n40,M,alpha\n41,M,alpha\n",
+        k=2,
+        l=2,
+    )
+
+    assert k_failure["anonymization_status"] == "failed_privacy_validation"
+    assert l_failure["anonymization_status"] == "failed_privacy_validation"
+
+
+def test_unresolved_safe_harbor_category_forces_failed_privacy_validation():
+    forced_report = {
+        "safe_harbor_validation_status": "failed",
+        "identifier_categories_detected": ["18_photographs_and_unique_identifiers"],
+        "identifier_categories_removed": [],
+        "unresolved_identifier_categories": ["18_photographs_and_unique_identifiers"],
+        "date_compliance_status": "passed",
+        "age_over_89_status": "passed",
+        "geographic_compliance_status": "passed",
+        "free_text_scan_status": "passed",
+        "unique_code_scan_status": "failed",
+        "actual_knowledge_review_required": True,
+        "warnings": ["Technical review required."],
+    }
+    with patch(
+        "services.tabular_anonymization.build_safe_harbor_report",
+        return_value=forced_report,
+    ):
+        result = anonymize_tabular_csv(
+            b"age,gender\n30,F\n31,M\n",
+            k=2,
+        )
+
+    assert result["k_anonymity_satisfied"] is True
+    assert result["anonymization_status"] == "failed_privacy_validation"
+
+
+def test_api_does_not_leak_identifier_in_body_headers_filename_log_or_error():
+    csv_content = (
+        b"age,gender,notes\n"
+        b"30,F,Patient Alice Alpha SSN 111-22-3333\n"
+        b"31,M,Patient Bob Beta SSN 222-33-4444\n"
+        b"32,F,Patient Carol Gamma SSN 333-44-5555\n"
+        b"33,M,Patient Dan Delta SSN 444-55-6666\n"
+    )
+    logged_details = []
+
+    with patch(
+        "main.audit_logger.log_operation",
+        side_effect=lambda operation, details: logged_details.append(details),
+    ):
+        response = client.post(
+            "/anonymize_csv",
+            files={
+                "file": (
+                    "111-22-3333.csv",
+                    BytesIO(csv_content),
+                    "text/csv",
+                )
+            },
+            data={"k": "2", "l": "2"},
+        )
+
+    response_surface = (
+        response.content.decode("utf-8")
+        + json.dumps(dict(response.headers))
+        + json.dumps(logged_details)
+    )
+    assert response.status_code == 200
+    assert "anonymized_dataset.csv" in response.headers["content-disposition"]
+    assert response.headers["x-bioblock-safe-harbor-status"] == "passed_with_warnings"
+    for identifier in (
+        "111-22-3333",
+        "222-33-4444",
+        "Alice Alpha",
+        "Bob Beta",
+    ):
+        assert identifier not in response_surface
+
+    error_response = client.post(
+        "/anonymize_csv",
+        files={"file": ("dataset.csv", BytesIO(csv_content), "text/csv")},
+        data={
+            "k": "2",
+            "safe_harbor_mappings": json.dumps(
+                {"11_account_numbers": ["missing_column"]}
+            ),
+        },
+    )
+    assert error_response.status_code == 400
+    assert "111-22-3333" not in error_response.text

--- a/python_backend/tests/test_tabular_anonymization.py
+++ b/python_backend/tests/test_tabular_anonymization.py
@@ -1,0 +1,352 @@
+import csv
+import io
+import json
+import os
+import re
+import sys
+from collections import Counter
+
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from services.tabular_anonymization import (  # noqa: E402
+    TabularAnonymizationError,
+    anonymize_tabular_csv,
+    classify_tabular_columns,
+)
+
+
+DIRECT_COLUMNS = {
+    "Id",
+    "SSN",
+    "DRIVERS",
+    "PASSPORT",
+    "PREFIX",
+    "FIRST",
+    "LAST",
+    "SUFFIX",
+    "MAIDEN",
+    "ADDRESS",
+}
+
+QUASI_COLUMNS = {
+    "BIRTHDATE",
+    "DEATHDATE",
+    "GENDER",
+    "RACE",
+    "ETHNICITY",
+    "MARITAL",
+    "BIRTHPLACE",
+    "CITY",
+    "STATE",
+    "COUNTY",
+    "ZIP",
+    "LAT",
+    "LON",
+}
+
+SYNTHETIC_SYNTHEA_CSV = """Id,BIRTHDATE,DEATHDATE,SSN,DRIVERS,PASSPORT,PREFIX,FIRST,LAST,SUFFIX,MAIDEN,MARITAL,RACE,ETHNICITY,GENDER,BIRTHPLACE,ADDRESS,CITY,STATE,COUNTY,ZIP,LAT,LON,HEALTHCARE_EXPENSES,HEALTHCARE_COVERAGE
+fake-uuid-001,1980-01-04,,111-22-3333,DL-FAKE-01,P-FAKE-01,Ms.,Alicia,Alpha,Jr.,MaidenA,M,white,nonhispanic,F,Boston MA,101 Fake Street,Boston,MA,Suffolk,02139,42.3601,-71.0589,1000.00,600.00
+fake-uuid-002,1981-01-05,,222-33-4444,DL-FAKE-02,P-FAKE-02,Mr.,Boris,Beta,Sr.,MaidenB,M,white,nonhispanic,M,Boston MA,202 Fake Avenue,Boston,MA,Suffolk,02140,42.3611,-71.0599,1100.00,650.00
+fake-uuid-003,1990-06-14,2024-02-01,333-44-5555,DL-FAKE-03,P-FAKE-03,Dr.,Carla,Gamma,III,MaidenC,S,black,hispanic,F,San Francisco CA,303 Fake Road,San Francisco,CA,San Francisco,94107,37.7749,-122.4194,1200.00,700.00
+fake-uuid-004,1991-06-15,2024-02-02,444-55-6666,DL-FAKE-04,P-FAKE-04,Mx.,Dario,Delta,IV,MaidenD,S,black,hispanic,M,San Francisco CA,404 Fake Lane,San Francisco,CA,San Francisco,94110,37.7759,-122.4184,1300.00,750.00
+""".encode("utf-8")
+
+
+def internal_rows(result):
+    return list(csv.DictReader(io.StringIO(result["_internal_anonymized_csv"])))
+
+
+def independently_group(rows, quasi_identifiers):
+    return Counter(
+        tuple(row[column] for column in quasi_identifiers)
+        for row in rows
+    )
+
+
+def test_synthea_column_classification_is_case_insensitive():
+    upper = classify_tabular_columns([*DIRECT_COLUMNS, *QUASI_COLUMNS])
+    lower_header = [column.lower() for column in [*DIRECT_COLUMNS, *QUASI_COLUMNS]]
+    lower = classify_tabular_columns(lower_header)
+
+    assert set(upper["direct_identifiers"]) == DIRECT_COLUMNS
+    assert set(upper["quasi_identifiers"]) == QUASI_COLUMNS
+    assert set(lower["direct_identifiers"]) == {
+        column.lower() for column in DIRECT_COLUMNS
+    }
+    assert set(lower["quasi_identifiers"]) == {
+        column.lower() for column in QUASI_COLUMNS
+    }
+
+
+def test_column_classification_supports_common_aliases():
+    header = [
+        "patient_id",
+        "first_name",
+        "family_name",
+        "driver_license",
+        "passport_number",
+        "street_address",
+        "birth_date",
+        "death_date",
+        "marital_status",
+        "birth_place",
+        "postal_code",
+        "latitude",
+        "longitude",
+    ]
+
+    classified = classify_tabular_columns(header)
+
+    assert set(classified["direct_identifiers"]) == set(header[:6])
+    assert set(classified["quasi_identifiers"]) == set(header[6:])
+    assert classified["precise_geography"] == ["latitude", "longitude"]
+
+
+def test_direct_identifiers_and_exact_coordinates_are_removed_without_leakage():
+    result = anonymize_tabular_csv(
+        SYNTHETIC_SYNTHEA_CSV,
+        k=2,
+        include_anonymized_csv=True,
+    )
+    output = result["_internal_anonymized_csv"]
+    rows = internal_rows(result)
+
+    assert DIRECT_COLUMNS.isdisjoint(rows[0])
+    assert {"LAT", "LON"}.isdisjoint(rows[0])
+    assert set(result["direct_identifiers_removed"]) == DIRECT_COLUMNS
+    assert result["precise_geography_columns_removed"] == ["LAT", "LON"]
+    for fake_value in (
+        "fake-uuid-001",
+        "111-22-3333",
+        "DL-FAKE-01",
+        "P-FAKE-01",
+        "Alicia",
+        "Alpha",
+        "MaidenA",
+        "101 Fake Street",
+        "42.3601",
+        "-71.0589",
+    ):
+        assert fake_value not in output
+
+
+def test_dates_are_generalized_and_missing_deathdate_is_safe():
+    result = anonymize_tabular_csv(
+        SYNTHETIC_SYNTHEA_CSV,
+        k=2,
+        include_anonymized_csv=True,
+    )
+    rows = internal_rows(result)
+    output = result["_internal_anonymized_csv"]
+
+    assert all(not re.fullmatch(r"\d{4}-\d{2}-\d{2}", row["BIRTHDATE"]) for row in rows)
+    assert all(not re.fullmatch(r"\d{4}-\d{2}-\d{2}", row["DEATHDATE"]) for row in rows)
+    assert "UNKNOWN" in {row["DEATHDATE"] for row in rows}
+    for exact_date in ("1980-01-04", "1981-01-05", "2024-02-01", "2024-02-02"):
+        assert exact_date not in output
+
+
+def test_invalid_date_becomes_unknown_with_safe_warning():
+    csv_bytes = b"Id,BIRTHDATE,GENDER\na,not-a-date,F\nb,2001-02-03,M\n"
+
+    result = anonymize_tabular_csv(
+        csv_bytes,
+        k=2,
+        include_anonymized_csv=True,
+    )
+
+    assert "not-a-date" not in result["_internal_anonymized_csv"]
+    assert all(row["BIRTHDATE"] == "UNKNOWN" for row in internal_rows(result))
+    assert any("1 invalid date" in warning for warning in result["warnings"])
+
+
+def test_geography_is_removed_generalized_or_suppressed_consistently():
+    result = anonymize_tabular_csv(
+        SYNTHETIC_SYNTHEA_CSV,
+        k=2,
+        include_anonymized_csv=True,
+    )
+    rows = internal_rows(result)
+    output = result["_internal_anonymized_csv"]
+
+    assert {"ADDRESS", "CITY", "COUNTY", "BIRTHPLACE", "ZIP", "LAT", "LON"}.isdisjoint(rows[0])
+    assert set(row["STATE"] for row in rows) <= {"*", "UNKNOWN"}
+    for raw_value in (
+        "02139",
+        "94107",
+        "Boston",
+        "Suffolk",
+        "101 Fake Street",
+        "42.3601",
+        "-122.4194",
+    ):
+        assert raw_value not in output
+
+
+def test_reported_k_metrics_match_independent_csv_calculation():
+    result = anonymize_tabular_csv(
+        SYNTHETIC_SYNTHEA_CSV,
+        k=2,
+        include_anonymized_csv=True,
+    )
+    rows = internal_rows(result)
+    groups = independently_group(rows, result["quasi_identifiers_used"])
+    independent_minimum = min(groups.values())
+
+    assert independent_minimum >= 2
+    assert result["min_group_size"] == independent_minimum
+    assert result["equivalence_classes"] == len(groups)
+    assert result["k_anonymity_satisfied"] is True
+    assert result["anonymization_status"] == "completed_with_warnings"
+
+
+def test_k_failure_cannot_report_completed_or_satisfied():
+    csv_bytes = b"Id,age,gender\na,30,F\nb,31,M\nc,32,F\n"
+
+    result = anonymize_tabular_csv(
+        csv_bytes,
+        k=5,
+        include_anonymized_csv=True,
+    )
+    rows = internal_rows(result)
+    groups = independently_group(rows, result["quasi_identifiers_used"])
+
+    assert min(groups.values()) == 3
+    assert result["min_group_size"] == 3
+    assert result["k_anonymity_satisfied"] is False
+    assert result["anonymization_status"] == "failed_privacy_validation"
+    assert any("k-anonymity" in warning for warning in result["warnings"])
+
+
+def test_l_diversity_passes_when_sensitive_column_is_diverse():
+    csv_bytes = (
+        b"Id,age,gender,diagnosis\n"
+        b"a,30,F,alpha\n"
+        b"b,31,F,beta\n"
+        b"c,40,M,alpha\n"
+        b"d,41,M,beta\n"
+    )
+
+    result = anonymize_tabular_csv(csv_bytes, k=2, l=2)
+
+    assert result["sensitive_column"] == "diagnosis"
+    assert result["l_diversity_satisfied"] is True
+    assert result["anonymization_status"] == "completed_with_warnings"
+
+
+def test_l_diversity_failure_is_truthful_and_not_completed():
+    csv_bytes = (
+        b"Id,age,gender,diagnosis\n"
+        b"a,30,F,alpha\n"
+        b"b,31,F,alpha\n"
+        b"c,40,M,alpha\n"
+        b"d,41,M,alpha\n"
+    )
+
+    result = anonymize_tabular_csv(csv_bytes, k=2, l=2)
+
+    assert result["k_anonymity_satisfied"] is True
+    assert result["l_diversity_satisfied"] is False
+    assert result["anonymization_status"] == "failed_privacy_validation"
+    assert any("l-diversity" in warning for warning in result["warnings"])
+
+
+def test_l_diversity_is_not_applicable_without_sensitive_column():
+    csv_bytes = b"Id,age,gender\na,30,F\nb,31,F\nc,32,M\nd,33,M\n"
+
+    result = anonymize_tabular_csv(csv_bytes, k=2, l=2)
+
+    assert result["sensitive_column"] is None
+    assert result["l_diversity_satisfied"] == "not_applicable"
+    assert result["l_diversity_satisfied"] is not True
+    assert any("not evaluated" in warning for warning in result["warnings"])
+
+
+@pytest.mark.parametrize("sensitive_column", ["HEALTHCARE_EXPENSES", "HEALTHCARE_COVERAGE"])
+def test_raw_numerical_sensitive_columns_require_bucketing(sensitive_column):
+    with pytest.raises(TabularAnonymizationError) as exc:
+        anonymize_tabular_csv(
+            SYNTHETIC_SYNTHEA_CSV,
+            k=2,
+            sensitive_column=sensitive_column,
+        )
+
+    assert "requires bucketing" in exc.value.detail
+    assert "pre-bucketed categorical" in exc.value.detail
+
+
+def test_safe_summary_does_not_expose_rows_or_raw_sensitive_values():
+    csv_bytes = (
+        b"Id,SSN,FIRST,ADDRESS,age,gender,diagnosis\n"
+        b"uuid-secret-1,111-22-3333,NameSecret,1 Secret Road,30,F,RareAlpha\n"
+        b"uuid-secret-2,222-33-4444,OtherSecret,2 Secret Road,31,M,RareBeta\n"
+    )
+
+    result = anonymize_tabular_csv(csv_bytes, k=2, l=2)
+    response_text = json.dumps(result)
+
+    assert "_internal_anonymized_csv" not in result
+    for raw_value in (
+        "uuid-secret-1",
+        "111-22-3333",
+        "NameSecret",
+        "1 Secret Road",
+        "RareAlpha",
+        "RareBeta",
+    ):
+        assert raw_value not in response_text
+
+
+def test_rows_columns_missing_values_and_analytical_data_are_preserved():
+    csv_bytes = (
+        b"Id,score,gender,lab_result,notes\n"
+        b"a,-10,F,7.1,cohort-a\n"
+        b"b,-5,F,,cohort-b\n"
+        b"c,10,M,8.2,cohort-c\n"
+        b"d,20,M,9.3,cohort-d\n"
+    )
+
+    result = anonymize_tabular_csv(
+        csv_bytes,
+        k=2,
+        quasi_identifiers=["score", "gender"],
+        include_anonymized_csv=True,
+    )
+    rows = internal_rows(result)
+
+    assert result["rows_in"] == result["rows_out"] == 4
+    assert result["output_columns"] == ["score", "gender", "lab_result", "notes"]
+    assert list(rows[0]) == result["output_columns"]
+    assert [row["notes"] for row in rows] == [
+        "cohort-a",
+        "cohort-b",
+        "cohort-c",
+        "cohort-d",
+    ]
+    assert rows[1]["lab_result"] == "UNKNOWN"
+    assert all("--" not in row["score"] for row in rows)
+    assert any(" to " in row["score"] for row in rows)
+    assert 0.0 <= result["generalization_rate"] <= 1.0
+    assert 0.0 <= result["suppression_rate"] <= 1.0
+
+
+def test_empty_and_invalid_csv_are_rejected_clearly():
+    with pytest.raises(TabularAnonymizationError, match="empty"):
+        anonymize_tabular_csv(b"  \n")
+    with pytest.raises(TabularAnonymizationError, match="Invalid CSV"):
+        anonymize_tabular_csv(b'age,diagnosis\n"42,flu\n')
+
+
+def test_missing_required_columns_are_rejected_clearly():
+    with pytest.raises(TabularAnonymizationError, match="Missing quasi-identifier"):
+        anonymize_tabular_csv(
+            b"diagnosis\nflu\n",
+            quasi_identifiers=["age"],
+        )
+    with pytest.raises(TabularAnonymizationError, match="Missing sensitive column"):
+        anonymize_tabular_csv(
+            b"age,diagnosis\n40,flu\n41,cold\n",
+            sensitive_column="outcome",
+        )

--- a/python_backend/tests/test_text_anonymization.py
+++ b/python_backend/tests/test_text_anonymization.py
@@ -20,7 +20,7 @@ def test_mrn_with_context_is_detected_and_replaced():
 
     assert result["anonymization_status"] == "completed"
     assert "123456" not in result["anonymized_text"]
-    assert "MRN_" in result["anonymized_text"]
+    assert "<REDACTED_MRN>" in result["anonymized_text"]
     assert result["detected_entities"]["MEDICAL_RECORD_NUMBER"] == 1
 
 
@@ -50,7 +50,7 @@ def test_patient_id_is_detected_and_replaced():
     )
 
     assert "PT-1001" not in result["anonymized_text"]
-    assert "PATIENT_ID_" in result["anonymized_text"]
+    assert "<REDACTED_PATIENT_ID>" in result["anonymized_text"]
     assert result["detected_entities"]["PATIENT_ID"] == 1
 
 
@@ -61,15 +61,15 @@ def test_health_plan_id_is_detected_and_replaced():
     )
 
     assert "ABC123456789" not in result["anonymized_text"]
-    assert "HEALTH_PLAN_" in result["anonymized_text"]
+    assert "<REDACTED_HEALTH_PLAN>" in result["anonymized_text"]
     assert result["detected_entities"]["HEALTH_PLAN_ID"] == 1
 
 
 def test_deterministic_surrogate_consistency_with_same_salt():
     text = "Patient has MRN: 123456."
 
-    first = anonymize_clinical_text(text, study_salt="study-a")
-    second = anonymize_clinical_text(text, study_salt="study-a")
+    first = anonymize_clinical_text(text, profile="research", study_salt="study-a")
+    second = anonymize_clinical_text(text, profile="research", study_salt="study-a")
 
     assert first["anonymized_text"] == second["anonymized_text"]
 
@@ -77,8 +77,8 @@ def test_deterministic_surrogate_consistency_with_same_salt():
 def test_different_salt_changes_surrogate():
     text = "Patient has MRN: 123456."
 
-    first = anonymize_clinical_text(text, study_salt="study-a")
-    second = anonymize_clinical_text(text, study_salt="study-b")
+    first = anonymize_clinical_text(text, profile="research", study_salt="study-a")
+    second = anonymize_clinical_text(text, profile="research", study_salt="study-b")
 
     assert first["anonymized_text"] != second["anonymized_text"]
     assert "123456" not in first["anonymized_text"]
@@ -165,3 +165,38 @@ def test_overlapping_email_text_does_not_leave_email_exposed():
 
     assert "john.doe@example.com" not in result["anonymized_text"]
     assert "<REDACTED_EMAIL>" in result["anonymized_text"]
+
+
+def test_research_profile_shifts_dates_and_removes_patient_context_name():
+    result = anonymize_clinical_text(
+        "Patient John Doe, MRN 123456, visited on 2026-06-16.",
+        profile="research",
+        study_salt="study-a",
+    )
+
+    assert result["privacy_profile"] == "research"
+    assert result["date_strategy"] == "shift"
+    assert result["text_identifier_strategy"] == "pseudonymize"
+    assert "John Doe" not in result["anonymized_text"]
+    assert "123456" not in result["anonymized_text"]
+    assert "2026-06-16" not in result["anonymized_text"]
+    assert "<REDACTED_DATE>" not in result["anonymized_text"]
+    assert result["detected_entities"]["PERSON"] == 1
+    assert result["detected_entities"]["DATE_TIME"] == 1
+
+
+def test_strict_profile_redacts_dates():
+    result = anonymize_clinical_text(
+        "Patient John Doe, MRN 123456, visited on 2026-06-16.",
+        profile="strict",
+        study_salt="study-a",
+    )
+
+    assert result["privacy_profile"] == "strict"
+    assert result["date_strategy"] == "redact"
+    assert result["text_identifier_strategy"] == "redact"
+    assert "<REDACTED_NAME>" in result["anonymized_text"]
+    assert "<REDACTED_MRN>" in result["anonymized_text"]
+    assert "2026-06-16" not in result["anonymized_text"]
+    assert "<REDACTED_DATE>" in result["anonymized_text"]
+

--- a/python_backend/tests/test_wsi_tiling.py
+++ b/python_backend/tests/test_wsi_tiling.py
@@ -1,0 +1,132 @@
+import json
+import math
+import os
+import sys
+
+from PIL import Image
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from services.ocr_redaction import OCRBox  # noqa: E402
+from services.wsi_tiling import (  # noqa: E402
+    TileCoordinate,
+    generate_priority_tiles,
+    map_tile_boxes_to_slide,
+    scan_wsi_bytes,
+    scan_wsi_slide,
+)
+
+
+class FakeOCRBackend:
+    ocr_engine_status = "available"
+
+    def __init__(self, boxes=None):
+        self.boxes = boxes or []
+
+    def detect_text_boxes(self, image):
+        return self.boxes
+
+
+class FakeSlide:
+    def __init__(self, width, height):
+        self.dimensions = (width, height)
+        self.read_regions = []
+
+    def read_region(self, location, level, size):
+        self.read_regions.append((location, level, size))
+        return Image.new("RGB", size, "white")
+
+
+def test_priority_tile_generator_returns_corners_and_borders_first():
+    tiles = generate_priority_tiles(4096, 3072, tile_size=1024)
+
+    assert [tile.priority_region for tile in tiles[:4]] == [
+        "corner_top_left",
+        "corner_top_right",
+        "corner_bottom_left",
+        "corner_bottom_right",
+    ]
+    assert "top_border" in [tile.priority_region for tile in tiles]
+    assert "bottom_border" in [tile.priority_region for tile in tiles]
+    assert "left_border" in [tile.priority_region for tile in tiles]
+    assert "right_border" in [tile.priority_region for tile in tiles]
+
+
+def test_tile_coordinates_stay_inside_image_bounds():
+    width = 2500
+    height = 1800
+    tiles = generate_priority_tiles(width, height, tile_size=700)
+
+    assert tiles
+    for tile in tiles:
+        assert tile.x >= 0
+        assert tile.y >= 0
+        assert tile.width > 0
+        assert tile.height > 0
+        assert tile.x + tile.width <= width
+        assert tile.y + tile.height <= height
+
+
+def test_large_wsi_scan_reads_priority_tiles_not_full_image():
+    slide = FakeSlide(10000, 8000)
+    result = scan_wsi_slide(
+        slide,
+        ocr_backend=FakeOCRBackend(),
+        tile_size=1024,
+    )
+
+    assert result["pixel_redaction_status"] == "redaction_plan_ready"
+    assert result["tiles_scanned"] == len(slide.read_regions)
+    full_tile_count = math.ceil(10000 / 1024) * math.ceil(8000 / 1024)
+    assert result["tiles_scanned"] < full_tile_count
+    for _location, _level, size in slide.read_regions:
+        assert size[0] <= 1024
+        assert size[1] <= 1024
+
+
+def test_tile_ocr_boxes_map_to_global_coordinates():
+    tile = TileCoordinate(
+        x=1024,
+        y=2048,
+        width=512,
+        height=512,
+        priority_region="top_border",
+    )
+    mapped = map_tile_boxes_to_slide(
+        tile,
+        [OCRBox("SLIDE_LABEL", 0.95, 10, 20, 100, 30)],
+    )
+
+    assert mapped == [
+        OCRBox("SLIDE_LABEL", 0.95, 1034, 2068, 100, 30),
+    ]
+
+
+def test_wsi_scan_is_honest_when_rewrite_is_not_supported():
+    result = scan_wsi_slide(
+        FakeSlide(2048, 2048),
+        ocr_backend=FakeOCRBackend([OCRBox("WSI_LABEL", 0.99, 0, 0, 50, 20)]),
+        tile_size=1024,
+    )
+    response_text = json.dumps(result)
+
+    assert result["pixel_redaction_status"] == "redaction_plan_ready"
+    assert result["wsi_rewrite_status"] == "not_supported_yet"
+    assert result["ocr_boxes_detected"] > 0
+    assert result["boxes_redacted"] == 0
+    assert result["redaction_plan_boxes"] == result["ocr_boxes_detected"]
+    assert "WSI_LABEL" not in response_text
+
+
+def test_wsi_bytes_returns_honest_status_without_openslide(monkeypatch):
+    monkeypatch.setattr("services.wsi_tiling._load_openslide_module", lambda: None)
+
+    result = scan_wsi_bytes(
+        b"not a real slide",
+        filename="slide.svs",
+        ocr_backend=FakeOCRBackend(),
+    )
+
+    assert result["pixel_redaction_status"] == "redaction_plan_unavailable"
+    assert result["wsi_rewrite_status"] == "not_supported_yet"
+    assert result["tiles_scanned"] == 0


### PR DESCRIPTION
@karthiksathishjeemain @pradeeban @Chali-healthy This PR implements the Week 8 BM25 lexical retrieval milestone for Bio-Block.

It introduces deterministic keyword search over anonymized clinical content and explicitly approved metadata. The BM25 index is kept separate from original uploads, raw PHI, unsafe metadata, and the existing ChromaDB retrieval pipeline.

## Why this change is needed

Exact terminology matters in biomedical search. Semantic retrieval may not always prioritize exact clinical terms and codes such as `E11.9`, `COVID-19`, or `HbA1c`.

BM25 provides a lightweight lexical retrieval layer that considers:

- How frequently a query term appears in a document
- How rare the term is across the index
- Document-length normalization
- Repeated query terms
- Deterministic ordering when scores are tied

The implementation is internal and does not introduce another dependency solely for BM25 scoring.

## What was implemented

### Privacy-gated searchable document model

The BM25 service accepts a restricted internal document contract containing:

- A safe document ID
- Modality
- Anonymized text
- Anonymization status
- Explicitly approved safe metadata
- Optional privacy-validation status

Documents are accepted only when their anonymization status is exactly `completed`.

When a privacy-validation status is provided, it must indicate a successful validation result.

Documents are rejected when they contain:

- Failed, pending, missing, or warning-only anonymization status
- Failed privacy validation
- Raw file bytes
- Raw or original content fields
- Unsupported document fields
- Unsafe or unapproved metadata

The metadata denylist uses case-insensitive and separator-insensitive matching. This catches variants such as:

- `Patient_Name`
- `patient-id`
- `original.filename`
- `raw DICOM metadata`
- `temporary-path`

The denylist is an additional indexing safety gate. It does not independently prove that content has been de-identified; anonymization remains an upstream responsibility.

### Safe searchable content construction

Searchable text is constructed only from:

- Anonymized text
- Modality
- Explicitly approved metadata values

Approved metadata categories include:

- Document type
- Clinical terms
- Category labels
- Clinical codes
- Disease tags

Document IDs may be returned for result selection, but they are never included in searchable text.

Original filenames, upload paths, temporary paths, raw metadata, arbitrary metadata values, and file bytes are never indexed.

### BM25 implementation

The service contains a small internal Okapi BM25 implementation using the standard defaults:

- `k1 = 1.5`
- `b = 0.75`

It tracks:

- Document token frequencies
- Document frequencies
- Document lengths
- Average document length
- Inverse document frequency
- BM25 query scores

The service supports:

- Batch document indexing
- Document upsert and replacement
- Atomic index rebuilding
- Document deletion
- Index clearing
- Empty indexes
- One-document indexes
- Zero average document length
- Repeated query terms
- Terms missing from every document
- Deterministic score ordering
- Modality filtering before top-k selection

Results are ordered by descending BM25 score. Ties are resolved deterministically using the document ID.

BM25 scores are returned as their real values and are not converted into percentages.

### Tokenization

Tokenization is deterministic, Unicode-aware, and entirely local. It does not download NLTK resources or language models.

The tokenizer:

- Converts text to lowercase
- Handles whitespace and punctuation consistently
- Retains numeric tokens
- Preserves useful clinical codes
- Preserves hyphenated terms

Examples supported by the tokenizer include:

- `E11.9`
- `COVID-19`
- `HbA1c`
- `type 2 diabetes`

Search is case-insensitive.

### Search endpoint

A new endpoint is available:

`POST /api/v1/search/bm25`

Example request:

```json
{
  "query": "type 2 diabetes",
  "top_k": 10,
  "modality": "text"
}
```

The endpoint:

- Rejects empty and whitespace-only queries
- Restricts `top_k` to values between 1 and 100
- Rejects unsupported request fields
- Supports an optional modality filter
- Returns an empty result list when nothing matches
- Does not expose unexpected internal errors

The response contains:

- Search type
- Query token count
- Result count
- Index document count
- Retrieval status
- Ranked safe results

Each search result contains only:

- Document ID
- Rank
- BM25 score
- Modality
- Approved safe metadata
- A short snippet generated from anonymized text

The endpoint does not echo the raw query in its response.

Raw queries are also not written to logs because search input may itself contain PHI. Logs contain only non-reversible operational information such as query length, token count, and result count.

### Safe snippet generation

Result snippets are generated only from the anonymized text stored in the BM25 index.

Metadata values, raw records, original files, and internal paths are never used to construct snippets.

Snippets are intentionally short and whitespace-normalized.

### Index population and persistence

The BM25 index is currently maintained in memory.

It is not populated from `/store` or `/store_enhanced` because those endpoints currently accept arbitrary content and do not provide a reliable privacy-safe stored-record contract.

There is also no public endpoint that accepts arbitrary documents for BM25 indexing.

Trusted backend code can populate the service through its internal methods:

- `index_documents(...)`
- `upsert_document(...)`
- `rebuild(...)`
- `delete_document(...)`
- `clear()`

This avoids creating an unsafe parallel storage path.

Persistent index rebuilding can be connected later when the backend has a finalized contract for retrieving completed, privacy-validated anonymized records.

Because the index is currently process-local, it will be empty after an application restart.

### Existing retrieval behavior

The existing ChromaDB collections and vector-search behavior were not modified.

This PR does not change:

- `/store`
- `/store_enhanced`
- `/search`
- `/search_with_filter`
- `/search_enhanced`
- Existing ChromaDB collections
- Existing semantic-search ranking

The new BM25 endpoint is an independent lexical retrieval path.

## Privacy and safety behavior

The implementation verifies that:

- Failed anonymization outputs cannot enter the index
- Missing anonymization status is rejected
- Failed privacy validation is rejected
- Raw bytes are rejected
- Raw content fields are rejected
- Original filenames are rejected
- Unsafe metadata keys are rejected
- Arbitrary metadata is not automatically indexed
- Document IDs are not searchable
- Snippets come only from anonymized text
- Responses expose only approved result fields
- Internal errors are not returned to clients
- Raw search queries are not logged

No raw PHI, original uploads, datasets, internal filesystem paths, or binary files are included in this PR.

## Ranking behavior covered

The test suite verifies that:

- Relevant documents rank above unrelated documents
- Rare terms receive more weight than common terms
- Repeated document terms contribute to ranking
- Repeated query terms contribute consistently
- Shorter focused documents benefit from length normalization
- Search is case-insensitive
- Clinical codes such as `E11.9` remain searchable
- Hyphenated terms such as `COVID-19` remain searchable
- No-match queries return an empty result list
- Ties are deterministic
- Modality filters are applied before top-k selection
- Duplicate document IDs are replaced through upsert
- Index rebuilding replaces the previous index atomically
