### PR TITLE
Week 8b Tree enhancements

### DIFF
--- a/analytics-service/app/main.py
+++ b/analytics-service/app/main.py
@@ -27,6 +27,12 @@ from app.services.inferential import (
     run_paired_test,
     run_one_sample_test,
     run_multi_group_test,
+    run_chi_square_independence,
+    run_chi_square_goodness_of_fit,
+    run_pearson_correlation,
+    run_spearman_correlation,
+    run_correlation_analysis,
+    run_correlation_matrix,
 )
 from app.utils.csv_parser import parse_csv
 
@@ -225,6 +231,8 @@ async def visualize(
 VALID_TEST_TYPES = {
     "t_test": ["independent", "paired", "one_sample"],
     "anova": ["one_way", "two_way", "repeated_measures"],
+    "chi_square": ["independence", "goodness_of_fit"],
+    "correlation": ["pearson", "spearman", "auto", "matrix"],
 }
 VALID_ALTERNATIVES = ["two-sided", "less", "greater"]
 
@@ -235,13 +243,15 @@ async def inferential_analysis(
     file: UploadFile = File(...),
     test_type: str = Form(
         ...,
-        description="Test category: t_test, anova",
+        description="Test category: t_test, anova, chi_square, correlation",
     ),
     test_subtype: Optional[str] = Form(
         None,
         description=(
             "Test subtype. For t_test: independent, paired, one_sample. "
-            "For anova: one_way, two_way, repeated_measures."
+            "For anova: one_way, two_way, repeated_measures. "
+            "For chi_square: independence, goodness_of_fit. "
+            "For correlation: pearson, spearman, auto, matrix."
         ),
     ),
     numeric_column: Optional[str] = Form(
@@ -265,6 +275,22 @@ async def inferential_analysis(
     repeated_columns: Optional[str] = Form(
         None,
         description="Comma-separated condition columns (for repeated measures)",
+    ),
+    column_1: Optional[str] = Form(
+        None,
+        description="First column (for chi-square independence or correlation)",
+    ),
+    column_2: Optional[str] = Form(
+        None,
+        description="Second column (for chi-square independence or correlation)",
+    ),
+    target_columns: Optional[str] = Form(
+        None,
+        description="Comma-separated columns (for correlation matrix)",
+    ),
+    correlation_method: Optional[str] = Form(
+        "auto",
+        description="Correlation method: pearson, spearman, auto",
     ),
     alpha: float = Form(0.05, description="Significance level"),
     alternative: str = Form(
@@ -307,16 +333,13 @@ async def inferential_analysis(
     cleaned_numeric_2 = _clean(numeric_column_2)
     cleaned_factor_2 = _clean(factor_column_2)
     cleaned_repeated = _clean(repeated_columns)
+    cleaned_col1 = _clean(column_1)
+    cleaned_col2 = _clean(column_2)
+    cleaned_target_cols = _clean(target_columns)
+    cleaned_corr_method = _clean(correlation_method) or "auto"
 
     # Validate test_type
     if cleaned_test_type not in VALID_TEST_TYPES:
-        # Check for not-yet-implemented types with a specific message
-        if cleaned_test_type in ("chi_square", "correlation"):
-            raise HTTPException(
-                400,
-                f"Test type '{cleaned_test_type}' is not yet implemented. "
-                f"Supported types: {list(VALID_TEST_TYPES.keys())}",
-            )
         raise HTTPException(
             400,
             f"Unsupported test type '{cleaned_test_type}'. "
@@ -431,6 +454,71 @@ async def inferential_analysis(
                 raise HTTPException(
                     400, f"Unknown anova subtype: {subtype}"
                 )
+
+        elif cleaned_test_type == "chi_square":
+            subtype = cleaned_subtype or "independence"
+            if subtype == "independence":
+                c1 = cleaned_col1 or cleaned_numeric
+                c2 = cleaned_col2 or cleaned_group
+                if not c1 or not c2:
+                    raise HTTPException(
+                        400,
+                        "Chi-square independence test requires 'column_1' "
+                        "and 'column_2' (or 'numeric_column' and "
+                        "'group_column').",
+                    )
+                analysis = run_chi_square_independence(
+                    df, c1, c2, alpha
+                )
+            elif subtype == "goodness_of_fit":
+                col = cleaned_col1 or cleaned_numeric
+                if not col:
+                    raise HTTPException(
+                        400,
+                        "Chi-square goodness-of-fit requires 'column_1' "
+                        "(or 'numeric_column').",
+                    )
+                analysis = run_chi_square_goodness_of_fit(
+                    df, col, alpha=alpha
+                )
+            else:
+                raise HTTPException(
+                    400, f"Unknown chi_square subtype: {subtype}"
+                )
+
+        elif cleaned_test_type == "correlation":
+            subtype = cleaned_subtype or "auto"
+            if subtype == "matrix":
+                cols_list = None
+                if cleaned_target_cols:
+                    cols_list = [
+                        c.strip() for c in cleaned_target_cols.split(",")
+                        if c.strip()
+                    ]
+                analysis = run_correlation_matrix(
+                    df, columns=cols_list, method=cleaned_corr_method, alpha=alpha
+                )
+            else:
+                c1 = cleaned_col1 or cleaned_numeric
+                c2 = cleaned_col2 or cleaned_group
+                if not c1 or not c2:
+                    raise HTTPException(
+                        400,
+                        "Correlation analysis requires 'column_1' and "
+                        "'column_2' (or 'numeric_column' and "
+                        "'group_column').",
+                    )
+                if subtype == "pearson":
+                    analysis = run_pearson_correlation(df, c1, c2, alpha)
+                elif subtype == "spearman":
+                    analysis = run_spearman_correlation(df, c1, c2, alpha)
+                elif subtype == "auto":
+                    analysis = run_correlation_analysis(df, c1, c2, alpha)
+                else:
+                    raise HTTPException(
+                        400, f"Unknown correlation subtype: {subtype}"
+                    )
+
         else:
             raise HTTPException(400, f"Unknown test type: {cleaned_test_type}")
 

--- a/analytics-service/app/main.py
+++ b/analytics-service/app/main.py
@@ -36,6 +36,10 @@ from app.services.inferential import (
 )
 from app.utils.csv_parser import parse_csv
 
+# Demo: Hypothesis Lab prototype
+from app.routers.demo_router import router as demo_router
+from app.services.demo_sessions import session_store
+
 APP_VERSION = "0.1.0"
 
 app = FastAPI(
@@ -45,11 +49,24 @@ app = FastAPI(
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:3000"],
+    allow_origins=["http://localhost:3000", "http://localhost:5174"],
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+# Mount the hypothesis-tree demo router
+app.include_router(demo_router)
+
+
+@app.on_event("startup")
+async def startup_event():
+    await session_store.start_cleanup_loop()
+
+
+@app.on_event("shutdown")
+async def shutdown_event():
+    await session_store.stop_cleanup_loop()
 
 
 @app.get("/health", response_model=HealthResponse)

--- a/analytics-service/app/models/demo_schemas.py
+++ b/analytics-service/app/models/demo_schemas.py
@@ -1,0 +1,299 @@
+"""Pydantic schemas for the Hypothesis Lab Demo.
+
+These models are intentionally separate from the production schemas in
+``schemas.py`` so the demo can evolve independently without touching the
+existing analytics contract.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field
+
+
+# ---------------------------------------------------------------------------
+# Enums
+# ---------------------------------------------------------------------------
+
+class ColumnType(str, Enum):
+    NUMERIC = "numeric"
+    CATEGORICAL = "categorical"
+    BOOLEAN = "boolean"
+    DATETIME = "datetime"
+    TEXT = "text"
+    IDENTIFIER = "identifier"
+
+
+class NodeKind(str, Enum):
+    ROOT = "root"
+    QUESTION = "question"
+    ANSWER = "answer"
+    HYPOTHESIS = "hypothesis"
+    ASSUMPTION = "assumption"
+    ANALYSIS = "analysis"
+    RESULT = "result"
+
+
+class BranchStatus(str, Enum):
+    ACTIVE = "active"
+    ARCHIVED = "archived"
+    COMPLETED = "completed"
+
+
+class StartMode(str, Enum):
+    GOAL = "goal"
+    VARIABLE = "variable"
+    OBSERVATION = "observation"
+    FREE_TEXT = "free_text"
+
+
+class VariableRole(str, Enum):
+    OUTCOME = "outcome"
+    PREDICTOR = "predictor"
+    GROUP = "group"
+    SUBJECT = "subject"
+    TIME = "time"
+    PAIRED = "paired"
+    COVARIATE = "covariate"
+    EFFECT_MODIFIER = "effect_modifier"
+
+
+class HypothesisOrigin(str, Enum):
+    """Track whether a hypothesis was formed before or after viewing results."""
+    CONFIRMATORY = "confirmatory"
+    EXPLORATORY = "exploratory"
+
+
+# ---------------------------------------------------------------------------
+# Dataset Profile
+# ---------------------------------------------------------------------------
+
+class ColumnProfile(BaseModel):
+    name: str
+    dtype: ColumnType
+    missing_count: int = 0
+    missing_pct: float = 0.0
+    unique_count: int = 0
+    total_count: int = 0
+
+    # Numeric-specific
+    mean: Optional[float] = None
+    median: Optional[float] = None
+    std: Optional[float] = None
+    min_val: Optional[float] = None
+    max_val: Optional[float] = None
+    skewness: Optional[float] = None
+    kurtosis: Optional[float] = None
+    normality_hint: Optional[str] = None
+
+    # Categorical-specific
+    top_values: Optional[List[Dict[str, Any]]] = None
+    cardinality: Optional[int] = None
+
+    # Datetime-specific
+    date_min: Optional[str] = None
+    date_max: Optional[str] = None
+
+    # Role suggestions from profiler
+    suggested_roles: List[VariableRole] = Field(default_factory=list)
+
+
+class DatasetProfile(BaseModel):
+    row_count: int
+    column_count: int
+    columns: List[ColumnProfile]
+    warnings: List[str] = Field(default_factory=list)
+    suggested_group_columns: List[str] = Field(default_factory=list)
+    suggested_time_columns: List[str] = Field(default_factory=list)
+    suggested_subject_columns: List[str] = Field(default_factory=list)
+    suggested_outcome_columns: List[str] = Field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Tree Nodes and Branches
+# ---------------------------------------------------------------------------
+
+class QuestionOption(BaseModel):
+    id: str
+    label: str
+    description: Optional[str] = None
+    disabled: bool = False
+    disabled_reason: Optional[str] = None
+
+
+class Question(BaseModel):
+    id: str
+    prompt: str
+    explanation: Optional[str] = None
+    options: List[QuestionOption] = Field(default_factory=list)
+    allows_custom: bool = True
+    allows_skip: bool = False
+    category: Optional[str] = None
+
+
+class VariableRoleAssignment(BaseModel):
+    column: str
+    role: VariableRole
+    branch_id: str
+
+
+class TreeNode(BaseModel):
+    id: str
+    parent_id: Optional[str] = None
+    branch_id: str
+    kind: NodeKind
+    prompt: Optional[str] = None
+    answer: Optional[str] = None
+    answer_option_id: Optional[str] = None
+    options: List[QuestionOption] = Field(default_factory=list)
+    context: Dict[str, Any] = Field(default_factory=dict)
+    created_at: str = Field(default_factory=lambda: datetime.utcnow().isoformat())
+    is_exploratory: bool = False
+
+
+class TreeBranch(BaseModel):
+    id: str
+    name: str = "Untitled Branch"
+    status: BranchStatus = BranchStatus.ACTIVE
+    node_ids: List[str] = Field(default_factory=list)
+    is_primary: bool = False
+    annotation: Optional[str] = None
+    created_at: str = Field(default_factory=lambda: datetime.utcnow().isoformat())
+
+
+class TreeState(BaseModel):
+    nodes: Dict[str, TreeNode] = Field(default_factory=dict)
+    branches: Dict[str, TreeBranch] = Field(default_factory=dict)
+    active_branch_id: Optional[str] = None
+    root_node_id: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# Candidate Hypothesis & Analysis
+# ---------------------------------------------------------------------------
+
+class CandidateHypothesis(BaseModel):
+    id: str
+    branch_id: str
+    statement: str
+    null_hypothesis: Optional[str] = None
+    alternative_hypothesis: Optional[str] = None
+    variables: Dict[str, VariableRoleAssignment] = Field(default_factory=dict)
+    origin: HypothesisOrigin = HypothesisOrigin.CONFIRMATORY
+    is_primary: bool = False
+    annotation: Optional[str] = None
+    created_at: str = Field(default_factory=lambda: datetime.utcnow().isoformat())
+
+
+class AnalysisTradeoff(BaseModel):
+    label: str
+    description: str
+
+
+class CandidateAnalysis(BaseModel):
+    id: str
+    hypothesis_id: str
+    test_name: str
+    display_name: str
+    description: str
+    is_suggested: bool = False
+    suggestion_reason: Optional[str] = None
+    tradeoffs: List[AnalysisTradeoff] = Field(default_factory=list)
+    requirements: Dict[str, Any] = Field(default_factory=dict)
+
+
+class AnalysisResult(BaseModel):
+    analysis_id: str
+    hypothesis_id: Optional[str] = None
+    test_used: str
+    result: Dict[str, Any] = Field(default_factory=dict)
+    effect_size: Dict[str, Any] = Field(default_factory=dict)
+    assumptions: Dict[str, Any] = Field(default_factory=dict)
+    interpretation: str = ""
+    warnings: List[str] = Field(default_factory=list)
+    follow_up_options: List[str] = Field(default_factory=list)
+    applied_followups: List[str] = Field(default_factory=list)
+
+
+
+class BranchValidation(BaseModel):
+    is_valid: bool = True
+    contradictions: List[str] = Field(default_factory=list)
+    warnings: List[str] = Field(default_factory=list)
+    missing_roles: List[VariableRole] = Field(default_factory=list)
+    data_quality_issues: List[str] = Field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# API Request / Response
+# ---------------------------------------------------------------------------
+
+class AnswerRequest(BaseModel):
+    parent_node_id: str
+    option_id: Optional[str] = None
+    custom_answer: Optional[str] = None
+    selected_columns: Optional[Dict[str, str]] = None  # column -> role
+
+
+class ForkRequest(BaseModel):
+    node_id: str
+    new_answer: Optional[str] = None
+    new_option_id: Optional[str] = None
+
+
+class HypothesisAction(str, Enum):
+    SAVE = "save"
+    RENAME = "rename"
+    ANNOTATE = "annotate"
+    DUPLICATE = "duplicate"
+    SET_PRIMARY = "set_primary"
+    ARCHIVE = "archive"
+    DELETE = "delete"
+
+
+class HypothesisRequest(BaseModel):
+    action: HypothesisAction
+    hypothesis_id: Optional[str] = None
+    statement: Optional[str] = None
+    annotation: Optional[str] = None
+    branch_id: Optional[str] = None
+
+
+class AnalysisRequest(BaseModel):
+    hypothesis_id: str
+    analysis_id: str
+
+
+class SessionResponse(BaseModel):
+    session_id: str
+    profile: DatasetProfile
+    tree: TreeState
+    current_question: Optional[Question] = None
+    candidate_hypotheses: List[CandidateHypothesis] = Field(default_factory=list)
+    candidate_analyses: List[CandidateAnalysis] = Field(default_factory=list)
+    validation: Optional[BranchValidation] = None
+    analysis_result: Optional[AnalysisResult] = None
+
+
+class AnswerResponse(BaseModel):
+    tree: TreeState
+    current_question: Optional[Question] = None
+    candidate_hypotheses: List[CandidateHypothesis] = Field(default_factory=list)
+    candidate_analyses: List[CandidateAnalysis] = Field(default_factory=list)
+    validation: Optional[BranchValidation] = None
+    analysis_result: Optional[AnalysisResult] = None
+
+
+class ForkResponse(BaseModel):
+    new_branch_id: str
+    tree: TreeState
+    current_question: Optional[Question] = None
+
+
+class AnalysisRunResponse(BaseModel):
+    result: AnalysisResult
+    tree: TreeState
+    follow_up_question: Optional[Question] = None

--- a/analytics-service/app/models/demo_schemas.py
+++ b/analytics-service/app/models/demo_schemas.py
@@ -212,6 +212,7 @@ class AnalysisResult(BaseModel):
     result: Dict[str, Any] = Field(default_factory=dict)
     effect_size: Dict[str, Any] = Field(default_factory=dict)
     assumptions: Dict[str, Any] = Field(default_factory=dict)
+    group_stats: Dict[str, Any] = Field(default_factory=dict)
     interpretation: str = ""
     warnings: List[str] = Field(default_factory=list)
     follow_up_options: List[str] = Field(default_factory=list)

--- a/analytics-service/app/routers/demo_router.py
+++ b/analytics-service/app/routers/demo_router.py
@@ -1,11 +1,20 @@
-"""Hypothesis Lab demo router. No auth required."""
+"""Hypothesis Lab demo router — no auth except attestation."""
 
 from __future__ import annotations
 
+import hashlib
+import json
 import logging
-from typing import Optional
+import time
+from typing import Any, Dict, List, Optional
 
-from fastapi import APIRouter, File, HTTPException, UploadFile
+from fastapi import APIRouter, Body, File, HTTPException, UploadFile
+from pydantic import BaseModel, Field
+
+from app.auth.eip712 import verify_signature
+from app.services.ipfs_uploader import upload_result_to_ipfs
+from app.services.chain_registry import register_on_chain
+from app.services.result_serializer import serialize_analytics_result
 
 from app.models.demo_schemas import (
     AnalysisRequest,
@@ -120,6 +129,7 @@ def _get_active_analysis_result(session, branch_id: str) -> Optional[AnalysisRes
         result=result_data.get("result", {}),
         effect_size=result_data.get("effect_size", {}),
         assumptions=result_data.get("assumptions", {}),
+        group_stats=result_data.get("group_stats", {}),
         interpretation=result_data.get("interpretation", ""),
         warnings=result_data.get("warnings", []),
         follow_up_options=[
@@ -533,6 +543,7 @@ async def run_analysis(session_id: str, body: AnalysisRequest):
         result=result_data.get("result", {}),
         effect_size=result_data.get("effect_size", {}),
         assumptions=result_data.get("assumptions", {}),
+        group_stats=result_data.get("group_stats", {}),
         interpretation=result_data.get("interpretation", ""),
         warnings=result_data.get("warnings", []),
         follow_up_options=[
@@ -584,6 +595,10 @@ def _execute_analysis(
     elif test_name in ("one_way_anova", "kruskal_wallis"):
         if not outcome_col or not group_col:
             raise ValueError("outcome and group columns are required.")
+        unique_groups = df[group_col].dropna().nunique()
+        if unique_groups == 2:
+            force = "mann_whitney_u" if test_name == "kruskal_wallis" else "independent_ttest"
+            return run_two_group_test(df, outcome_col, group_col, force_test=force)
         return run_multi_group_test(df, outcome_col, group_col)
 
     elif test_name in ("paired_ttest", "wilcoxon_signed_rank"):
@@ -699,3 +714,160 @@ def _execute_analysis(
 
     else:
         raise ValueError(f"Unsupported analysis: {test_name}")
+
+
+# ── Attestation models ─────────────────────────────────────────────────
+
+class AttestRequest(BaseModel):
+    wallet_address: str = Field(...)
+    signature: str = Field(...)
+    timestamp: int = Field(...)
+    nonce: int = Field(...)
+    request_hash: str = Field(...)
+    source_cid: Optional[str] = None
+    branch_id: Optional[str] = None
+
+
+class AttestResponse(BaseModel):
+    result_cid: Optional[str] = None
+    tx_hash: Optional[str] = None
+    etherscan_url: Optional[str] = None
+    analysis_type: str = "hypothesis-tree"
+    timestamp: int = 0
+
+
+class AttestationEntry(BaseModel):
+    result_cid: Optional[str] = None
+    tx_hash: Optional[str] = None
+    etherscan_url: Optional[str] = None
+    analysis_type: str = "hypothesis-tree"
+    timestamp: int = 0
+    branch_id: Optional[str] = None
+
+
+# ── Attestation endpoints ──────────────────────────────────────────────
+
+@router.post("/sessions/{session_id}/attest", response_model=AttestResponse)
+async def attest_session(session_id: str, req: AttestRequest):
+    """Verify sig → serialize branch → IPFS → on-chain."""
+    session = _get_session(session_id)
+
+    # verify sig — fall back to session id for local uploads
+    dataset_cid = req.source_cid or f"local-session-{session_id}"
+
+    if not verify_signature(
+        wallet_address=req.wallet_address,
+        dataset_cid=dataset_cid,
+        signature=req.signature,
+        timestamp=req.timestamp,
+        nonce=req.nonce,
+        request_hash=req.request_hash,
+    ):
+        raise HTTPException(401, "Invalid or expired EIP-712 signature.")
+
+    # resolve branch
+    branch_id = req.branch_id or session.tree.active_branch_id
+    branch = session.tree.branches.get(branch_id)
+    if not branch:
+        raise HTTPException(404, f"Branch '{branch_id}' not found in session.")
+
+    # build audit trail
+    decision_trail = []
+    result_data = None
+    for nid in branch.node_ids:
+        node = session.tree.nodes.get(nid)
+        if not node:
+            continue
+        if node.kind == NodeKind.ANSWER:
+            decision_trail.append({
+                "kind": "answer",
+                "answer": node.answer or node.answer_option_id,
+            })
+        elif node.kind == NodeKind.QUESTION:
+            decision_trail.append({
+                "kind": "question",
+                "prompt": node.prompt,
+            })
+        elif node.kind == NodeKind.RESULT:
+            result_data = node.context or {}
+            decision_trail.append({
+                "kind": "result",
+                "test_used": (node.context or {}).get("test_used", "unknown"),
+            })
+
+
+    analysis_type = "hypothesis-tree"
+    if result_data:
+        analysis_type = result_data.get("test_used", "hypothesis-tree")
+
+    # serialize + upload + register
+    result_doc = serialize_analytics_result(
+        analysis_type=analysis_type,
+        source_cid=dataset_cid,
+        wallet_address=req.wallet_address,
+        results={
+            "decision_trail": decision_trail,
+            "statistical_result": result_data,
+            "branch_id": branch_id,
+        },
+        row_count=len(session.df),
+        columns=list(session.df.columns),
+        parameters={
+            "session_id": session_id,
+            "branch_status": branch.status.value if hasattr(branch.status, "value") else str(branch.status),
+        },
+    )
+
+
+    result_cid = await upload_result_to_ipfs(
+        result_data=result_doc,
+        analysis_type=analysis_type,
+        source_cid=dataset_cid,
+    )
+
+
+    tx_hash = None
+    etherscan_url = None
+    if result_cid:
+        tx_hash = await register_on_chain(
+            source_cid=dataset_cid,
+            result_cid=result_cid,
+            analysis_type=analysis_type,
+            analyst_address=req.wallet_address,
+        )
+        if tx_hash:
+            etherscan_url = f"https://sepolia.etherscan.io/tx/{tx_hash}"
+
+    # stash in session
+    entry = {
+        "result_cid": result_cid,
+        "tx_hash": tx_hash,
+        "etherscan_url": etherscan_url,
+        "analysis_type": analysis_type,
+        "timestamp": int(time.time()),
+        "branch_id": branch_id,
+    }
+    if not hasattr(session, "attestations"):
+        session.attestations = []
+    session.attestations.append(entry)
+
+    logger.info(
+        "Attestation complete  session=%s  branch=%s  cid=%s  tx=%s",
+        session_id, branch_id, result_cid, tx_hash,
+    )
+
+    return AttestResponse(
+        result_cid=result_cid,
+        tx_hash=tx_hash,
+        etherscan_url=etherscan_url,
+        analysis_type=analysis_type,
+        timestamp=int(time.time()),
+    )
+
+
+@router.get("/sessions/{session_id}/attestations", response_model=List[AttestationEntry])
+async def get_attestations(session_id: str):
+    """Fetch all attestations made during this session."""
+    session = _get_session(session_id)
+    entries = getattr(session, "attestations", [])
+    return [AttestationEntry(**e) for e in entries]

--- a/analytics-service/app/routers/demo_router.py
+++ b/analytics-service/app/routers/demo_router.py
@@ -1,0 +1,701 @@
+"""Hypothesis Lab demo router. No auth required."""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from fastapi import APIRouter, File, HTTPException, UploadFile
+
+from app.models.demo_schemas import (
+    AnalysisRequest,
+    AnalysisResult,
+    AnalysisRunResponse,
+    AnswerRequest,
+    AnswerResponse,
+    ForkRequest,
+    ForkResponse,
+    HypothesisAction,
+    HypothesisRequest,
+    SessionResponse,
+    CandidateHypothesis,
+    HypothesisOrigin,
+    VariableRoleAssignment,
+    VariableRole,
+    NodeKind,
+)
+from app.services.dataset_profiler import profile_dataset
+from app.services.demo_sessions import session_store
+from app.services.hypothesis_tree import (
+    add_answer_node,
+    add_result_node,
+    create_initial_tree,
+    fork_branch,
+    get_available_starts,
+    get_candidate_analyses,
+    get_candidate_hypotheses,
+    get_follow_up_question,
+    get_next_question,
+    get_resolved_answers,
+    _branch_nodes,
+    validate_branch,
+)
+
+from app.utils.csv_parser import parse_csv
+
+
+from app.services.inferential import (
+    run_two_group_test,
+    run_paired_test,
+    run_one_sample_test,
+    run_multi_group_test,
+    _TEST_DISPLAY_NAMES,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/demo/hypothesis-tree", tags=["Demo – Hypothesis Lab"])
+
+
+
+def _get_session(session_id: str):
+    session = session_store.get(session_id)
+    if session is None:
+        raise HTTPException(404, f"Session '{session_id}' not found or expired.")
+    return session
+
+
+def _get_active_analysis_result(session, branch_id: str) -> Optional[AnalysisResult]:
+    """Reconstruct AnalysisResult from branch RESULT node."""
+    if not branch_id:
+        return None
+    branch = session.tree.branches.get(branch_id)
+    if not branch or not branch.node_ids:
+        return None
+
+    # Find the last RESULT node and collect answer nodes after it
+    nodes = [session.tree.nodes[nid] for nid in branch.node_ids if nid in session.tree.nodes]
+    last_res_idx = -1
+    for i, n in enumerate(nodes):
+        if n.kind == NodeKind.RESULT:
+            last_res_idx = i
+
+    if last_res_idx < 0:
+        return None
+
+    res_node = nodes[last_res_idx]
+    result_data = res_node.context
+    test_code = result_data.get("test_used", "")
+    test_used = _TEST_DISPLAY_NAMES.get(test_code, test_code) or "Statistical Analysis"
+
+    # Collect follow-up actions selected after the last RESULT node
+    applied_followups = []
+    for n in nodes[last_res_idx + 1:]:
+        if n.kind == NodeKind.ANSWER:
+            opt_id = n.answer_option_id or ""
+            text = n.answer or ""
+            ctx = n.context or {}
+
+            if opt_id == "followup_effect_size" or "effect size" in text.lower():
+                applied_followups.append("Inspected effect size & 95% confidence interval")
+            elif opt_id == "followup_nonparametric" or "non-parametric" in text.lower():
+                applied_followups.append("Prioritized non-parametric alternative methods")
+            elif opt_id == "followup_export" or "export" in text.lower():
+                applied_followups.append("Exported branch exploration rationale")
+            elif "select_covariate" in ctx:
+                applied_followups.append(f"Added covariate: {ctx['select_covariate']}")
+            elif "select_subgroup" in ctx:
+                applied_followups.append(f"Tested subgroup: {ctx['select_subgroup']}")
+            elif "new_outcome" in ctx:
+                applied_followups.append(f"Explored related outcome: {ctx['new_outcome']}")
+            elif opt_id.startswith("followup_"):
+                applied_followups.append(opt_id.replace("followup_", "").replace("_", " ").title())
+            elif text and not text.startswith("col_"):
+                applied_followups.append(text)
+
+    return AnalysisResult(
+        analysis_id=res_node.id,
+        hypothesis_id=result_data.get("hypothesis_id"),
+        test_used=test_used,
+        result=result_data.get("result", {}),
+        effect_size=result_data.get("effect_size", {}),
+        assumptions=result_data.get("assumptions", {}),
+        interpretation=result_data.get("interpretation", ""),
+        warnings=result_data.get("warnings", []),
+        follow_up_options=[
+            "Inspect effect size",
+            "Add a covariate",
+            "Compare with non-parametric alternative",
+            "Test a subgroup",
+            "Create a related hypothesis",
+        ],
+        applied_followups=applied_followups,
+    )
+
+
+
+def _build_session_response(session) -> SessionResponse:
+    """Build session response with question, hypotheses, etc."""
+    branch_id = session.tree.active_branch_id
+    current_q = None
+    hypotheses = []
+    analyses = []
+    validation = None
+
+    if branch_id:
+        current_q = get_next_question(session.profile, session.tree, branch_id)
+        hypotheses = get_candidate_hypotheses(session.profile, session.tree, branch_id)
+        validation = validate_branch(session.profile, session.tree, branch_id)
+
+        # Also include saved hypotheses
+        for hyp in session.hypotheses.values():
+            if hyp.branch_id == branch_id and hyp not in hypotheses:
+                hypotheses.append(hyp)
+
+        # Generate analyses for each hypothesis
+        for hyp in hypotheses:
+            hyp_analyses = get_candidate_analyses(
+                session.profile, hyp, session.tree, branch_id
+            )
+            analyses.extend(hyp_analyses)
+
+    analysis_result = _get_active_analysis_result(session, branch_id)
+
+    return SessionResponse(
+        session_id=session.session_id,
+        profile=session.profile,
+        tree=session.tree,
+        current_question=current_q,
+        candidate_hypotheses=hypotheses,
+        candidate_analyses=analyses,
+        validation=validation,
+        analysis_result=analysis_result,
+    )
+
+
+# ── endpoints ─────────────────────────────────────────────────────────────
+
+@router.post("/sessions", response_model=SessionResponse)
+async def create_session(file: UploadFile = File(...)):
+    """Upload CSV, profile it, create session."""
+    contents = await file.read()
+    df = parse_csv(contents)
+    profile = profile_dataset(df)
+    tree = create_initial_tree()
+
+    session_id = session_store.create(df=df, profile=profile, tree=tree)
+    session = session_store.get(session_id)
+
+    return _build_session_response(session)
+
+
+@router.get("/sessions/{session_id}", response_model=SessionResponse)
+async def get_session(session_id: str, active_branch_id: Optional[str] = None):
+    """Get current session state."""
+    session = _get_session(session_id)
+    if active_branch_id:
+        if active_branch_id in session.tree.branches:
+            session.tree.active_branch_id = active_branch_id
+        else:
+            raise HTTPException(400, f"Branch '{active_branch_id}' not found in tree.")
+    return _build_session_response(session)
+
+
+@router.post("/sessions/{session_id}/answers", response_model=AnswerResponse)
+async def submit_answer(session_id: str, body: AnswerRequest):
+    """Submit answer, advance tree."""
+    session = _get_session(session_id)
+    branch_id = session.tree.active_branch_id
+
+    if not branch_id:
+        raise HTTPException(400, "No active branch.")
+
+    parent_node = session.tree.nodes.get(body.parent_node_id)
+    if parent_node is None:
+        raise HTTPException(404, f"Node '{body.parent_node_id}' not found.")
+
+    # Determine the answer text and option ID
+    answer_text = body.custom_answer or body.option_id or ""
+    option_id = body.option_id
+
+    # Get the current question for context
+    current_q = get_next_question(session.profile, session.tree, branch_id)
+
+    # Build context from the answer
+    context = {}
+    if current_q:
+        category = current_q.category
+        if category:
+            context[category] = answer_text
+
+    # Handle column selections that set variable roles
+    if body.selected_columns:
+        context["role_assignments"] = body.selected_columns
+
+    # If user selected a column (option starts with "col_"), extract the column name
+    if option_id and option_id.startswith("col_"):
+        col_name = option_id[4:]  # strip "col_" prefix
+        answer_text = col_name
+        if current_q and current_q.category:
+            role = current_q.category.replace("select_", "")
+            context[role] = col_name
+            context.setdefault("role_assignments", {})[col_name] = role
+
+    # If the category is a known context key, store the answer under it
+    if current_q and current_q.category:
+        context[current_q.category] = answer_text
+
+    # For start_mode, store as "start_mode"
+    if current_q and current_q.category == "start_mode":
+        context["start_mode"] = option_id or answer_text
+
+    tree, answer_node = add_answer_node(
+        tree=session.tree,
+        branch_id=branch_id,
+        parent_node_id=body.parent_node_id,
+        answer=answer_text,
+        option_id=option_id,
+        question=current_q,
+        context=context,
+    )
+    session.tree = tree
+    session_store.update_tree(session_id, tree)
+
+    # Automatically execute re-analysis if a follow-up parameter was submitted
+    answers = get_resolved_answers(session.profile, session.tree, branch_id)
+    outcome_col = answers.get("outcome") or answers.get("select_outcome")
+    group_col = answers.get("group") or answers.get("select_group")
+
+    # Recover outcome/group from previous RESULT node if missing
+    for n in reversed(_branch_nodes(session.tree, branch_id)):
+        if n.kind == NodeKind.RESULT and n.context:
+            res_ctx = n.context
+            if not outcome_col and res_ctx.get("outcome_col"):
+                outcome_col = res_ctx["outcome_col"]
+            if not group_col and res_ctx.get("group_col"):
+                group_col = res_ctx["group_col"]
+
+    new_result_data = None
+
+    if "select_covariate" in context and outcome_col and group_col:
+        covariate_col = context["select_covariate"]
+        try:
+            from app.services.inferential import run_ancova
+            new_result_data = run_ancova(session.df, outcome_col, group_col, covariate_col)
+            new_result_data["outcome_col"] = outcome_col
+            new_result_data["group_col"] = group_col
+            new_result_data["hypothesis_id"] = f"hyp_{outcome_col}_{group_col}"
+        except Exception as err:
+            logger.warning(f"Covariate re-analysis failed: {err}")
+
+    elif "select_subgroup" in context and outcome_col and group_col:
+        subgroup_col = context["select_subgroup"]
+        try:
+            from app.services.inferential import run_subgroup_analysis
+            new_result_data = run_subgroup_analysis(session.df, outcome_col, group_col, subgroup_col)
+            new_result_data["outcome_col"] = outcome_col
+            new_result_data["group_col"] = group_col
+            new_result_data["hypothesis_id"] = f"hyp_{outcome_col}_{group_col}"
+        except Exception as err:
+            logger.warning(f"Subgroup re-analysis failed: {err}")
+
+    elif "new_outcome" in context and group_col:
+        new_outcome_col = context["new_outcome"]
+        try:
+            new_result_data = run_two_group_test(session.df, new_outcome_col, group_col)
+            new_result_data["outcome_col"] = new_outcome_col
+            new_result_data["group_col"] = group_col
+            new_result_data["hypothesis_id"] = f"hyp_{new_outcome_col}_{group_col}"
+        except Exception as err:
+            logger.warning(f"New outcome re-analysis failed: {err}")
+
+    elif option_id == "followup_nonparametric" and outcome_col and group_col:
+        try:
+            new_result_data = run_two_group_test(session.df, outcome_col, group_col, force_test="mann_whitney_u")
+            new_result_data["outcome_col"] = outcome_col
+            new_result_data["group_col"] = group_col
+            new_result_data["hypothesis_id"] = f"hyp_{outcome_col}_{group_col}"
+        except Exception as err:
+            logger.warning(f"Non-parametric re-analysis failed: {err}")
+
+    if new_result_data:
+        session.tree, r_node = add_result_node(
+            tree=session.tree,
+            branch_id=branch_id,
+            parent_node_id=answer_node.id,
+            result_data=new_result_data,
+        )
+        session_store.update_tree(session_id, session.tree)
+
+    # Build response
+    next_q = get_next_question(session.profile, session.tree, branch_id)
+    hypotheses = get_candidate_hypotheses(session.profile, session.tree, branch_id)
+    validation = validate_branch(session.profile, session.tree, branch_id)
+
+    analyses = []
+    for hyp in hypotheses:
+        hyp_analyses = get_candidate_analyses(
+            session.profile, hyp, session.tree, branch_id
+        )
+        analyses.extend(hyp_analyses)
+
+    analysis_result = _get_active_analysis_result(session, branch_id)
+
+    return AnswerResponse(
+        tree=session.tree,
+        current_question=next_q,
+        candidate_hypotheses=hypotheses,
+        candidate_analyses=analyses,
+        validation=validation,
+        analysis_result=analysis_result,
+    )
+
+
+
+@router.post("/sessions/{session_id}/forks", response_model=ForkResponse)
+async def fork_from_node(session_id: str, body: ForkRequest):
+    """Fork from any prior node."""
+    session = _get_session(session_id)
+
+    try:
+        tree, new_branch_id = fork_branch(
+            tree=session.tree,
+            source_node_id=body.node_id,
+            new_answer=body.new_answer,
+        )
+    except ValueError as exc:
+        raise HTTPException(400, str(exc))
+
+    session.tree = tree
+    session_store.update_tree(session_id, tree)
+
+    next_q = get_next_question(session.profile, tree, new_branch_id)
+
+    return ForkResponse(
+        new_branch_id=new_branch_id,
+        tree=tree,
+        current_question=next_q,
+    )
+
+
+@router.post("/sessions/{session_id}/hypotheses", response_model=SessionResponse)
+async def manage_hypothesis(session_id: str, body: HypothesisRequest):
+    """Manage hypothesis: save, rename, annotate, duplicate, archive."""
+    session = _get_session(session_id)
+    branch_id = body.branch_id or session.tree.active_branch_id
+
+    if body.action == HypothesisAction.SAVE:
+        if not body.statement:
+            raise HTTPException(400, "statement is required for save.")
+        from app.services.hypothesis_tree import _uid
+        hyp_id = f"hyp_{_uid()}"
+        hyp = CandidateHypothesis(
+            id=hyp_id,
+            branch_id=branch_id or "",
+            statement=body.statement,
+            annotation=body.annotation,
+        )
+        session.hypotheses[hyp_id] = hyp
+
+    elif body.action == HypothesisAction.RENAME:
+        if not body.hypothesis_id or not body.statement:
+            raise HTTPException(400, "hypothesis_id and statement are required.")
+        hyp = session.hypotheses.get(body.hypothesis_id)
+        if not hyp:
+            raise HTTPException(404, "Hypothesis not found.")
+        hyp.statement = body.statement
+
+    elif body.action == HypothesisAction.ANNOTATE:
+        if not body.hypothesis_id:
+            raise HTTPException(400, "hypothesis_id is required.")
+        hyp = session.hypotheses.get(body.hypothesis_id)
+        if not hyp:
+            raise HTTPException(404, "Hypothesis not found.")
+        hyp.annotation = body.annotation
+
+    elif body.action == HypothesisAction.DUPLICATE:
+        if not body.hypothesis_id:
+            raise HTTPException(400, "hypothesis_id is required.")
+        original = session.hypotheses.get(body.hypothesis_id)
+        if not original:
+            raise HTTPException(404, "Hypothesis not found.")
+        from app.services.hypothesis_tree import _uid
+        dup_id = f"hyp_{_uid()}"
+        dup = original.model_copy(update={"id": dup_id, "is_primary": False})
+        session.hypotheses[dup_id] = dup
+
+    elif body.action == HypothesisAction.SET_PRIMARY:
+        if not body.hypothesis_id:
+            raise HTTPException(400, "hypothesis_id is required.")
+        for hyp in session.hypotheses.values():
+            hyp.is_primary = False
+        hyp = session.hypotheses.get(body.hypothesis_id)
+        if hyp:
+            hyp.is_primary = True
+
+    elif body.action == HypothesisAction.ARCHIVE:
+        if not body.hypothesis_id:
+            raise HTTPException(400, "hypothesis_id is required.")
+        hyp = session.hypotheses.get(body.hypothesis_id)
+        if hyp:
+            hyp.origin = HypothesisOrigin.EXPLORATORY
+
+    elif body.action == HypothesisAction.DELETE:
+        if not body.hypothesis_id:
+            raise HTTPException(400, "hypothesis_id is required.")
+        session.hypotheses.pop(body.hypothesis_id, None)
+
+    return _build_session_response(session)
+
+
+@router.post("/sessions/{session_id}/analyses", response_model=AnalysisRunResponse)
+async def run_analysis(session_id: str, body: AnalysisRequest):
+    """Run selected analysis."""
+    session = _get_session(session_id)
+    branch_id = session.tree.active_branch_id
+
+    if not branch_id:
+        raise HTTPException(400, "No active branch.")
+
+    # Find the hypothesis
+    hyp = session.hypotheses.get(body.hypothesis_id)
+    if not hyp:
+        # Check generated hypotheses
+        generated = get_candidate_hypotheses(session.profile, session.tree, branch_id)
+        hyp = next((h for h in generated if h.id == body.hypothesis_id), None)
+    if not hyp:
+        raise HTTPException(404, "Hypothesis not found.")
+
+    # Find the analysis
+    analyses = get_candidate_analyses(
+        session.profile, hyp, session.tree, branch_id
+    )
+    analysis = next((a for a in analyses if a.id == body.analysis_id), None)
+    if not analysis:
+        raise HTTPException(404, "Analysis not found.")
+
+    # Extract variable info from hypothesis
+    df = session.df
+    outcome_col = None
+    group_col = None
+    paired_col = None
+    predictor_col = None
+
+    for var_name, role_assign in hyp.variables.items():
+        if role_assign.role == VariableRole.OUTCOME:
+            outcome_col = role_assign.column
+        elif role_assign.role == VariableRole.GROUP:
+            group_col = role_assign.column
+        elif role_assign.role == VariableRole.PAIRED:
+            paired_col = role_assign.column
+        elif role_assign.role == VariableRole.PREDICTOR:
+            predictor_col = role_assign.column
+
+    # Run the appropriate test
+    try:
+        result_data = _execute_analysis(
+            df=df,
+            test_name=analysis.test_name,
+            outcome_col=outcome_col,
+            group_col=group_col,
+            paired_col=paired_col,
+            predictor_col=predictor_col,
+            answers=None,
+        )
+    except ValueError as exc:
+        raise HTTPException(400, str(exc))
+    except Exception as exc:
+        logger.exception("Analysis execution failed")
+        raise HTTPException(500, f"Analysis failed: {exc}")
+
+    # Add result node to tree
+    result_data["hypothesis_id"] = body.hypothesis_id
+    result_data["outcome_col"] = outcome_col
+    result_data["group_col"] = group_col
+    last_node_id = session.tree.branches[branch_id].node_ids[-1]
+    tree, result_node = add_result_node(
+        tree=session.tree,
+        branch_id=branch_id,
+        parent_node_id=last_node_id,
+        result_data=result_data,
+    )
+
+    session.tree = tree
+    session_store.update_tree(session_id, tree)
+
+    # Build result
+    test_code = result_data.get("test_used", analysis.test_name)
+    test_used = _TEST_DISPLAY_NAMES.get(test_code, test_code)
+    analysis_result = AnalysisResult(
+        analysis_id=body.analysis_id,
+        hypothesis_id=body.hypothesis_id,
+        test_used=test_used,
+        result=result_data.get("result", {}),
+        effect_size=result_data.get("effect_size", {}),
+        assumptions=result_data.get("assumptions", {}),
+        interpretation=result_data.get("interpretation", ""),
+        warnings=result_data.get("warnings", []),
+        follow_up_options=[
+            "Inspect effect size",
+            "Add a covariate",
+            "Compare with non-parametric alternative",
+            "Test a subgroup",
+            "Create a related hypothesis",
+        ],
+    )
+
+    follow_up = get_follow_up_question(session.profile, tree, branch_id)
+
+    return AnalysisRunResponse(
+        result=analysis_result,
+        tree=tree,
+        follow_up_question=follow_up,
+    )
+
+
+@router.delete("/sessions/{session_id}")
+async def delete_session(session_id: str):
+    """Delete session."""
+    deleted = session_store.delete(session_id)
+    if not deleted:
+        raise HTTPException(404, f"Session '{session_id}' not found.")
+    return {"detail": "Session deleted."}
+
+
+# ── analysis execution bridge ─────────────────────────────────────────────
+
+def _execute_analysis(
+    df,
+    test_name: str,
+    outcome_col: Optional[str],
+    group_col: Optional[str],
+    paired_col: Optional[str],
+    predictor_col: Optional[str],
+    answers: Optional[dict],
+) -> dict:
+    """Bridge between hypothesis-tree IDs and inferential functions."""
+
+    if test_name in ("independent_ttest", "mann_whitney_u"):
+        if not outcome_col or not group_col:
+            raise ValueError("outcome and group columns are required.")
+        return run_two_group_test(df, outcome_col, group_col, force_test=test_name)
+
+
+    elif test_name in ("one_way_anova", "kruskal_wallis"):
+        if not outcome_col or not group_col:
+            raise ValueError("outcome and group columns are required.")
+        return run_multi_group_test(df, outcome_col, group_col)
+
+    elif test_name in ("paired_ttest", "wilcoxon_signed_rank"):
+        if not outcome_col or not paired_col:
+            raise ValueError("Two paired columns are required.")
+        return run_paired_test(df, outcome_col, paired_col)
+
+    elif test_name in ("one_sample_ttest", "one_sample_wilcoxon"):
+        if not outcome_col:
+            raise ValueError("outcome column is required.")
+        # Extract population mean from context
+        pop_mean = 0.0  # Default
+        if answers and "population_mean" in answers:
+            try:
+                pop_mean = float(answers["population_mean"])
+            except (ValueError, TypeError):
+                pass
+        return run_one_sample_test(df, outcome_col, pop_mean)
+
+    elif test_name in ("pearson_correlation", "spearman_correlation"):
+        if not outcome_col or not predictor_col:
+            raise ValueError("Two numeric columns are required.")
+        # Use scipy directly for correlation
+        import numpy as np
+        from scipy import stats as sp_stats
+
+        x = df[predictor_col].dropna().astype(float)
+        y = df[outcome_col].dropna().astype(float)
+        # Align on shared indices
+        shared = x.index.intersection(y.index)
+        x, y = x.loc[shared].values, y.loc[shared].values
+
+        if test_name == "pearson_correlation":
+            stat, p = sp_stats.pearsonr(x, y)
+            method = "Pearson correlation"
+        else:
+            stat, p = sp_stats.spearmanr(x, y)
+            method = "Spearman rank correlation"
+
+        return {
+            "test_used": method,
+            "result": {
+                "correlation": round(float(stat), 6),
+                "p_value": round(float(p), 6),
+                "n": len(x),
+                "significant": bool(p < 0.05),
+            },
+            "effect_size": {
+                "metric": "r",
+                "value": round(float(stat), 4),
+                "magnitude": (
+                    "large" if abs(stat) >= 0.5
+                    else "medium" if abs(stat) >= 0.3
+                    else "small" if abs(stat) >= 0.1
+                    else "negligible"
+                ),
+            },
+            "assumptions": {},
+            "interpretation": (
+                f"The {method.lower()} between '{predictor_col}' and '{outcome_col}' "
+                f"is r = {stat:.4f} (p = {p:.4f}). "
+                f"{'This is statistically significant at α = 0.05.' if p < 0.05 else 'This is not statistically significant at α = 0.05.'}"
+            ),
+            "warnings": [],
+            "reason": f"{method} selected.",
+            "group_stats": {},
+        }
+
+    elif test_name == "chi_square":
+        if not outcome_col or not predictor_col:
+            raise ValueError("Two categorical columns are required.")
+        import pandas as pd_local
+        contingency = pd_local.crosstab(df[outcome_col], df[predictor_col])
+        from scipy import stats as sp_stats
+        chi2, p, dof, expected = sp_stats.chi2_contingency(contingency)
+
+        n = contingency.sum().sum()
+        cramers_v = float(np.sqrt(chi2 / (n * (min(contingency.shape) - 1)))) if n > 0 else 0
+
+        return {
+            "test_used": "Chi-square test of independence",
+            "result": {
+                "chi2": round(float(chi2), 6),
+                "p_value": round(float(p), 6),
+                "dof": int(dof),
+                "significant": bool(p < 0.05),
+            },
+            "effect_size": {
+                "metric": "cramers_v",
+                "value": round(cramers_v, 4),
+                "magnitude": (
+                    "large" if cramers_v >= 0.5
+                    else "medium" if cramers_v >= 0.3
+                    else "small" if cramers_v >= 0.1
+                    else "negligible"
+                ),
+            },
+            "assumptions": {
+                "min_expected": round(float(expected.min()), 2),
+                "adequate_expected": bool(expected.min() >= 5),
+            },
+            "interpretation": (
+                f"Chi-square test: χ² = {chi2:.4f}, df = {dof}, p = {p:.4f}. "
+                f"{'Significant association detected.' if p < 0.05 else 'No significant association.'}"
+            ),
+            "warnings": (
+                ["Some expected cell counts are < 5. Consider Fisher's exact test."]
+                if expected.min() < 5 else []
+            ),
+            "reason": "Chi-square test of independence selected.",
+            "group_stats": {},
+        }
+
+    else:
+        raise ValueError(f"Unsupported analysis: {test_name}")

--- a/analytics-service/app/services/dataset_profiler.py
+++ b/analytics-service/app/services/dataset_profiler.py
@@ -1,0 +1,290 @@
+"""Dataset profiler for Hypothesis Lab."""
+
+from __future__ import annotations
+
+from typing import List
+
+import numpy as np
+import pandas as pd
+from scipy import stats as sp_stats
+
+from app.models.demo_schemas import (
+    ColumnProfile,
+    ColumnType,
+    DatasetProfile,
+    VariableRole,
+)
+
+
+# ---------------------------------------------------------------------------
+# Thresholds
+# ---------------------------------------------------------------------------
+
+_IDENTIFIER_UNIQUE_RATIO = 0.95  # ≥95 % unique → likely identifier
+_LOW_CARDINALITY_MAX = 20       # ≤20 unique values → treat as categorical/group
+_TIME_KEYWORDS = {"date", "time", "timestamp", "year", "month", "day", "week", "period"}
+_SUBJECT_KEYWORDS = {"id", "subject", "participant", "patient", "sample", "user", "respondent"}
+_HIGH_MISSING_PCT = 50.0        # warn when >50 % missing
+
+
+def _is_likely_identifier(name: str, series: pd.Series) -> bool:
+    """Heuristic: likely an ID column (patient #, names, sequential ints, etc)."""
+    if len(series.dropna()) < 3:
+        return False
+
+    clean = series.dropna()
+    nunique = clean.nunique()
+    unique_ratio = nunique / max(len(clean), 1)
+    lower_name = name.lower().strip().replace("_", " ").replace("-", " ")
+
+    # Explicit name matches (e.g. "patient #", "patient id", "first name", "last name")
+    id_name_patterns = [
+        "patient #", "patient id", "patient_id", "pt #", "pt id",
+        "subject id", "subject_id", "participant id", "sample id",
+        "first name", "last name", "full name", "mrn", "ssn", "uuid"
+    ]
+    if any(pat in lower_name for pat in id_name_patterns):
+        return True
+
+    if lower_name in {"id", "row", "index", "seq", "#", "number", "patient"}:
+        return True
+
+    if lower_name.endswith(" id") or lower_name.endswith(" #") or lower_name.endswith("_id"):
+        return True
+
+    # High-cardinality checks for numeric sequence IDs or string identifiers
+    if unique_ratio >= _IDENTIFIER_UNIQUE_RATIO and nunique >= 5:
+        if any(kw in lower_name for kw in _SUBJECT_KEYWORDS) or "name" in lower_name or "#" in lower_name or "num" in lower_name:
+            return True
+        # Check if numeric values are sequential integers (e.g. 1..N)
+        if pd.api.types.is_numeric_dtype(series):
+            vals = clean.values
+            if np.issubdtype(vals.dtype, np.integer) or (np.all(np.mod(vals, 1) == 0)):
+                if np.all(np.diff(np.sort(vals)) == 1):
+                    return True
+
+    return False
+
+
+def _is_likely_time_column(name: str, series: pd.Series) -> bool:
+    lower = name.lower().replace("_", " ").replace("-", " ")
+    if any(kw in lower for kw in _TIME_KEYWORDS):
+        return True
+    if pd.api.types.is_datetime64_any_dtype(series):
+        return True
+    return False
+
+
+def _is_likely_subject_column(name: str) -> bool:
+    lower = name.lower().replace("_", " ").replace("-", " ")
+    return any(kw in lower for kw in _SUBJECT_KEYWORDS)
+
+
+def _infer_column_type(series: pd.Series, name: str = "") -> ColumnType:
+    """Infer column type from dtype, name, and data shape."""
+    if _is_likely_identifier(name, series):
+        return ColumnType.IDENTIFIER
+
+    if pd.api.types.is_datetime64_any_dtype(series):
+        return ColumnType.DATETIME
+
+    if pd.api.types.is_bool_dtype(series):
+        return ColumnType.BOOLEAN
+
+    if pd.api.types.is_numeric_dtype(series):
+        # A numeric column with very few unique values may be categorical
+        nunique = series.nunique()
+        if nunique <= 2 and set(series.dropna().unique()).issubset({0, 1, 0.0, 1.0}):
+            return ColumnType.BOOLEAN
+        return ColumnType.NUMERIC
+
+    nunique = series.nunique()
+    if nunique <= _LOW_CARDINALITY_MAX:
+        return ColumnType.CATEGORICAL
+
+    # Try parsing as dates
+    try:
+        pd.to_datetime(series.dropna().head(20))
+        return ColumnType.DATETIME
+    except (ValueError, TypeError):
+        pass
+
+    return ColumnType.TEXT
+
+
+def _profile_numeric(series: pd.Series) -> dict:
+    clean = series.dropna().astype(float)
+    if len(clean) == 0:
+        return {}
+
+    result = {
+        "mean": round(float(clean.mean()), 4),
+        "median": round(float(clean.median()), 4),
+        "std": round(float(clean.std()), 4),
+        "min_val": round(float(clean.min()), 4),
+        "max_val": round(float(clean.max()), 4),
+    }
+
+    if len(clean) >= 3:
+        result["skewness"] = round(float(clean.skew()), 4)
+        result["kurtosis"] = round(float(clean.kurtosis()), 4)
+
+    # Quick normality hint
+    if 8 <= len(clean) <= 5000:
+        _, p = sp_stats.shapiro(clean.values)
+        if p > 0.05:
+            result["normality_hint"] = "appears_normal"
+        else:
+            result["normality_hint"] = "likely_non_normal"
+    elif len(clean) > 5000:
+        result["normality_hint"] = "large_sample_check_advised"
+
+    return result
+
+
+def _profile_categorical(series: pd.Series) -> dict:
+    counts = series.value_counts()
+    top = [
+        {"value": str(v), "count": int(c)}
+        for v, c in counts.head(10).items()
+    ]
+    return {
+        "top_values": top,
+        "cardinality": int(series.nunique()),
+    }
+
+
+def _profile_datetime(series: pd.Series) -> dict:
+    try:
+        parsed = pd.to_datetime(series.dropna())
+        if len(parsed) == 0:
+            return {}
+        return {
+            "date_min": str(parsed.min()),
+            "date_max": str(parsed.max()),
+        }
+    except Exception:
+        return {}
+
+
+def _suggest_roles(name: str, dtype: ColumnType, series: pd.Series) -> List[VariableRole]:
+    """Suggest variable roles from column name and type."""
+    roles: List[VariableRole] = []
+
+    if dtype == ColumnType.NUMERIC:
+        roles.append(VariableRole.OUTCOME)
+        roles.append(VariableRole.COVARIATE)
+
+    if dtype == ColumnType.CATEGORICAL:
+        nunique = series.nunique()
+        if 2 <= nunique <= 10:
+            roles.append(VariableRole.GROUP)
+        if nunique == 2:
+            roles.append(VariableRole.PREDICTOR)
+
+    if _is_likely_time_column(name, series):
+        roles.append(VariableRole.TIME)
+
+    if _is_likely_subject_column(name):
+        roles.append(VariableRole.SUBJECT)
+
+    if dtype == ColumnType.IDENTIFIER:
+        roles.append(VariableRole.SUBJECT)
+
+    return roles
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def profile_dataset(df: pd.DataFrame) -> DatasetProfile:
+    """Profile every column, return DatasetProfile."""
+    columns: List[ColumnProfile] = []
+    warnings: List[str] = []
+    suggested_group: List[str] = []
+    suggested_time: List[str] = []
+    suggested_subject: List[str] = []
+    suggested_outcome: List[str] = []
+
+    for col_name in df.columns:
+        series = df[col_name]
+        dtype = _infer_column_type(series, col_name)
+
+        missing_count = int(series.isna().sum())
+        total_count = len(series)
+        missing_pct = round(100.0 * missing_count / max(total_count, 1), 2)
+
+        profile_data = {
+            "name": col_name,
+            "dtype": dtype,
+            "missing_count": missing_count,
+            "missing_pct": missing_pct,
+            "unique_count": int(series.nunique()),
+            "total_count": total_count,
+        }
+
+        if dtype == ColumnType.NUMERIC:
+            profile_data.update(_profile_numeric(series))
+        elif dtype in (ColumnType.CATEGORICAL, ColumnType.TEXT):
+            profile_data.update(_profile_categorical(series))
+        elif dtype == ColumnType.DATETIME:
+            profile_data.update(_profile_datetime(series))
+        elif dtype == ColumnType.BOOLEAN:
+            vc = series.value_counts()
+            profile_data["top_values"] = [
+                {"value": str(v), "count": int(c)} for v, c in vc.items()
+            ]
+            profile_data["cardinality"] = int(series.nunique())
+
+        roles = _suggest_roles(col_name, dtype, series)
+        profile_data["suggested_roles"] = roles
+
+        col_profile = ColumnProfile(**profile_data)
+        columns.append(col_profile)
+
+        # Aggregate suggestions
+        if VariableRole.GROUP in roles:
+            suggested_group.append(col_name)
+        if VariableRole.TIME in roles:
+            suggested_time.append(col_name)
+        if VariableRole.SUBJECT in roles:
+            suggested_subject.append(col_name)
+        if VariableRole.OUTCOME in roles:
+            suggested_outcome.append(col_name)
+
+        # Warnings
+        if missing_pct > _HIGH_MISSING_PCT:
+            warnings.append(
+                f"Column '{col_name}' has {missing_pct}% missing values."
+            )
+
+        if dtype == ColumnType.NUMERIC and series.nunique() == 1:
+            warnings.append(
+                f"Column '{col_name}' is constant (single value). "
+                "It cannot be used for statistical comparisons."
+            )
+
+    # Global warnings
+    dup_count = df.duplicated().sum()
+    if dup_count > 0:
+        warnings.append(
+            f"Dataset contains {int(dup_count)} duplicate row(s)."
+        )
+
+    if len(df) < 10:
+        warnings.append(
+            f"Very small dataset ({len(df)} rows). "
+            "Statistical tests may have low power."
+        )
+
+    return DatasetProfile(
+        row_count=len(df),
+        column_count=len(df.columns),
+        columns=columns,
+        warnings=warnings,
+        suggested_group_columns=suggested_group,
+        suggested_time_columns=suggested_time,
+        suggested_subject_columns=suggested_subject,
+        suggested_outcome_columns=suggested_outcome,
+    )

--- a/analytics-service/app/services/dataset_profiler.py
+++ b/analytics-service/app/services/dataset_profiler.py
@@ -129,15 +129,21 @@ def _profile_numeric(series: pd.Series) -> dict:
         result["skewness"] = round(float(clean.skew()), 4)
         result["kurtosis"] = round(float(clean.kurtosis()), 4)
 
-    # Quick normality hint
-    if 8 <= len(clean) <= 5000:
+    # Normality hint — Shapiro-Wilk for small/moderate samples
+    if 8 <= len(clean) <= 500:
         _, p = sp_stats.shapiro(clean.values)
         if p > 0.05:
             result["normality_hint"] = "appears_normal"
         else:
             result["normality_hint"] = "likely_non_normal"
-    elif len(clean) > 5000:
-        result["normality_hint"] = "large_sample_check_advised"
+    elif len(clean) > 500:
+        # large n: SW rejects everything, use skew/kurtosis heuristic instead
+        skew = abs(float(clean.skew())) if len(clean) >= 3 else 0.0
+        kurt = abs(float(clean.kurtosis())) if len(clean) >= 3 else 0.0
+        if skew > 1.5 or kurt > 5.0:
+            result["normality_hint"] = "likely_non_normal"
+        else:
+            result["normality_hint"] = "appears_normal"
 
     return result
 

--- a/analytics-service/app/services/demo_sessions.py
+++ b/analytics-service/app/services/demo_sessions.py
@@ -36,6 +36,7 @@ class DemoSession:
         "tree",
         "hypotheses",
         "analyses",
+        "attestations",
         "created_at",
         "last_accessed",
         "idle_timeout",
@@ -55,6 +56,7 @@ class DemoSession:
         self.tree = tree
         self.hypotheses: Dict[str, CandidateHypothesis] = {}
         self.analyses: Dict[str, CandidateAnalysis] = {}
+        self.attestations: List[Dict] = []
         self.created_at = time.time()
         self.last_accessed = time.time()
         self.idle_timeout = idle_timeout

--- a/analytics-service/app/services/demo_sessions.py
+++ b/analytics-service/app/services/demo_sessions.py
@@ -1,0 +1,172 @@
+"""In-memory session store for Hypothesis Lab demo."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+import uuid
+from typing import Any, Dict, List, Optional
+
+import pandas as pd
+
+from app.models.demo_schemas import (
+    CandidateAnalysis,
+    CandidateHypothesis,
+    DatasetProfile,
+    TreeState,
+)
+
+logger = logging.getLogger(__name__)
+
+# Default idle timeout in seconds (30 minutes)
+DEFAULT_IDLE_TIMEOUT = 30 * 60
+
+# Cleanup interval in seconds
+CLEANUP_INTERVAL = 60
+
+
+class DemoSession:
+    """Single exploration session."""
+
+    __slots__ = (
+        "session_id",
+        "df",
+        "profile",
+        "tree",
+        "hypotheses",
+        "analyses",
+        "created_at",
+        "last_accessed",
+        "idle_timeout",
+    )
+
+    def __init__(
+        self,
+        session_id: str,
+        df: pd.DataFrame,
+        profile: DatasetProfile,
+        tree: TreeState,
+        idle_timeout: int = DEFAULT_IDLE_TIMEOUT,
+    ):
+        self.session_id = session_id
+        self.df = df
+        self.profile = profile
+        self.tree = tree
+        self.hypotheses: Dict[str, CandidateHypothesis] = {}
+        self.analyses: Dict[str, CandidateAnalysis] = {}
+        self.created_at = time.time()
+        self.last_accessed = time.time()
+        self.idle_timeout = idle_timeout
+
+    def touch(self) -> None:
+        """Reset the idle timer."""
+        self.last_accessed = time.time()
+
+    @property
+    def is_expired(self) -> bool:
+        return (time.time() - self.last_accessed) > self.idle_timeout
+
+
+class SessionStore:
+    """In-memory session store with idle expiry."""
+
+    def __init__(self, idle_timeout: int = DEFAULT_IDLE_TIMEOUT):
+        self._sessions: Dict[str, DemoSession] = {}
+        self._idle_timeout = idle_timeout
+        self._cleanup_task: Optional[asyncio.Task] = None
+
+    # -- public --
+
+    def create(
+        self,
+        df: pd.DataFrame,
+        profile: DatasetProfile,
+        tree: TreeState,
+    ) -> str:
+        """Create session, return ID."""
+        session_id = uuid.uuid4().hex
+        session = DemoSession(
+            session_id=session_id,
+            df=df,
+            profile=profile,
+            tree=tree,
+            idle_timeout=self._idle_timeout,
+        )
+        self._sessions[session_id] = session
+        logger.info("Created demo session %s", session_id)
+        return session_id
+
+    def get(self, session_id: str) -> Optional[DemoSession]:
+        """Get session by ID or None if expired."""
+        session = self._sessions.get(session_id)
+        if session is None:
+            return None
+        if session.is_expired:
+            self._remove(session_id)
+            return None
+        session.touch()
+        return session
+
+    def update_tree(self, session_id: str, tree: TreeState) -> bool:
+        """Replace the tree state in an existing session."""
+        session = self.get(session_id)
+        if session is None:
+            return False
+        session.tree = tree
+        return True
+
+    def delete(self, session_id: str) -> bool:
+        """Immediately delete a session and its data."""
+        return self._remove(session_id)
+
+    def list_sessions(self) -> List[str]:
+        """Return IDs of all non-expired sessions (for admin/debug)."""
+        self._sweep()
+        return list(self._sessions.keys())
+
+    # -- lifecycle --
+
+    async def start_cleanup_loop(self) -> None:
+        """Start the background task that sweeps expired sessions."""
+        if self._cleanup_task is None or self._cleanup_task.done():
+            self._cleanup_task = asyncio.create_task(self._cleanup_loop())
+            logger.info("Demo session cleanup loop started (interval=%ds)", CLEANUP_INTERVAL)
+
+    async def stop_cleanup_loop(self) -> None:
+        if self._cleanup_task and not self._cleanup_task.done():
+            self._cleanup_task.cancel()
+            try:
+                await self._cleanup_task
+            except asyncio.CancelledError:
+                pass
+            logger.info("Demo session cleanup loop stopped.")
+
+    # -- internals --
+
+    def _remove(self, session_id: str) -> bool:
+        session = self._sessions.pop(session_id, None)
+        if session is not None:
+            # free memory
+            session.df = pd.DataFrame()
+            logger.info("Deleted demo session %s", session_id)
+            return True
+        return False
+
+    def _sweep(self) -> None:
+        expired = [
+            sid for sid, s in self._sessions.items() if s.is_expired
+        ]
+        for sid in expired:
+            self._remove(sid)
+        if expired:
+            logger.info("Swept %d expired demo session(s).", len(expired))
+
+    async def _cleanup_loop(self) -> None:
+        while True:
+            await asyncio.sleep(CLEANUP_INTERVAL)
+            self._sweep()
+
+
+# Module-level singleton — imported by the router.
+session_store = SessionStore()

--- a/analytics-service/app/services/hypothesis_tree.py
+++ b/analytics-service/app/services/hypothesis_tree.py
@@ -749,20 +749,74 @@ def get_candidate_hypotheses(
 
 
 def _is_column_non_normal(profile: DatasetProfile, col_name: str) -> bool:
-    """Check if column looks non-normal."""
+    """Check if column looks non-normal using evidence-based heuristics.
+
+    Parametric tests (t-tests, ANOVA) are robust to moderate departures from normality,
+    especially in moderate to large samples by the Central Limit Theorem (CLT).
+    Therefore, parametric tests (which auto-handle heteroscedasticity via Welch's correction)
+    are recommended by default unless:
+      - The sample size is small (< 500) and formal tests/heuristics show non-normality.
+      - The sample is substantially skewed (|skewness| > 1.5).
+      - The user explicitly requested a non-parametric alternative.
+    """
     if not col_name:
         return False
+    
+    n_rows = profile.row_count
+
     for col in profile.columns:
         if col.name == col_name:
+            # Large samples (n >= 500): CLT guarantees asymptotic normality of sample means.
+            # Only extreme skewness (|skew| > 1.5) warrants a non-parametric default suggestion.
+            if n_rows >= 500:
+                if col.skewness is not None and abs(col.skewness) > 1.5:
+                    return True
+                return False
+
+            # Moderate / small samples (n < 500)
             if col.normality_hint == "likely_non_normal":
                 return True
-            if col.skewness is not None and abs(col.skewness) > 0.5:
+            if col.normality_hint == "appears_normal":
+                return False
+
+            # Substantial skewness threshold (|skewness| > 1.0)
+            # Bulmer (1979): |skew| < 0.5 is approx symmetric, 0.5-1.0 is moderate, > 1.0 is highly skewed.
+            if col.skewness is not None and abs(col.skewness) > 1.0:
                 return True
-            if col.kurtosis is not None and abs(col.kurtosis) > 2.0:
+
+            # Substantial kurtosis threshold (|excess kurtosis| > 3.0)
+            if col.kurtosis is not None and abs(col.kurtosis) > 3.0:
                 return True
-            if col.normality_hint and col.normality_hint != "appears_normal":
-                return True
+
+            return False
     return False
+
+
+def _normality_confidence(profile: DatasetProfile, col_name: str) -> str:
+    """Return normality confidence: 'normal', 'borderline', or 'non_normal'."""
+    if not col_name:
+        return "normal"
+    n_rows = profile.row_count
+    for col in profile.columns:
+        if col.name == col_name:
+            if n_rows >= 500:
+                if col.skewness is not None and abs(col.skewness) > 1.5:
+                    return "non_normal"
+                if col.skewness is not None and abs(col.skewness) > 0.8:
+                    return "borderline"
+                return "normal"
+            if col.normality_hint == "likely_non_normal":
+                return "non_normal"
+            if col.normality_hint == "appears_normal":
+                return "normal"
+            if col.skewness is not None and abs(col.skewness) > 1.0:
+                return "non_normal"
+            if col.kurtosis is not None and abs(col.kurtosis) > 3.0:
+                return "non_normal"
+            if (col.skewness is not None and abs(col.skewness) > 0.5) or (col.kurtosis is not None and abs(col.kurtosis) > 2.0):
+                return "borderline"
+            return "normal"
+    return "normal"
 
 
 
@@ -799,11 +853,11 @@ def get_candidate_analyses(
                 hypothesis_id=hypothesis.id,
                 test_name="independent_ttest",
                 display_name="Independent samples t-test",
-                description="Compares means of two groups assuming normal distributions.",
+                description="Compares means of two groups. Automatically runs Levene's test to apply Student's t-test (equal variances) or Welch's t-test (unequal variances).",
                 is_suggested=not use_nonparametric,
-                suggestion_reason=None if use_nonparametric else "Standard parametric test for two-group mean comparisons.",
+                suggestion_reason=None if use_nonparametric else "Standard parametric test for two-group comparisons. Evaluates equality of variances via Levene's test to select Student's or Welch's t-test.",
                 tradeoffs=[
-                    AnalysisTradeoff(label="Assumes normality", description="May be inaccurate if data is heavily skewed."),
+                    AnalysisTradeoff(label="Assumes normality & checks variance", description="Robust for moderate/large samples under CLT; auto-corrects for unequal variances via Welch's t-test."),
                     AnalysisTradeoff(label="More statistical power", description="Detects smaller differences than non-parametric alternatives."),
                 ],
             ))
@@ -828,18 +882,19 @@ def get_candidate_analyses(
         elif group_count in ("groups_multi", "multi"):
             outcome_col = answers.get("outcome", "")
             non_normal = _is_column_non_normal(profile, outcome_col)
+            use_nonparametric = non_normal or prefer_nonparametric
 
             analyses.append(CandidateAnalysis(
                 id=_stable_id("ana", hypothesis.id, "one_way_anova"),
                 hypothesis_id=hypothesis.id,
                 test_name="one_way_anova",
                 display_name="One-way ANOVA",
-                description="Compares means across three or more groups assuming normality and equal variance.",
-                is_suggested=not non_normal,
-                suggestion_reason=None if non_normal else "Standard parametric test for multi-group comparisons with post-hoc testing.",
+                description="Compares means across three or more groups. Automatically applies standard Fisher's ANOVA or Welch's ANOVA based on Levene's test.",
+                is_suggested=not use_nonparametric,
+                suggestion_reason=None if use_nonparametric else "Standard parametric test for multi-group comparisons with post-hoc testing (auto-handles unequal variances via Welch's ANOVA).",
                 tradeoffs=[
-                    AnalysisTradeoff(label="Assumes normality & equal variance", description="Violations may inflate error rates."),
-                    AnalysisTradeoff(label="Post-hoc tests available", description="Can identify which specific groups differ."),
+                    AnalysisTradeoff(label="Assumes normality & checks variance", description="Auto-falls back to Welch's ANOVA if variances are unequal across groups."),
+                    AnalysisTradeoff(label="Post-hoc tests available", description="Can identify which specific groups differ via Tukey HSD or Games-Howell."),
                 ],
             ))
             analyses.append(CandidateAnalysis(
@@ -848,8 +903,12 @@ def get_candidate_analyses(
                 test_name="kruskal_wallis",
                 display_name="Kruskal-Wallis H test",
                 description="Non-parametric alternative for comparing distributions across 3+ groups.",
-                is_suggested=non_normal,
-                suggestion_reason="Suggested fallback because the outcome variable appears to be non-normally distributed." if non_normal else None,
+                is_suggested=use_nonparametric,
+                suggestion_reason=(
+                    "Suggested non-parametric alternative requested by researcher."
+                    if prefer_nonparametric
+                    else ("Suggested fallback because the outcome variable appears to be non-normally distributed." if non_normal else None)
+                ),
                 tradeoffs=[
                     AnalysisTradeoff(label="No normality assumption", description="Works with skewed or ordinal data."),
                     AnalysisTradeoff(label="Less specific", description="Tests whether distributions differ, not specifically means."),
@@ -861,6 +920,7 @@ def get_candidate_analyses(
         outcome_col = answers.get("outcome", "")
         paired_col = answers.get("paired", "")
         non_normal = _is_column_non_normal(profile, outcome_col) or _is_column_non_normal(profile, paired_col)
+        use_nonparametric = non_normal or prefer_nonparametric
 
         analyses.append(CandidateAnalysis(
             id=_stable_id("ana", hypothesis.id, "paired_ttest"),
@@ -868,8 +928,8 @@ def get_candidate_analyses(
             test_name="paired_ttest",
             display_name="Paired t-test",
             description="Compares two related measurements assuming normal distribution of differences.",
-            is_suggested=not non_normal,
-            suggestion_reason=None if non_normal else "Standard test for before/after or matched-pairs designs.",
+            is_suggested=not use_nonparametric,
+            suggestion_reason=None if use_nonparametric else "Standard test for before/after or matched-pairs designs.",
             tradeoffs=[
                 AnalysisTradeoff(label="Assumes normal differences", description="The differences (not raw scores) must be approximately normal."),
             ],
@@ -880,8 +940,12 @@ def get_candidate_analyses(
             test_name="wilcoxon_signed_rank",
             display_name="Wilcoxon signed-rank test",
             description="Non-parametric paired comparison.",
-            is_suggested=non_normal,
-            suggestion_reason="Suggested fallback because one or both paired variables appear to be non-normally distributed." if non_normal else None,
+            is_suggested=use_nonparametric,
+            suggestion_reason=(
+                "Suggested non-parametric alternative requested by researcher."
+                if prefer_nonparametric
+                else ("Suggested fallback because one or both paired variables appear to be non-normally distributed." if non_normal else None)
+            ),
             tradeoffs=[
                 AnalysisTradeoff(label="No normality assumption", description="Uses ranks rather than raw values."),
                 AnalysisTradeoff(label="Slightly less power", description="May miss small effects."),
@@ -892,6 +956,7 @@ def get_candidate_analyses(
     elif goal in ("goal_compare", "compare") and design in ("design_repeated", "repeated"):
         outcome_col = answers.get("outcome", "")
         non_normal = _is_column_non_normal(profile, outcome_col)
+        use_nonparametric = non_normal or prefer_nonparametric
 
         analyses.append(CandidateAnalysis(
             id=_stable_id("ana", hypothesis.id, "repeated_measures_anova"),
@@ -899,8 +964,8 @@ def get_candidate_analyses(
             test_name="repeated_measures_anova",
             display_name="Repeated-measures ANOVA",
             description="Tests for differences across 3+ time points with the same subjects.",
-            is_suggested=not non_normal,
-            suggestion_reason=None if non_normal else "Standard approach for within-subjects longitudinal designs.",
+            is_suggested=not use_nonparametric,
+            suggestion_reason=None if use_nonparametric else "Standard approach for within-subjects longitudinal designs.",
             tradeoffs=[
                 AnalysisTradeoff(label="Assumes sphericity", description="Requires similar variances of differences between conditions."),
             ],
@@ -911,8 +976,12 @@ def get_candidate_analyses(
             test_name="friedman",
             display_name="Friedman test",
             description="Non-parametric alternative for repeated measures.",
-            is_suggested=non_normal,
-            suggestion_reason="Suggested fallback because the outcome variable appears to be non-normally distributed." if non_normal else None,
+            is_suggested=use_nonparametric,
+            suggestion_reason=(
+                "Suggested non-parametric alternative requested by researcher."
+                if prefer_nonparametric
+                else ("Suggested fallback because the outcome variable appears to be non-normally distributed." if non_normal else None)
+            ),
             tradeoffs=[
                 AnalysisTradeoff(label="Rank-based", description="No distributional assumptions."),
                 AnalysisTradeoff(label="Less power", description="May miss subtle changes."),
@@ -923,6 +992,7 @@ def get_candidate_analyses(
     elif goal in ("goal_reference", "reference"):
         outcome_col = answers.get("outcome", "")
         non_normal = _is_column_non_normal(profile, outcome_col)
+        use_nonparametric = non_normal or prefer_nonparametric
 
         analyses.append(CandidateAnalysis(
             id=_stable_id("ana", hypothesis.id, "one_sample_ttest"),
@@ -930,8 +1000,8 @@ def get_candidate_analyses(
             test_name="one_sample_ttest",
             display_name="One-sample t-test",
             description="Tests whether the sample mean differs from a known value.",
-            is_suggested=not non_normal,
-            suggestion_reason=None if non_normal else "Standard test for comparing a sample to a reference.",
+            is_suggested=not use_nonparametric,
+            suggestion_reason=None if use_nonparametric else "Standard test for comparing a sample to a reference.",
             tradeoffs=[
                 AnalysisTradeoff(label="Assumes normality", description="Best with roughly symmetric data."),
             ],
@@ -942,8 +1012,12 @@ def get_candidate_analyses(
             test_name="one_sample_wilcoxon",
             display_name="One-sample Wilcoxon signed-rank test",
             description="Non-parametric alternative using signed ranks.",
-            is_suggested=non_normal,
-            suggestion_reason="Suggested fallback because the outcome variable appears to be non-normally distributed." if non_normal else None,
+            is_suggested=use_nonparametric,
+            suggestion_reason=(
+                "Suggested non-parametric alternative requested by researcher."
+                if prefer_nonparametric
+                else ("Suggested fallback because the outcome variable appears to be non-normally distributed." if non_normal else None)
+            ),
             tradeoffs=[
                 AnalysisTradeoff(label="No normality assumption", description="Robust to skewed data."),
             ],
@@ -955,6 +1029,7 @@ def get_candidate_analyses(
             outcome_col = answers.get("outcome", "")
             predictor_col = answers.get("predictor", "")
             non_normal = _is_column_non_normal(profile, outcome_col) or _is_column_non_normal(profile, predictor_col)
+            use_nonparametric = non_normal or prefer_nonparametric
 
             analyses.append(CandidateAnalysis(
                 id=_stable_id("ana", hypothesis.id, "pearson_correlation"),
@@ -962,8 +1037,8 @@ def get_candidate_analyses(
                 test_name="pearson_correlation",
                 display_name="Pearson correlation",
                 description="Measures linear relationship between two numeric variables.",
-                is_suggested=not non_normal,
-                suggestion_reason=None if non_normal else "Most common for bivariate linear associations.",
+                is_suggested=not use_nonparametric,
+                suggestion_reason=None if use_nonparametric else "Most common for bivariate linear associations.",
                 tradeoffs=[
                     AnalysisTradeoff(label="Assumes linearity", description="Only detects linear relationships."),
                     AnalysisTradeoff(label="Sensitive to outliers", description="Extreme values can distort the coefficient."),
@@ -975,8 +1050,12 @@ def get_candidate_analyses(
                 test_name="spearman_correlation",
                 display_name="Spearman rank correlation",
                 description="Non-parametric monotonic relationship measure.",
-                is_suggested=non_normal,
-                suggestion_reason="Suggested fallback because one or both variables appear to be non-normally distributed." if non_normal else None,
+                is_suggested=use_nonparametric,
+                suggestion_reason=(
+                    "Suggested non-parametric alternative requested by researcher."
+                    if prefer_nonparametric
+                    else ("Suggested fallback because one or both variables appear to be non-normally distributed." if non_normal else None)
+                ),
                 tradeoffs=[
                     AnalysisTradeoff(label="Detects monotonic relationships", description="Not limited to linear patterns."),
                     AnalysisTradeoff(label="Robust to outliers", description="Uses ranks instead of raw values."),
@@ -1001,6 +1080,7 @@ def get_candidate_analyses(
     elif goal in ("goal_change", "change"):
         outcome_col = answers.get("outcome", "")
         non_normal = _is_column_non_normal(profile, outcome_col)
+        use_nonparametric = non_normal or prefer_nonparametric
 
         analyses.append(CandidateAnalysis(
             id=_stable_id("ana", hypothesis.id, "repeated_measures_anova"),
@@ -1008,8 +1088,8 @@ def get_candidate_analyses(
             test_name="repeated_measures_anova",
             display_name="Repeated-measures ANOVA",
             description="Tests for change across time points within subjects.",
-            is_suggested=not non_normal,
-            suggestion_reason=None if non_normal else "Standard for longitudinal within-subjects designs.",
+            is_suggested=not use_nonparametric,
+            suggestion_reason=None if use_nonparametric else "Standard for longitudinal within-subjects designs.",
             tradeoffs=[
                 AnalysisTradeoff(label="Assumes sphericity", description="Requires similar variances of differences."),
             ],
@@ -1020,8 +1100,12 @@ def get_candidate_analyses(
             test_name="friedman",
             display_name="Friedman test",
             description="Non-parametric repeated-measures test.",
-            is_suggested=non_normal,
-            suggestion_reason="Suggested fallback because the outcome variable appears to be non-normally distributed." if non_normal else None,
+            is_suggested=use_nonparametric,
+            suggestion_reason=(
+                "Suggested non-parametric alternative requested by researcher."
+                if prefer_nonparametric
+                else ("Suggested fallback because the outcome variable appears to be non-normally distributed." if non_normal else None)
+            ),
             tradeoffs=[
                 AnalysisTradeoff(label="Rank-based", description="No distributional assumptions."),
             ],
@@ -1237,7 +1321,7 @@ def get_follow_up_question(
     latest_followup = _get_latest_followup(tree, branch_id)
 
     prompt = "What would you like to do next?"
-    explanation = "Results continue the tree — you can keep exploring."
+    explanation = "Pick a follow-up path."
 
     if latest_followup == "followup_effect_size":
         # Extract active analysis result from tree if available
@@ -1261,47 +1345,53 @@ def get_follow_up_question(
 
             prompt = f"📊 Effect Size & Confidence Interval: {val_str}{mag_str}"
             if ci_str:
-                explanation = f"Detailed Breakdown — {ci_str}. Sample differences evaluate the magnitude of treatment effect beyond p-value significance."
+                explanation = f"Detailed Breakdown — {ci_str}. Evaluates effect magnitude beyond p-value."
             elif val_str:
                 explanation = f"Detailed Breakdown — {val_str}{mag_str} calculated for this active test."
             else:
-                explanation = "Effect sizes quantify the magnitude of the observed effect beyond p-value significance."
+                explanation = "Effect sizes show how big the effect actually is, independent of sample size."
         else:
             prompt = "📊 Effect Size & Confidence Interval Breakdown"
-            explanation = "Effect sizes quantify the magnitude of the observed effect beyond p-value significance."
+            explanation = "Effect sizes show how big the effect actually is, independent of sample size."
 
     elif latest_followup == "followup_nonparametric":
         prompt = "🔄 Non-parametric Alternative Selected"
-        explanation = "We've updated candidate test recommendations below to suggest non-parametric tests (Mann-Whitney U, Wilcoxon, Kruskal-Wallis, Spearman). Click a test below to execute."
+        explanation = "Updated recommendations to rank-based tests (Mann-Whitney U, Wilcoxon, Kruskal-Wallis, Spearman). Pick one below."
 
     elif latest_followup == "followup_export":
         prompt = "📄 Branch Rationale & Audit Trail Exported"
-        explanation = "All decision nodes, dataset profile context, statistical outputs, effect sizes, and rationale for this exploration branch have been logged."
+        explanation = "Decision trail, stats, effect sizes, and provenance for this branch have been logged."
 
     options = [
         QuestionOption(
             id="followup_effect_size",
             label="Inspect effect size and confidence interval",
+            description="Check Cohen's d / η² / r with 95% CIs.",
         ),
         QuestionOption(
             id="followup_covariate",
             label="Add a covariate and re-analyze",
+            description="Control for a confounding variable via ANCOVA / regression.",
         ),
         QuestionOption(
             id="followup_nonparametric",
             label="Compare with a non-parametric alternative",
+            description="Try rank-based tests when normality assumptions are violated.",
         ),
         QuestionOption(
             id="followup_subgroup",
             label="Test a subgroup or interaction",
+            description="Stratify by a categorical variable to check for interaction effects.",
         ),
         QuestionOption(
             id="followup_new_hypothesis",
             label="Create a related hypothesis with a different outcome",
+            description="Same groups, different outcome variable.",
         ),
         QuestionOption(
             id="followup_export",
             label="Stop and export this branch's rationale",
+            description="Export full decision trail, stats, and provenance.",
         ),
     ]
 

--- a/analytics-service/app/services/hypothesis_tree.py
+++ b/analytics-service/app/services/hypothesis_tree.py
@@ -1,0 +1,1316 @@
+
+
+from __future__ import annotations
+
+import hashlib
+import uuid
+from copy import deepcopy
+from datetime import datetime
+from typing import Any, Dict, List, Optional, Tuple
+
+from app.models.demo_schemas import (
+    AnalysisTradeoff,
+    BranchStatus,
+    BranchValidation,
+    CandidateAnalysis,
+    CandidateHypothesis,
+    ColumnType,
+    DatasetProfile,
+    ForkResponse,
+    HypothesisOrigin,
+    NodeKind,
+    Question,
+    QuestionOption,
+    StartMode,
+    TreeBranch,
+    TreeNode,
+    TreeState,
+    VariableRole,
+    VariableRoleAssignment,
+)
+
+
+def _uid() -> str:
+    return uuid.uuid4().hex[:12]
+
+def _stable_id(prefix: str, *args: Any) -> str:
+    """Stable deterministic ID from args."""
+    m = hashlib.md5()
+    for arg in args:
+        m.update(str(arg).encode('utf-8'))
+    return f"{prefix}_{m.hexdigest()[:12]}"
+
+def _now() -> str:
+    return datetime.utcnow().isoformat()
+
+
+
+def _cols_by_type(profile: DatasetProfile, dtype: ColumnType) -> List[str]:
+    return [c.name for c in profile.columns if c.dtype == dtype]
+
+
+def _cols_with_role_suggestion(profile: DatasetProfile, role: VariableRole) -> List[str]:
+    return [c.name for c in profile.columns if role in c.suggested_roles]
+
+
+def _branch_nodes(tree: TreeState, branch_id: str) -> List[TreeNode]:
+    """Ordered nodes in a branch."""
+    branch = tree.branches.get(branch_id)
+    if not branch:
+        return []
+    return [tree.nodes[nid] for nid in branch.node_ids if nid in tree.nodes]
+
+
+def _branch_answers(tree: TreeState, branch_id: str) -> Dict[str, str]:
+    """Answer values keyed by category / option id."""
+    answers: Dict[str, str] = {}
+    for node in _branch_nodes(tree, branch_id):
+        if node.kind == NodeKind.ANSWER and node.answer:
+            key = node.answer_option_id or node.answer
+            answers[key] = node.answer
+        # Also track context data
+        if node.context:
+            answers.update({str(k): str(v) for k, v in node.context.items()})
+    return answers
+
+
+def get_resolved_answers(profile: DatasetProfile, tree: TreeState, branch_id: str) -> Dict[str, str]:
+    """Answers with auto-mapping for focus_variable."""
+    answers = _branch_answers(tree, branch_id)
+    
+
+    if "focus_variable" in answers:
+        col = answers["focus_variable"]
+        col_profile = next((c for c in profile.columns if c.name == col), None)
+        if col_profile:
+            if col_profile.dtype == ColumnType.NUMERIC:
+                answers.setdefault("outcome", col)
+            elif col_profile.dtype == ColumnType.CATEGORICAL:
+                answers.setdefault("group", col)
+                
+
+    if "goal" in answers:
+        answers["start_mode"] = "goal"
+        
+    return answers
+
+
+def _has_results_in_branch(tree: TreeState, branch_id: str) -> bool:
+    return any(
+        n.kind == NodeKind.RESULT for n in _branch_nodes(tree, branch_id)
+    )
+
+
+
+def resolve_variable_roles(
+    tree: TreeState, branch_id: str
+) -> Dict[str, VariableRoleAssignment]:
+    """Column→role assignments from branch history."""
+    roles: Dict[str, VariableRoleAssignment] = {}
+    for node in _branch_nodes(tree, branch_id):
+        ctx = node.context
+        if "role_assignments" in ctx:
+            for col, role_str in ctx["role_assignments"].items():
+                roles[col] = VariableRoleAssignment(
+                    column=col,
+                    role=VariableRole(role_str),
+                    branch_id=branch_id,
+                )
+    return roles
+
+
+
+def get_available_starts(profile: DatasetProfile) -> Question:
+    """Opening question: how to begin."""
+    options = [
+        QuestionOption(
+            id="start_goal",
+            label="Start with a research goal",
+            description="Compare groups, study a relationship, or investigate change over time.",
+        ),
+        QuestionOption(
+            id="start_variable",
+            label="Start with an interesting variable",
+            description="Choose a column and explore what can be investigated with it.",
+        ),
+        QuestionOption(
+            id="start_observation",
+            label="Start with an observation",
+            description='For example: "Group A appears higher than Group B."',
+        ),
+        QuestionOption(
+            id="start_free_text",
+            label="Write my own hypothesis",
+            description="State a hypothesis and map it to your dataset columns.",
+        ),
+    ]
+    return Question(
+        id=f"q_{_uid()}",
+        prompt="How would you like to begin exploring this dataset?",
+        explanation=(
+            "You can approach your data from different angles. "
+            "There is no single correct starting point."
+        ),
+        options=options,
+        allows_custom=False,
+        category="start_mode",
+    )
+
+
+
+def _goal_question(profile: DatasetProfile) -> Question:
+    options = [
+        QuestionOption(
+            id="goal_compare",
+            label="Compare outcomes across groups",
+            description="Are outcomes different between two or more groups?",
+        ),
+        QuestionOption(
+            id="goal_relationship",
+            label="Study a relationship between variables",
+            description="Is there a correlation or predictive link?",
+        ),
+        QuestionOption(
+            id="goal_change",
+            label="Study change over time",
+            description="Do measurements change across repeated observations?",
+        ),
+        QuestionOption(
+            id="goal_reference",
+            label="Compare to a known reference value",
+            description="Is the sample mean different from a known standard?",
+        ),
+    ]
+    return Question(
+        id=f"q_{_uid()}",
+        prompt="What is your research goal?",
+        explanation="Select the broad type of question you want to answer.",
+        options=options,
+        allows_custom=True,
+        category="goal",
+    )
+
+
+def _variable_select_question(
+    profile: DatasetProfile, role: str, exclude: List[str] | None = None
+) -> Question:
+    """Column-selection question for a variable role."""
+    exclude = exclude or []
+
+    if role == "outcome":
+        candidates = _cols_by_type(profile, ColumnType.NUMERIC)
+        prompt = "Which numeric column is your outcome (dependent variable)?"
+        explanation = "This is the variable you want to measure or compare."
+    elif role == "group":
+        candidates = [
+            c.name for c in profile.columns
+            if c.dtype == ColumnType.CATEGORICAL and 2 <= (c.cardinality or c.unique_count) <= 20
+        ]
+        prompt = "Which column defines your groups?"
+        explanation = "This column splits your data into comparison groups."
+    elif role == "predictor":
+        candidates = _cols_by_type(profile, ColumnType.NUMERIC)
+        prompt = "Which numeric column is your predictor (independent variable)?"
+        explanation = "This is the variable you think might predict or explain the outcome."
+    elif role == "paired":
+        candidates = _cols_by_type(profile, ColumnType.NUMERIC)
+        prompt = "Which column contains the second (paired) measurement?"
+        explanation = "Select the matching measurement for a within-subjects comparison."
+    elif role == "time":
+        candidates = (
+            _cols_with_role_suggestion(profile, VariableRole.TIME)
+            or _cols_by_type(profile, ColumnType.DATETIME)
+        )
+        prompt = "Which column represents time or measurement order?"
+        explanation = "This defines the sequence of observations."
+    elif role == "subject":
+        candidates = (
+            _cols_with_role_suggestion(profile, VariableRole.SUBJECT)
+            or _cols_by_type(profile, ColumnType.IDENTIFIER)
+        )
+        prompt = "Which column identifies individual subjects or units?"
+        explanation = "This links repeated measurements to the same participant."
+    elif role == "covariate":
+        candidates = [c.name for c in profile.columns]
+        prompt = "Which column would you like to add as a covariate?"
+        explanation = "This variable will be controlled for during analysis."
+    elif role == "subgroup":
+        candidates = [
+            c.name for c in profile.columns
+            if c.dtype == ColumnType.CATEGORICAL and 2 <= (c.cardinality or c.unique_count) <= 20
+        ]
+        prompt = "Which column defines the subgroup you want to analyze?"
+        explanation = "The analysis will filter or stratify data based on this column."
+    else:
+        candidates = [c.name for c in profile.columns]
+        prompt = f"Select a column for the '{role}' role."
+        explanation = None
+
+    candidates = [c for c in candidates if c not in exclude]
+
+    options = [
+        QuestionOption(id=f"col_{c}", label=c)
+        for c in candidates
+    ]
+
+    if not options:
+        options = [
+            QuestionOption(
+                id="no_columns",
+                label="No suitable columns found",
+                disabled=True,
+                disabled_reason=f"The dataset has no columns suitable for the {role} role.",
+            )
+        ]
+
+    return Question(
+        id=f"q_{_uid()}",
+        prompt=prompt,
+        explanation=explanation,
+        options=options,
+        allows_custom=False,
+        category=f"select_{role}",
+    )
+
+
+def _group_count_question(profile: DatasetProfile, group_col: str) -> Question:
+    """Group count question (auto-detected from data)."""
+    col_profile = next((c for c in profile.columns if c.name == group_col), None)
+    n_groups = col_profile.unique_count if col_profile else 0
+
+    options = []
+    if n_groups == 2:
+        options.append(QuestionOption(
+            id="groups_two",
+            label=f"Two groups (detected: {n_groups} levels)",
+            description="Use a two-sample test.",
+        ))
+    elif n_groups >= 3:
+        options.append(QuestionOption(
+            id="groups_multi",
+            label=f"Three or more groups (detected: {n_groups} levels)",
+            description="Use an ANOVA-family test.",
+        ))
+    else:
+        options.append(QuestionOption(
+            id="groups_two",
+            label="Two groups",
+        ))
+        options.append(QuestionOption(
+            id="groups_multi",
+            label="Three or more groups",
+        ))
+
+    return Question(
+        id=f"q_{_uid()}",
+        prompt=f"How many groups does '{group_col}' define?",
+        explanation=f"Column '{group_col}' has {n_groups} unique value(s).",
+        options=options,
+        allows_custom=False,
+        category="group_count",
+    )
+
+
+def _design_question() -> Question:
+    return Question(
+        id=f"q_{_uid()}",
+        prompt="Are the measurements independent or paired/repeated?",
+        explanation=(
+            "Independent: different participants in each group. "
+            "Paired: same participants measured twice. "
+            "Repeated: same participants measured 3+ times."
+        ),
+        options=[
+            QuestionOption(
+                id="design_independent",
+                label="Independent groups (different participants)",
+            ),
+            QuestionOption(
+                id="design_paired",
+                label="Paired measurements (same participants, two time points)",
+            ),
+            QuestionOption(
+                id="design_repeated",
+                label="Repeated measures (same participants, 3+ time points)",
+            ),
+        ],
+        allows_custom=False,
+        category="design",
+    )
+
+
+def _relationship_type_question() -> Question:
+    return Question(
+        id=f"q_{_uid()}",
+        prompt="What type of relationship are you investigating?",
+        options=[
+            QuestionOption(
+                id="rel_numeric_numeric",
+                label="Relationship between two numeric variables",
+                description="Correlation or regression.",
+            ),
+            QuestionOption(
+                id="rel_categorical_categorical",
+                label="Association between two categorical variables",
+                description="Chi-square or Fisher's exact test.",
+            ),
+            QuestionOption(
+                id="rel_with_covariates",
+                label="Relationship while controlling for other variables",
+                description="Regression with covariates.",
+            ),
+        ],
+        allows_custom=True,
+        category="relationship_type",
+    )
+
+
+def _not_sure_explanation(category: str) -> str:
+    explanations = {
+        "goal": (
+            "• 'Compare outcomes' is for testing whether groups differ.\n"
+            "• 'Study a relationship' is for correlations and predictions.\n"
+            "• 'Change over time' is for longitudinal/repeated data.\n"
+            "• 'Reference value' is for comparing your sample to a known number."
+        ),
+        "design": (
+            "• 'Independent' means each participant appears in only one group.\n"
+            "• 'Paired' means each participant is measured twice (e.g., before/after).\n"
+            "• 'Repeated' means 3 or more measurements per participant."
+        ),
+    }
+    return explanations.get(category, "Review the options and their descriptions.")
+
+
+
+def _get_latest_followup(tree: TreeState, branch_id: str) -> Optional[str]:
+    """Most recent follow-up action on the branch (after last RESULT node)."""
+    nodes = _branch_nodes(tree, branch_id)
+
+
+    last_result_idx = -1
+    for i, n in enumerate(nodes):
+        if n.kind == NodeKind.RESULT:
+            last_result_idx = i
+
+
+    search_nodes = nodes[last_result_idx + 1:] if last_result_idx >= 0 else nodes
+    for n in reversed(search_nodes):
+        if n.kind == NodeKind.ANSWER:
+            opt = n.answer_option_id or n.answer or ""
+            opt_lower = opt.lower()
+
+            if opt.startswith("followup_"):
+                return opt  # e.g. "followup_covariate"
+            if "covariate" in opt_lower and "col_" not in opt:
+                return "followup_covariate"
+            if "nonparametric" in opt_lower or "non-parametric" in opt_lower:
+                return "followup_nonparametric"
+            if "subgroup" in opt_lower:
+                return "followup_subgroup"
+            if "related hypothesis" in opt_lower:
+                return "followup_new_hypothesis"
+            if "effect size" in opt_lower:
+                return "followup_effect_size"
+            if "export" in opt_lower:
+                return "followup_export"
+            return None  # non-followup answer — stop scanning
+    return None
+
+
+
+def _done_or_followup(profile: DatasetProfile, tree: TreeState, branch_id: str) -> Optional[Question]:
+    """Return follow-up question if results exist, else None."""
+    if _has_results_in_branch(tree, branch_id):
+        return get_follow_up_question(profile, tree, branch_id)
+    return None
+
+
+def get_next_question(
+    profile: DatasetProfile,
+    tree: TreeState,
+    branch_id: str,
+) -> Optional[Question]:
+    """Next unresolved question for the branch."""
+    answers = get_resolved_answers(profile, tree, branch_id)
+
+
+    latest_followup = _get_latest_followup(tree, branch_id)
+    if latest_followup == "followup_covariate" and "select_covariate" not in answers:
+        exclude = [c for c in [answers.get("outcome"), answers.get("group"), answers.get("predictor")] if c]
+        return _variable_select_question(profile, "covariate", exclude=exclude)
+
+    if latest_followup == "followup_subgroup" and "select_subgroup" not in answers:
+        exclude = [c for c in [answers.get("outcome"), answers.get("group")] if c]
+        return _variable_select_question(profile, "subgroup", exclude=exclude)
+
+    if latest_followup == "followup_new_hypothesis" and "new_outcome" not in answers:
+        exclude = [c for c in [answers.get("outcome")] if c]
+        q = _variable_select_question(profile, "outcome", exclude=exclude)
+        q.prompt = "Select a new outcome variable for the related hypothesis."
+        q.category = "new_outcome"
+        return q
+
+    # start mode
+    if "start_mode" not in answers:
+        return get_available_starts(profile)
+
+    start = answers.get("start_mode", "")
+
+    # -- goal path --
+    if start in ("start_goal", "goal"):
+        if "goal" not in answers:
+            return _goal_question(profile)
+
+        goal = answers.get("goal", "")
+
+        if goal in ("goal_compare", "compare"):
+
+            if "outcome" not in answers:
+                return _variable_select_question(profile, "outcome")
+
+            outcome = answers.get("outcome", "")
+
+
+            if "design" not in answers:
+                return _design_question()
+
+            design = answers.get("design", "")
+
+            if design in ("design_independent", "independent"):
+                if "group" not in answers:
+                    return _variable_select_question(
+                        profile, "group", exclude=[outcome]
+                    )
+                group = answers.get("group", "")
+                if "group_count" not in answers:
+                    return _group_count_question(profile, group)
+
+
+                return _done_or_followup(profile, tree, branch_id)
+
+            elif design in ("design_paired", "paired"):
+                if "paired" not in answers:
+                    return _variable_select_question(
+                        profile, "paired", exclude=[outcome]
+                    )
+                return _done_or_followup(profile, tree, branch_id)
+
+            elif design in ("design_repeated", "repeated"):
+                if "subject" not in answers:
+                    return _variable_select_question(profile, "subject")
+                if "time" not in answers:
+                    return _variable_select_question(profile, "time")
+                return _done_or_followup(profile, tree, branch_id)
+
+        elif goal in ("goal_relationship", "relationship"):
+            if "relationship_type" not in answers:
+                return _relationship_type_question()
+
+            rel_type = answers.get("relationship_type", "")
+
+            if rel_type in ("rel_numeric_numeric", "numeric_numeric"):
+                if "outcome" not in answers:
+                    return _variable_select_question(profile, "outcome")
+                outcome = answers.get("outcome", "")
+                if "predictor" not in answers:
+                    return _variable_select_question(
+                        profile, "predictor", exclude=[outcome]
+                    )
+                return _done_or_followup(profile, tree, branch_id)
+
+            elif rel_type in ("rel_categorical_categorical", "categorical_categorical"):
+                if "outcome" not in answers:
+                    return _variable_select_question(profile, "group")
+                if "predictor" not in answers:
+                    cat_cols = [
+                        c.name for c in profile.columns
+                        if c.dtype == ColumnType.CATEGORICAL
+                    ]
+                    q = _variable_select_question(profile, "group")
+                    q.prompt = "Select the second categorical variable."
+                    q.category = "predictor"
+                    return q
+                return _done_or_followup(profile, tree, branch_id)
+
+            elif rel_type in ("rel_with_covariates", "with_covariates"):
+                if "outcome" not in answers:
+                    return _variable_select_question(profile, "outcome")
+                if "predictor" not in answers:
+                    outcome = answers.get("outcome", "")
+                    return _variable_select_question(
+                        profile, "predictor", exclude=[outcome]
+                    )
+                return _done_or_followup(profile, tree, branch_id)
+
+        elif goal in ("goal_change", "change"):
+            if "outcome" not in answers:
+                return _variable_select_question(profile, "outcome")
+            if "subject" not in answers:
+                return _variable_select_question(profile, "subject")
+            if "time" not in answers:
+                return _variable_select_question(profile, "time")
+            return _done_or_followup(profile, tree, branch_id)
+
+        elif goal in ("goal_reference", "reference"):
+            if "outcome" not in answers:
+                return _variable_select_question(profile, "outcome")
+            # population mean as custom answer
+            if "population_mean" not in answers:
+                return Question(
+                    id=f"q_{_uid()}",
+                    prompt="What is the known reference (population) mean?",
+                    explanation="Enter the value you want to compare your sample against.",
+                    options=[],
+                    allows_custom=True,
+                    allows_skip=False,
+                    category="population_mean",
+                )
+            return _done_or_followup(profile, tree, branch_id)
+
+    # -- variable path --
+    elif start in ("start_variable", "variable"):
+        if "focus_variable" not in answers:
+            all_cols = [c.name for c in profile.columns]
+            return Question(
+                id=f"q_{_uid()}",
+                prompt="Which variable interests you?",
+                explanation="Select a column and we'll explore what analyses are possible.",
+                options=[QuestionOption(id=f"col_{c}", label=c) for c in all_cols],
+                allows_custom=False,
+                category="focus_variable",
+            )
+
+        if "goal" not in answers:
+            return _goal_question(profile)
+        # then follow goal path
+        return get_next_question(profile, tree, branch_id)
+
+    # -- observation path --
+    elif start in ("start_observation", "observation"):
+        if "observation_text" not in answers:
+            return Question(
+                id=f"q_{_uid()}",
+                prompt="Describe what you observed in the data.",
+                explanation='For example: "Treated patients seem to have higher scores."',
+                options=[],
+                allows_custom=True,
+                category="observation_text",
+            )
+        if "goal" not in answers:
+            return _goal_question(profile)
+        return get_next_question(profile, tree, branch_id)
+
+    # -- free text path --
+    elif start in ("start_free_text", "free_text"):
+        if "hypothesis_text" not in answers:
+            return Question(
+                id=f"q_{_uid()}",
+                prompt="Write your hypothesis in plain language.",
+                explanation="We'll help map it to your dataset columns.",
+                options=[],
+                allows_custom=True,
+                category="hypothesis_text",
+            )
+        if "outcome" not in answers:
+            return _variable_select_question(profile, "outcome")
+        if "goal" not in answers:
+            return _goal_question(profile)
+        return get_next_question(profile, tree, branch_id)
+
+    return _done_or_followup(profile, tree, branch_id)
+
+
+
+
+def get_candidate_hypotheses(
+    profile: DatasetProfile,
+    tree: TreeState,
+    branch_id: str,
+) -> List[CandidateHypothesis]:
+    """Generate hypotheses from branch state."""
+    answers = get_resolved_answers(profile, tree, branch_id)
+    hypotheses: List[CandidateHypothesis] = []
+    is_exploratory = _has_results_in_branch(tree, branch_id)
+
+    goal = answers.get("goal", "")
+    outcome = answers.get("outcome", "")
+    group = answers.get("group", "")
+    design = answers.get("design", "")
+
+    if goal in ("goal_compare", "compare") and outcome:
+        if design in ("design_independent", "independent") and group:
+            group_count = answers.get("group_count", "")
+            if group_count in ("groups_two", "two"):
+                hypotheses.append(CandidateHypothesis(
+                    id=_stable_id("hyp", branch_id, outcome, group, "compare_two"),
+                    branch_id=branch_id,
+                    statement=f"The mean '{outcome}' differs between the two groups defined by '{group}'.",
+                    null_hypothesis=f"There is no difference in '{outcome}' between groups of '{group}'.",
+                    alternative_hypothesis=f"There is a significant difference in '{outcome}' between groups of '{group}'.",
+                    variables={
+                        outcome: VariableRoleAssignment(column=outcome, role=VariableRole.OUTCOME, branch_id=branch_id),
+                        group: VariableRoleAssignment(column=group, role=VariableRole.GROUP, branch_id=branch_id),
+                    },
+                    origin=HypothesisOrigin.EXPLORATORY if is_exploratory else HypothesisOrigin.CONFIRMATORY,
+                ))
+            elif group_count in ("groups_multi", "multi"):
+                hypotheses.append(CandidateHypothesis(
+                    id=_stable_id("hyp", branch_id, outcome, group, "compare_multi"),
+                    branch_id=branch_id,
+                    statement=f"The mean '{outcome}' differs across the groups defined by '{group}'.",
+                    null_hypothesis=f"All group means of '{outcome}' are equal across '{group}' levels.",
+                    alternative_hypothesis=f"At least one group mean of '{outcome}' differs.",
+                    variables={
+                        outcome: VariableRoleAssignment(column=outcome, role=VariableRole.OUTCOME, branch_id=branch_id),
+                        group: VariableRoleAssignment(column=group, role=VariableRole.GROUP, branch_id=branch_id),
+                    },
+                    origin=HypothesisOrigin.EXPLORATORY if is_exploratory else HypothesisOrigin.CONFIRMATORY,
+                ))
+
+        elif design in ("design_paired", "paired"):
+            paired_col = answers.get("paired", "")
+            if paired_col:
+                hypotheses.append(CandidateHypothesis(
+                    id=_stable_id("hyp", branch_id, outcome, paired_col, "compare_paired"),
+                    branch_id=branch_id,
+                    statement=f"There is a difference between '{outcome}' and '{paired_col}' (paired measurements).",
+                    null_hypothesis=f"The mean difference between '{outcome}' and '{paired_col}' is zero.",
+                    alternative_hypothesis=f"The mean difference between '{outcome}' and '{paired_col}' is not zero.",
+                    variables={
+                        outcome: VariableRoleAssignment(column=outcome, role=VariableRole.OUTCOME, branch_id=branch_id),
+                        paired_col: VariableRoleAssignment(column=paired_col, role=VariableRole.PAIRED, branch_id=branch_id),
+                    },
+                    origin=HypothesisOrigin.EXPLORATORY if is_exploratory else HypothesisOrigin.CONFIRMATORY,
+                ))
+
+        elif design in ("design_repeated", "repeated"):
+            hypotheses.append(CandidateHypothesis(
+                id=_stable_id("hyp", branch_id, outcome, "compare_repeated"),
+                branch_id=branch_id,
+                statement=f"'{outcome}' changes significantly across repeated measurements.",
+                null_hypothesis=f"There is no change in '{outcome}' across time points.",
+                alternative_hypothesis=f"'{outcome}' differs across at least two time points.",
+                variables={
+                    outcome: VariableRoleAssignment(column=outcome, role=VariableRole.OUTCOME, branch_id=branch_id),
+                },
+                origin=HypothesisOrigin.EXPLORATORY if is_exploratory else HypothesisOrigin.CONFIRMATORY,
+            ))
+
+    elif goal in ("goal_relationship", "relationship") and outcome:
+        rel_type = answers.get("relationship_type", "")
+        predictor = answers.get("predictor", "")
+
+        if rel_type in ("rel_numeric_numeric", "numeric_numeric") and predictor:
+            hypotheses.append(CandidateHypothesis(
+                id=_stable_id("hyp", branch_id, outcome, predictor, "rel_numeric"),
+                branch_id=branch_id,
+                statement=f"There is a relationship between '{predictor}' and '{outcome}'.",
+                null_hypothesis=f"There is no correlation between '{predictor}' and '{outcome}'.",
+                alternative_hypothesis=f"There is a significant correlation between '{predictor}' and '{outcome}'.",
+                variables={
+                    outcome: VariableRoleAssignment(column=outcome, role=VariableRole.OUTCOME, branch_id=branch_id),
+                    predictor: VariableRoleAssignment(column=predictor, role=VariableRole.PREDICTOR, branch_id=branch_id),
+                },
+                origin=HypothesisOrigin.EXPLORATORY if is_exploratory else HypothesisOrigin.CONFIRMATORY,
+            ))
+
+        elif rel_type in ("rel_categorical_categorical", "categorical_categorical") and predictor:
+            hypotheses.append(CandidateHypothesis(
+                id=_stable_id("hyp", branch_id, outcome, predictor, "rel_categorical"),
+                branch_id=branch_id,
+                statement=f"There is an association between '{outcome}' and '{predictor}'.",
+                null_hypothesis=f"'{outcome}' and '{predictor}' are independent.",
+                alternative_hypothesis=f"'{outcome}' and '{predictor}' are associated.",
+                variables={
+                    outcome: VariableRoleAssignment(column=outcome, role=VariableRole.OUTCOME, branch_id=branch_id),
+                    predictor: VariableRoleAssignment(column=predictor, role=VariableRole.PREDICTOR, branch_id=branch_id),
+                },
+                origin=HypothesisOrigin.EXPLORATORY if is_exploratory else HypothesisOrigin.CONFIRMATORY,
+            ))
+
+    elif goal in ("goal_reference", "reference") and outcome:
+        pop_mean = answers.get("population_mean", "?")
+        hypotheses.append(CandidateHypothesis(
+            id=_stable_id("hyp", branch_id, outcome, pop_mean, "reference"),
+            branch_id=branch_id,
+            statement=f"The mean of '{outcome}' differs from the reference value {pop_mean}.",
+            null_hypothesis=f"The population mean of '{outcome}' equals {pop_mean}.",
+            alternative_hypothesis=f"The population mean of '{outcome}' does not equal {pop_mean}.",
+            variables={
+                outcome: VariableRoleAssignment(column=outcome, role=VariableRole.OUTCOME, branch_id=branch_id),
+            },
+            origin=HypothesisOrigin.EXPLORATORY if is_exploratory else HypothesisOrigin.CONFIRMATORY,
+        ))
+
+    return hypotheses
+
+
+
+
+def _is_column_non_normal(profile: DatasetProfile, col_name: str) -> bool:
+    """Check if column looks non-normal."""
+    if not col_name:
+        return False
+    for col in profile.columns:
+        if col.name == col_name:
+            if col.normality_hint == "likely_non_normal":
+                return True
+            if col.skewness is not None and abs(col.skewness) > 0.5:
+                return True
+            if col.kurtosis is not None and abs(col.kurtosis) > 2.0:
+                return True
+            if col.normality_hint and col.normality_hint != "appears_normal":
+                return True
+    return False
+
+
+
+def get_candidate_analyses(
+    profile: DatasetProfile,
+    hypothesis: CandidateHypothesis,
+    tree: TreeState,
+    branch_id: str,
+) -> List[CandidateAnalysis]:
+    """Competing analysis approaches for a hypothesis."""
+    answers = get_resolved_answers(profile, tree, branch_id)
+    analyses: List[CandidateAnalysis] = []
+
+    latest_followup = _get_latest_followup(tree, branch_id)
+    prefer_nonparametric = (
+        latest_followup == "followup_nonparametric"
+        or "followup_nonparametric" in answers
+    )
+
+    goal = answers.get("goal", "")
+    design = answers.get("design", "")
+    group_count = answers.get("group_count", "")
+    rel_type = answers.get("relationship_type", "")
+
+    # two independent groups
+    if goal in ("goal_compare", "compare") and design in ("design_independent", "independent"):
+        if group_count in ("groups_two", "two"):
+            outcome_col = answers.get("outcome", "")
+            non_normal = _is_column_non_normal(profile, outcome_col)
+            use_nonparametric = non_normal or prefer_nonparametric
+
+            analyses.append(CandidateAnalysis(
+                id=_stable_id("ana", hypothesis.id, "independent_ttest"),
+                hypothesis_id=hypothesis.id,
+                test_name="independent_ttest",
+                display_name="Independent samples t-test",
+                description="Compares means of two groups assuming normal distributions.",
+                is_suggested=not use_nonparametric,
+                suggestion_reason=None if use_nonparametric else "Standard parametric test for two-group mean comparisons.",
+                tradeoffs=[
+                    AnalysisTradeoff(label="Assumes normality", description="May be inaccurate if data is heavily skewed."),
+                    AnalysisTradeoff(label="More statistical power", description="Detects smaller differences than non-parametric alternatives."),
+                ],
+            ))
+            analyses.append(CandidateAnalysis(
+                id=_stable_id("ana", hypothesis.id, "mann_whitney_u"),
+                hypothesis_id=hypothesis.id,
+                test_name="mann_whitney_u",
+                display_name="Mann-Whitney U test",
+                description="Non-parametric alternative that compares distributions without assuming normality.",
+                is_suggested=use_nonparametric,
+                suggestion_reason=(
+                    "Suggested non-parametric alternative requested by researcher."
+                    if prefer_nonparametric
+                    else ("Suggested fallback because the outcome variable appears to be non-normally distributed." if non_normal else None)
+                ),
+                tradeoffs=[
+                    AnalysisTradeoff(label="No normality assumption", description="Works with skewed or ordinal data."),
+                    AnalysisTradeoff(label="Slightly less power", description="May miss small differences that a t-test would detect."),
+                ],
+            ))
+
+        elif group_count in ("groups_multi", "multi"):
+            outcome_col = answers.get("outcome", "")
+            non_normal = _is_column_non_normal(profile, outcome_col)
+
+            analyses.append(CandidateAnalysis(
+                id=_stable_id("ana", hypothesis.id, "one_way_anova"),
+                hypothesis_id=hypothesis.id,
+                test_name="one_way_anova",
+                display_name="One-way ANOVA",
+                description="Compares means across three or more groups assuming normality and equal variance.",
+                is_suggested=not non_normal,
+                suggestion_reason=None if non_normal else "Standard parametric test for multi-group comparisons with post-hoc testing.",
+                tradeoffs=[
+                    AnalysisTradeoff(label="Assumes normality & equal variance", description="Violations may inflate error rates."),
+                    AnalysisTradeoff(label="Post-hoc tests available", description="Can identify which specific groups differ."),
+                ],
+            ))
+            analyses.append(CandidateAnalysis(
+                id=_stable_id("ana", hypothesis.id, "kruskal_wallis"),
+                hypothesis_id=hypothesis.id,
+                test_name="kruskal_wallis",
+                display_name="Kruskal-Wallis H test",
+                description="Non-parametric alternative for comparing distributions across 3+ groups.",
+                is_suggested=non_normal,
+                suggestion_reason="Suggested fallback because the outcome variable appears to be non-normally distributed." if non_normal else None,
+                tradeoffs=[
+                    AnalysisTradeoff(label="No normality assumption", description="Works with skewed or ordinal data."),
+                    AnalysisTradeoff(label="Less specific", description="Tests whether distributions differ, not specifically means."),
+                ],
+            ))
+
+    # paired
+    elif goal in ("goal_compare", "compare") and design in ("design_paired", "paired"):
+        outcome_col = answers.get("outcome", "")
+        paired_col = answers.get("paired", "")
+        non_normal = _is_column_non_normal(profile, outcome_col) or _is_column_non_normal(profile, paired_col)
+
+        analyses.append(CandidateAnalysis(
+            id=_stable_id("ana", hypothesis.id, "paired_ttest"),
+            hypothesis_id=hypothesis.id,
+            test_name="paired_ttest",
+            display_name="Paired t-test",
+            description="Compares two related measurements assuming normal distribution of differences.",
+            is_suggested=not non_normal,
+            suggestion_reason=None if non_normal else "Standard test for before/after or matched-pairs designs.",
+            tradeoffs=[
+                AnalysisTradeoff(label="Assumes normal differences", description="The differences (not raw scores) must be approximately normal."),
+            ],
+        ))
+        analyses.append(CandidateAnalysis(
+            id=_stable_id("ana", hypothesis.id, "wilcoxon_signed_rank"),
+            hypothesis_id=hypothesis.id,
+            test_name="wilcoxon_signed_rank",
+            display_name="Wilcoxon signed-rank test",
+            description="Non-parametric paired comparison.",
+            is_suggested=non_normal,
+            suggestion_reason="Suggested fallback because one or both paired variables appear to be non-normally distributed." if non_normal else None,
+            tradeoffs=[
+                AnalysisTradeoff(label="No normality assumption", description="Uses ranks rather than raw values."),
+                AnalysisTradeoff(label="Slightly less power", description="May miss small effects."),
+            ],
+        ))
+
+    # repeated measures
+    elif goal in ("goal_compare", "compare") and design in ("design_repeated", "repeated"):
+        outcome_col = answers.get("outcome", "")
+        non_normal = _is_column_non_normal(profile, outcome_col)
+
+        analyses.append(CandidateAnalysis(
+            id=_stable_id("ana", hypothesis.id, "repeated_measures_anova"),
+            hypothesis_id=hypothesis.id,
+            test_name="repeated_measures_anova",
+            display_name="Repeated-measures ANOVA",
+            description="Tests for differences across 3+ time points with the same subjects.",
+            is_suggested=not non_normal,
+            suggestion_reason=None if non_normal else "Standard approach for within-subjects longitudinal designs.",
+            tradeoffs=[
+                AnalysisTradeoff(label="Assumes sphericity", description="Requires similar variances of differences between conditions."),
+            ],
+        ))
+        analyses.append(CandidateAnalysis(
+            id=_stable_id("ana", hypothesis.id, "friedman"),
+            hypothesis_id=hypothesis.id,
+            test_name="friedman",
+            display_name="Friedman test",
+            description="Non-parametric alternative for repeated measures.",
+            is_suggested=non_normal,
+            suggestion_reason="Suggested fallback because the outcome variable appears to be non-normally distributed." if non_normal else None,
+            tradeoffs=[
+                AnalysisTradeoff(label="Rank-based", description="No distributional assumptions."),
+                AnalysisTradeoff(label="Less power", description="May miss subtle changes."),
+            ],
+        ))
+
+    # reference value
+    elif goal in ("goal_reference", "reference"):
+        outcome_col = answers.get("outcome", "")
+        non_normal = _is_column_non_normal(profile, outcome_col)
+
+        analyses.append(CandidateAnalysis(
+            id=_stable_id("ana", hypothesis.id, "one_sample_ttest"),
+            hypothesis_id=hypothesis.id,
+            test_name="one_sample_ttest",
+            display_name="One-sample t-test",
+            description="Tests whether the sample mean differs from a known value.",
+            is_suggested=not non_normal,
+            suggestion_reason=None if non_normal else "Standard test for comparing a sample to a reference.",
+            tradeoffs=[
+                AnalysisTradeoff(label="Assumes normality", description="Best with roughly symmetric data."),
+            ],
+        ))
+        analyses.append(CandidateAnalysis(
+            id=_stable_id("ana", hypothesis.id, "one_sample_wilcoxon"),
+            hypothesis_id=hypothesis.id,
+            test_name="one_sample_wilcoxon",
+            display_name="One-sample Wilcoxon signed-rank test",
+            description="Non-parametric alternative using signed ranks.",
+            is_suggested=non_normal,
+            suggestion_reason="Suggested fallback because the outcome variable appears to be non-normally distributed." if non_normal else None,
+            tradeoffs=[
+                AnalysisTradeoff(label="No normality assumption", description="Robust to skewed data."),
+            ],
+        ))
+
+    # numeric-numeric relationship
+    elif goal in ("goal_relationship", "relationship"):
+        if rel_type in ("rel_numeric_numeric", "numeric_numeric"):
+            outcome_col = answers.get("outcome", "")
+            predictor_col = answers.get("predictor", "")
+            non_normal = _is_column_non_normal(profile, outcome_col) or _is_column_non_normal(profile, predictor_col)
+
+            analyses.append(CandidateAnalysis(
+                id=_stable_id("ana", hypothesis.id, "pearson_correlation"),
+                hypothesis_id=hypothesis.id,
+                test_name="pearson_correlation",
+                display_name="Pearson correlation",
+                description="Measures linear relationship between two numeric variables.",
+                is_suggested=not non_normal,
+                suggestion_reason=None if non_normal else "Most common for bivariate linear associations.",
+                tradeoffs=[
+                    AnalysisTradeoff(label="Assumes linearity", description="Only detects linear relationships."),
+                    AnalysisTradeoff(label="Sensitive to outliers", description="Extreme values can distort the coefficient."),
+                ],
+            ))
+            analyses.append(CandidateAnalysis(
+                id=_stable_id("ana", hypothesis.id, "spearman_correlation"),
+                hypothesis_id=hypothesis.id,
+                test_name="spearman_correlation",
+                display_name="Spearman rank correlation",
+                description="Non-parametric monotonic relationship measure.",
+                is_suggested=non_normal,
+                suggestion_reason="Suggested fallback because one or both variables appear to be non-normally distributed." if non_normal else None,
+                tradeoffs=[
+                    AnalysisTradeoff(label="Detects monotonic relationships", description="Not limited to linear patterns."),
+                    AnalysisTradeoff(label="Robust to outliers", description="Uses ranks instead of raw values."),
+                ],
+            ))
+
+        elif rel_type in ("rel_categorical_categorical", "categorical_categorical"):
+            analyses.append(CandidateAnalysis(
+                id=_stable_id("ana", hypothesis.id, "chi_square"),
+                hypothesis_id=hypothesis.id,
+                test_name="chi_square",
+                display_name="Chi-square test of independence",
+                description="Tests whether two categorical variables are independent.",
+                is_suggested=True,
+                suggestion_reason="Standard test for categorical associations.",
+                tradeoffs=[
+                    AnalysisTradeoff(label="Requires adequate cell counts", description="Expected counts should be ≥5 in most cells."),
+                ],
+            ))
+
+    # change over time
+    elif goal in ("goal_change", "change"):
+        outcome_col = answers.get("outcome", "")
+        non_normal = _is_column_non_normal(profile, outcome_col)
+
+        analyses.append(CandidateAnalysis(
+            id=_stable_id("ana", hypothesis.id, "repeated_measures_anova"),
+            hypothesis_id=hypothesis.id,
+            test_name="repeated_measures_anova",
+            display_name="Repeated-measures ANOVA",
+            description="Tests for change across time points within subjects.",
+            is_suggested=not non_normal,
+            suggestion_reason=None if non_normal else "Standard for longitudinal within-subjects designs.",
+            tradeoffs=[
+                AnalysisTradeoff(label="Assumes sphericity", description="Requires similar variances of differences."),
+            ],
+        ))
+        analyses.append(CandidateAnalysis(
+            id=_stable_id("ana", hypothesis.id, "friedman"),
+            hypothesis_id=hypothesis.id,
+            test_name="friedman",
+            display_name="Friedman test",
+            description="Non-parametric repeated-measures test.",
+            is_suggested=non_normal,
+            suggestion_reason="Suggested fallback because the outcome variable appears to be non-normally distributed." if non_normal else None,
+            tradeoffs=[
+                AnalysisTradeoff(label="Rank-based", description="No distributional assumptions."),
+            ],
+        ))
+
+    return analyses
+
+
+
+def validate_branch(
+    profile: DatasetProfile,
+    tree: TreeState,
+    branch_id: str,
+) -> BranchValidation:
+    """Check branch for contradictions and data issues."""
+    answers = get_resolved_answers(profile, tree, branch_id)
+    contradictions: List[str] = []
+    warnings: List[str] = []
+    missing_roles: List[VariableRole] = []
+    dq_issues: List[str] = []
+
+    goal = answers.get("goal", "")
+    design = answers.get("design", "")
+    outcome = answers.get("outcome", "")
+    group = answers.get("group", "")
+
+    # Check outcome column exists and is numeric
+    if outcome:
+        col = next((c for c in profile.columns if c.name == outcome), None)
+        if col is None:
+            contradictions.append(f"Outcome column '{outcome}' not found in dataset.")
+        elif col.dtype != ColumnType.NUMERIC and goal not in ("goal_relationship",):
+            warnings.append(
+                f"Outcome '{outcome}' is {col.dtype.value}, not numeric. "
+                "Some tests may not apply."
+            )
+        if col and col.missing_pct > 20:
+            dq_issues.append(
+                f"Outcome '{outcome}' has {col.missing_pct}% missing values."
+            )
+
+    # Check group column
+    if group:
+        col = next((c for c in profile.columns if c.name == group), None)
+        if col is None:
+            contradictions.append(f"Group column '{group}' not found in dataset.")
+        elif col.dtype == ColumnType.NUMERIC and col.unique_count > 20:
+            warnings.append(
+                f"Group column '{group}' has {col.unique_count} unique numeric values. "
+                "Consider using a categorical variable."
+            )
+
+    # Check design consistency
+    if design in ("design_paired", "paired") and not answers.get("paired"):
+        missing_roles.append(VariableRole.PAIRED)
+
+    if design in ("design_repeated", "repeated"):
+        if not answers.get("subject"):
+            missing_roles.append(VariableRole.SUBJECT)
+        if not answers.get("time"):
+            missing_roles.append(VariableRole.TIME)
+
+    return BranchValidation(
+        is_valid=len(contradictions) == 0,
+        contradictions=contradictions,
+        warnings=warnings,
+        missing_roles=missing_roles,
+        data_quality_issues=dq_issues,
+    )
+
+
+
+def create_initial_tree() -> TreeState:
+    """Create a fresh tree with a root node and one branch."""
+    root_id = f"node_{_uid()}"
+    branch_id = f"branch_{_uid()}"
+
+    root = TreeNode(
+        id=root_id,
+        branch_id=branch_id,
+        kind=NodeKind.ROOT,
+        prompt="Dataset uploaded. Ready to explore.",
+    )
+    branch = TreeBranch(
+        id=branch_id,
+        name="Main exploration",
+        node_ids=[root_id],
+        is_primary=True,
+    )
+
+    return TreeState(
+        nodes={root_id: root},
+        branches={branch_id: branch},
+        active_branch_id=branch_id,
+        root_node_id=root_id,
+    )
+
+
+def add_answer_node(
+    tree: TreeState,
+    branch_id: str,
+    parent_node_id: str,
+    answer: str,
+    option_id: Optional[str] = None,
+    question: Optional[Question] = None,
+    context: Optional[Dict[str, Any]] = None,
+) -> Tuple[TreeState, TreeNode]:
+    """Add question+answer node pair. Returns (tree, answer_node)."""
+    tree = deepcopy(tree)
+    branch = tree.branches[branch_id]
+
+    # Create question node
+    q_id = f"node_{_uid()}"
+    q_node = TreeNode(
+        id=q_id,
+        parent_id=parent_node_id,
+        branch_id=branch_id,
+        kind=NodeKind.QUESTION,
+        prompt=question.prompt if question else "Question",
+        options=question.options if question else [],
+        context=context or {},
+    )
+    tree.nodes[q_id] = q_node
+    branch.node_ids.append(q_id)
+
+    # Create answer node
+    a_id = f"node_{_uid()}"
+    a_node = TreeNode(
+        id=a_id,
+        parent_id=q_id,
+        branch_id=branch_id,
+        kind=NodeKind.ANSWER,
+        answer=answer,
+        answer_option_id=option_id,
+        context=context or {},
+        is_exploratory=_has_results_in_branch(tree, branch_id),
+    )
+    tree.nodes[a_id] = a_node
+    branch.node_ids.append(a_id)
+
+    return tree, a_node
+
+
+def fork_branch(
+    tree: TreeState,
+    source_node_id: str,
+    new_answer: Optional[str] = None,
+) -> Tuple[TreeState, str]:
+    """Fork from a prior node, creating a sibling branch.
+
+    Returns the updated tree and the new branch ID.
+    """
+    tree = deepcopy(tree)
+    source_node = tree.nodes.get(source_node_id)
+    if not source_node:
+        raise ValueError(f"Node '{source_node_id}' not found.")
+
+    old_branch_id = source_node.branch_id
+    old_branch = tree.branches[old_branch_id]
+
+    # Find the index of the source node in the old branch
+    try:
+        idx = old_branch.node_ids.index(source_node_id)
+    except ValueError:
+        idx = 0
+
+    # New branch shares ancestry up to (and including) source_node
+    shared_ids = old_branch.node_ids[: idx + 1]
+
+    new_branch_id = f"branch_{_uid()}"
+    new_branch = TreeBranch(
+        id=new_branch_id,
+        name=f"Fork from '{old_branch.name}'",
+        node_ids=list(shared_ids),
+    )
+    tree.branches[new_branch_id] = new_branch
+    tree.active_branch_id = new_branch_id
+
+    return tree, new_branch_id
+
+
+def add_result_node(
+    tree: TreeState,
+    branch_id: str,
+    parent_node_id: str,
+    result_data: Dict[str, Any],
+) -> Tuple[TreeState, TreeNode]:
+    """Append a result node."""
+    tree = deepcopy(tree)
+    branch = tree.branches[branch_id]
+
+    r_id = f"node_{_uid()}"
+    r_node = TreeNode(
+        id=r_id,
+        parent_id=parent_node_id,
+        branch_id=branch_id,
+        kind=NodeKind.RESULT,
+        prompt="Analysis complete",
+        context=result_data,
+    )
+    tree.nodes[r_id] = r_node
+    branch.node_ids.append(r_id)
+
+    return tree, r_node
+
+
+def get_follow_up_question(
+    profile: DatasetProfile,
+    tree: TreeState,
+    branch_id: str,
+) -> Optional[Question]:
+    """Post-result follow-up options."""
+    latest_followup = _get_latest_followup(tree, branch_id)
+
+    prompt = "What would you like to do next?"
+    explanation = "Results continue the tree — you can keep exploring."
+
+    if latest_followup == "followup_effect_size":
+        # Extract active analysis result from tree if available
+        res_node = None
+        for n in reversed(_branch_nodes(tree, branch_id)):
+            if n.kind == NodeKind.RESULT and n.context:
+                res_node = n.context
+                break
+
+        if res_node:
+            es = res_node.get("effect_size", {})
+            r = res_node.get("result", {})
+            ci = es.get("ci_95") or r.get("ci_95_difference") or r.get("ci_95")
+            metric = es.get("metric") or "effect size"
+            val = es.get("value")
+            mag = es.get("magnitude") or ""
+
+            ci_str = f"95% CI [{', '.join(str(x) for x in ci)}]" if ci else ""
+            val_str = f"{metric}: {val}" if val is not None else ""
+            mag_str = f" ({mag} magnitude)" if mag else ""
+
+            prompt = f"📊 Effect Size & Confidence Interval: {val_str}{mag_str}"
+            if ci_str:
+                explanation = f"Detailed Breakdown — {ci_str}. Sample differences evaluate the magnitude of treatment effect beyond p-value significance."
+            elif val_str:
+                explanation = f"Detailed Breakdown — {val_str}{mag_str} calculated for this active test."
+            else:
+                explanation = "Effect sizes quantify the magnitude of the observed effect beyond p-value significance."
+        else:
+            prompt = "📊 Effect Size & Confidence Interval Breakdown"
+            explanation = "Effect sizes quantify the magnitude of the observed effect beyond p-value significance."
+
+    elif latest_followup == "followup_nonparametric":
+        prompt = "🔄 Non-parametric Alternative Selected"
+        explanation = "We've updated candidate test recommendations below to suggest non-parametric tests (Mann-Whitney U, Wilcoxon, Kruskal-Wallis, Spearman). Click a test below to execute."
+
+    elif latest_followup == "followup_export":
+        prompt = "📄 Branch Rationale & Audit Trail Exported"
+        explanation = "All decision nodes, dataset profile context, statistical outputs, effect sizes, and rationale for this exploration branch have been logged."
+
+    options = [
+        QuestionOption(
+            id="followup_effect_size",
+            label="Inspect effect size and confidence interval",
+        ),
+        QuestionOption(
+            id="followup_covariate",
+            label="Add a covariate and re-analyze",
+        ),
+        QuestionOption(
+            id="followup_nonparametric",
+            label="Compare with a non-parametric alternative",
+        ),
+        QuestionOption(
+            id="followup_subgroup",
+            label="Test a subgroup or interaction",
+        ),
+        QuestionOption(
+            id="followup_new_hypothesis",
+            label="Create a related hypothesis with a different outcome",
+        ),
+        QuestionOption(
+            id="followup_export",
+            label="Stop and export this branch's rationale",
+        ),
+    ]
+
+    return Question(
+        id=f"q_{_uid()}",
+        prompt=prompt,
+        explanation=explanation,
+        options=options,
+        allows_custom=True,
+        category="follow_up",
+    )
+

--- a/analytics-service/app/services/inferential.py
+++ b/analytics-service/app/services/inferential.py
@@ -385,11 +385,8 @@ def _validate_numeric_col(df, col):
         raise ValueError(f"Column '{col}' is not numeric (dtype: {df[col].dtype}).")
 
 
-def run_two_group_test(df, numeric_col, group_col, alpha=0.05, alternative="two-sided"):
-    """Independent 2-group comparison with automatic test selection.
-
-    Shapiro-Wilk/KS → Levene's → Student's t / Welch's t / Mann-Whitney U.
-    """
+def run_two_group_test(df, numeric_col, group_col, alpha=0.05, alternative="two-sided", force_test=None):
+    """Independent 2-group comparison with test selection or explicit force_test."""
     _validate_numeric_col(df, numeric_col)
     if group_col not in df.columns:
         raise ValueError(f"Column '{group_col}' not found in dataset.")
@@ -440,17 +437,19 @@ def run_two_group_test(df, numeric_col, group_col, alpha=0.05, alternative="two-
     if note:
         assumptions["normality"]["note"] = note
 
-    if not both_normal:
+    if force_test == "mann_whitney_u" or (force_test is None and not both_normal):
         test_result = run_mann_whitney(group1, group2, alpha, alternative)
         reason = (
-            f"Data is NOT normally distributed "
+            f"Non-parametric Mann-Whitney U test selected. "
             f"({norm1['test']}: group '{groups[0]}' p={norm1['p_value']}, "
-            f"group '{groups[1]}' p={norm2['p_value']}). "
-            f"Using non-parametric Mann-Whitney U test instead of t-test."
+            f"group '{groups[1]}' p={norm2['p_value']})."
         )
     else:
         variance_check = check_equal_variance(group1, group2, alpha)
         assumptions["equal_variance"] = variance_check
+
+        if not both_normal:
+            warnings.append("Normality assumption violated (group distributions non-normal); consider Mann-Whitney U test.")
 
         if variance_check["equal_variance"]:
             test_result = run_students_ttest(group1, group2, alpha, alternative)
@@ -470,6 +469,7 @@ def run_two_group_test(df, numeric_col, group_col, alpha=0.05, alternative="two-
                 f"but has UNEQUAL variances (Levene's p={variance_check['p_value']}). "
                 f"Using Welch's t-test."
             )
+
 
     group_stats = {
         str(groups[0]): {
@@ -823,6 +823,13 @@ def _build_anova_response(
         column_name=column_name,
         alpha=alpha,
     )
+
+    if post_hoc and "bonferroni" in str(post_hoc.get("method", "")).lower():
+        n_comp = post_hoc.get("n_comparisons", 1)
+        adj_a = post_hoc.get("adjusted_alpha", alpha / max(n_comp, 1))
+        bonf_warning = f"Bonferroni correction applied across {n_comp} pairwise comparison(s) to control Family-Wise Error Rate (adjusted α = {adj_a:.4f})."
+        if bonf_warning not in warnings:
+            warnings.append(bonf_warning)
 
     if post_hoc and test_result["significant"]:
         sig_pairs = [
@@ -1198,11 +1205,128 @@ def run_two_way_anova(
             "std": round(float(np.std(vals, ddof=1)), 4) if len(vals) > 1 else 0.0,
         }
     group_stats["_effects"] = effects
-
     return _build_anova_response(
         test_result, reason, assumptions, group_stats,
         numeric_col, alpha, warnings, None,
     )
+
+
+
+def run_ancova(
+    df: pd.DataFrame,
+    numeric_col: str,
+    group_col: str,
+    covariate_col: str,
+    alpha: float = 0.05,
+) -> Dict[str, Any]:
+    """Analysis of Covariance (ANCOVA) combining group comparison with a covariate."""
+    _validate_numeric_col(df, numeric_col)
+    for col in (group_col, covariate_col):
+        if col not in df.columns:
+            raise ValueError(f"Column '{col}' not found in dataset.")
+
+    clean = df[[numeric_col, group_col, covariate_col]].dropna()
+    n = len(clean)
+    warnings: List[str] = []
+    sdc = check_sdc(n)
+    if sdc["status"] == "suppress":
+        return _suppressed_response(sdc, alpha, "two-sided", {"total_n": n})
+    if sdc["status"] == "warn":
+        warnings.append(sdc["message"])
+
+    # Sanitize formula column names
+    _safe = {
+        numeric_col: numeric_col.replace(" ", "_").replace("-", "_").replace(".", "_"),
+        group_col: group_col.replace(" ", "_").replace("-", "_").replace(".", "_"),
+        covariate_col: covariate_col.replace(" ", "_").replace("-", "_").replace(".", "_"),
+    }
+    safe_df = clean.rename(columns=_safe)
+
+    # Check if covariate is numeric vs categorical
+    is_covariate_numeric = pd.api.types.is_numeric_dtype(clean[covariate_col])
+
+    if is_covariate_numeric:
+        formula = f"Q('{_safe[numeric_col]}') ~ C(Q('{_safe[group_col]}')) + Q('{_safe[covariate_col]}')"
+    else:
+        formula = f"Q('{_safe[numeric_col]}') ~ C(Q('{_safe[group_col]}')) + C(Q('{_safe[covariate_col]}'))"
+
+    try:
+        model = sm_ols(formula, data=safe_df).fit()
+        anova_table = anova_lm(model, typ=2)
+    except Exception as exc:
+        raise ValueError(f"ANCOVA model fit failed: {exc}")
+
+    residuals = model.resid.values
+    norm_residuals = check_normality(residuals, alpha)
+
+    # Find rows matching group and covariate
+    group_row = [k for k in anova_table.index if _safe[group_col] in k][0]
+    cov_row = [k for k in anova_table.index if _safe[covariate_col] in k][0]
+
+    group_f = float(anova_table.loc[group_row, "F"])
+    group_p = float(anova_table.loc[group_row, "PR(>F)"])
+    cov_f = float(anova_table.loc[cov_row, "F"])
+    cov_p = float(anova_table.loc[cov_row, "PR(>F)"])
+
+    ss_group = float(anova_table.loc[group_row, "sum_sq"])
+    ss_total = float(anova_table["sum_sq"].sum())
+    eta_sq = ss_group / ss_total if ss_total > 0 else 0.0
+
+    is_sig = group_p < alpha
+    cov_sig = cov_p < alpha
+
+    interp = (
+        f"ANCOVA analyzing '{numeric_col}' across groups of '{group_col}' "
+        f"controlling for covariate '{covariate_col}'.\n"
+        f"• Group Effect ({group_col}): F={group_f:.4f}, p={group_p:.6f} "
+        f"({'Significant' if is_sig else 'Not Significant'}).\n"
+        f"• Covariate Effect ({covariate_col}): F={cov_f:.4f}, p={cov_p:.6f} "
+        f"({'Significant' if cov_sig else 'Not Significant'}).\n"
+        f"• Partial Eta Squared (Group): η²={eta_sq:.4f} ({classify_effect_size(eta_sq, 'eta_squared')} effect)."
+    )
+
+    return {
+        "test_used": f"ANCOVA ({group_col} + covariate: {covariate_col})",
+        "result": {
+            "statistic": round(group_f, 4),
+            "p_value": round(group_p, 6),
+            "covariate_p_value": round(cov_p, 6),
+            "covariate_f_statistic": round(cov_f, 4),
+            "significant": is_sig,
+        },
+        "effect_size": {
+            "metric": "eta_squared",
+            "value": round(eta_sq, 4),
+            "magnitude": classify_effect_size(eta_sq, "eta_squared"),
+        },
+        "assumptions": {
+            "residual_normality": norm_residuals,
+        },
+        "interpretation": interp,
+        "warnings": warnings,
+        "applied_followups": [f"Added covariate: {covariate_col}"],
+    }
+
+
+def run_subgroup_analysis(
+    df: pd.DataFrame,
+    numeric_col: str,
+    group_col: str,
+    subgroup_col: str,
+    alpha: float = 0.05,
+) -> Dict[str, Any]:
+    """Subgroup / Interaction analysis using 2-way ANOVA."""
+    res = run_two_way_anova(
+        df=df,
+        numeric_col=numeric_col,
+        factor_col_1=group_col,
+        factor_col_2=subgroup_col,
+        alpha=alpha,
+    )
+    res["test_used"] = f"Subgroup Analysis ({group_col} × {subgroup_col})"
+    res["applied_followups"] = [f"Tested subgroup: {subgroup_col}"]
+    return res
+
 
 
 # -- Repeated-Measures ANOVA / Friedman --

--- a/analytics-service/app/services/inferential.py
+++ b/analytics-service/app/services/inferential.py
@@ -1444,3 +1444,558 @@ def run_multi_group_test(
     ANOVA / Welch's ANOVA / Kruskal-Wallis.
     """
     return run_one_way_anova(df, numeric_col, group_col, alpha)
+
+
+# =====================================================================
+# Chi-Square Tests (Week 7)
+# =====================================================================
+
+CRAMERS_V_THRESHOLDS = {"small": 0.1, "medium": 0.3, "large": 0.5}
+
+
+def compute_cramers_v(chi2: float, n: int, k: int, r: int) -> float:
+    """Cramér's V effect size for chi-square test of independence.
+
+    V = sqrt(chi2 / (n * min(k-1, r-1)))
+    """
+    min_dim = min(k - 1, r - 1)
+    if min_dim == 0 or n == 0:
+        return 0.0
+    return float(math.sqrt(chi2 / (n * min_dim)))
+
+
+def _classify_cramers_v(v: float) -> str:
+    """Classify Cramér's V magnitude."""
+    abs_v = abs(v)
+    if abs_v >= CRAMERS_V_THRESHOLDS["large"]:
+        return "large"
+    if abs_v >= CRAMERS_V_THRESHOLDS["medium"]:
+        return "medium"
+    if abs_v >= CRAMERS_V_THRESHOLDS["small"]:
+        return "small"
+    return "negligible"
+
+
+def run_chi_square_independence(
+    df: pd.DataFrame,
+    col1: str,
+    col2: str,
+    alpha: float = 0.05,
+) -> Dict[str, Any]:
+    """Chi-square test of independence between two categorical columns.
+
+    Automatically falls back to Fisher's exact test for 2×2 tables
+    when any expected frequency is below 5.
+    """
+    if col1 not in df.columns:
+        raise ValueError(f"Column '{col1}' not found in dataset.")
+    if col2 not in df.columns:
+        raise ValueError(f"Column '{col2}' not found in dataset.")
+
+    clean = df[[col1, col2]].dropna()
+    n = len(clean)
+
+    # SDC check on overall sample size
+    sdc = check_sdc(n)
+    if sdc["status"] == "suppress":
+        return {
+            "test_used": "suppressed",
+            "reason": sdc["message"],
+            "assumptions": {},
+            "result": {
+                "statistic": None, "p_value": None,
+                "significant": None, "alpha": alpha,
+            },
+            "effect_size": {"metric": None, "value": None, "magnitude": None},
+            "contingency_table": {},
+            "interpretation": sdc["message"],
+            "warnings": [sdc["message"]],
+        }
+
+    warnings_list: List[str] = []
+    if sdc["status"] == "warn":
+        warnings_list.append(sdc["message"])
+
+    # Build contingency table
+    contingency = pd.crosstab(clean[col1], clean[col2])
+    observed = contingency.values
+    r, k = observed.shape
+
+    # Check expected frequencies
+    chi2_stat, p_value, dof, expected = stats.chi2_contingency(observed)
+    min_expected = expected.min()
+    use_fisher = False
+
+    if r == 2 and k == 2 and min_expected < 5:
+        # Fisher's exact test for 2×2 tables with small expected counts
+        use_fisher = True
+        odds_ratio, p_value = stats.fisher_exact(observed)
+        test_used = "fisher_exact"
+        stat_value = odds_ratio
+        reason = (
+            f"2×2 contingency table has expected frequency {min_expected:.1f} < 5. "
+            f"Using Fisher's exact test instead of chi-square."
+        )
+    else:
+        test_used = "chi_square_independence"
+        stat_value = chi2_stat
+        reason = (
+            f"Chi-square test of independence (χ²={chi2_stat:.4f}, df={dof}, "
+            f"min expected={min_expected:.1f})."
+        )
+        if min_expected < 5:
+            warnings_list.append(
+                f"Some expected frequencies are below 5 (min={min_expected:.1f}). "
+                "Chi-square approximation may be unreliable."
+            )
+
+    # Effect size
+    v = compute_cramers_v(chi2_stat, n, k, r)
+    effect_size = {
+        "metric": "cramers_v",
+        "value": round(v, 4),
+        "magnitude": _classify_cramers_v(v),
+    }
+
+    # Contingency table for response
+    ct_dict = {
+        "rows": list(contingency.index.astype(str)),
+        "columns": list(contingency.columns.astype(str)),
+        "observed": contingency.values.tolist(),
+        "expected": expected.round(2).tolist(),
+    }
+
+    significant = bool(p_value <= alpha)
+    verdict = (
+        f"There IS a statistically significant association between "
+        f"'{col1}' and '{col2}'"
+        if significant
+        else f"There is NO statistically significant association between "
+        f"'{col1}' and '{col2}'"
+    )
+    test_label = "Fisher's exact test" if use_fisher else "chi-square test"
+    stat_label = "OR" if use_fisher else "χ²"
+    p_str = _format_p(p_value)
+    interpretation = (
+        f"{verdict} ({test_label}, {stat_label}={stat_value:.4f}, {p_str}, "
+        f"Cramér's V={v:.4f} [{effect_size['magnitude']} effect])."
+    )
+
+    return {
+        "test_used": test_used,
+        "reason": reason,
+        "assumptions": {
+            "min_expected_frequency": round(float(min_expected), 2),
+            "fisher_fallback": use_fisher,
+        },
+        "result": {
+            "statistic": round(float(stat_value), 6),
+            "p_value": round(float(p_value), 6),
+            "significant": significant,
+            "alpha": alpha,
+            "degrees_of_freedom": int(dof) if not use_fisher else None,
+        },
+        "effect_size": effect_size,
+        "contingency_table": ct_dict,
+        "interpretation": interpretation,
+        "warnings": warnings_list,
+    }
+
+
+def run_chi_square_goodness_of_fit(
+    df: pd.DataFrame,
+    column: str,
+    expected_proportions: Optional[Dict[str, float]] = None,
+    alpha: float = 0.05,
+) -> Dict[str, Any]:
+    """Chi-square goodness-of-fit test for a single categorical column.
+
+    Tests whether observed frequencies match expected proportions.
+    If expected_proportions is None, tests against uniform distribution.
+    """
+    if column not in df.columns:
+        raise ValueError(f"Column '{column}' not found in dataset.")
+
+    clean = df[column].dropna()
+    n = len(clean)
+
+    sdc = check_sdc(n)
+    if sdc["status"] == "suppress":
+        return {
+            "test_used": "suppressed",
+            "reason": sdc["message"],
+            "assumptions": {},
+            "result": {
+                "statistic": None, "p_value": None,
+                "significant": None, "alpha": alpha,
+            },
+            "effect_size": {"metric": None, "value": None, "magnitude": None},
+            "frequency_table": {},
+            "interpretation": sdc["message"],
+            "warnings": [sdc["message"]],
+        }
+
+    warnings_list: List[str] = []
+    if sdc["status"] == "warn":
+        warnings_list.append(sdc["message"])
+
+    observed_counts = clean.value_counts()
+    categories = list(observed_counts.index.astype(str))
+    observed = observed_counts.values.astype(float)
+    k = len(categories)
+
+    if expected_proportions:
+        # Map user-supplied proportions to observed category order
+        expected_freq = np.array([
+            expected_proportions.get(cat, 1.0 / k) * n
+            for cat in categories
+        ])
+    else:
+        # Uniform distribution
+        expected_freq = np.full(k, n / k)
+
+    chi2_stat, p_value = stats.chisquare(observed, f_exp=expected_freq)
+    dof = k - 1
+
+    # Effect size: w = sqrt(chi2 / n)
+    w = math.sqrt(chi2_stat / n) if n > 0 else 0.0
+    w_mag = "large" if w >= 0.5 else ("medium" if w >= 0.3 else ("small" if w >= 0.1 else "negligible"))
+
+    significant = bool(p_value <= alpha)
+    dist_type = "uniform" if not expected_proportions else "specified"
+    verdict = (
+        f"The observed distribution of '{column}' significantly differs "
+        f"from the {dist_type} distribution"
+        if significant
+        else f"The observed distribution of '{column}' does NOT significantly "
+        f"differ from the {dist_type} distribution"
+    )
+    p_str = _format_p(p_value)
+    interpretation = (
+        f"{verdict} (χ²={chi2_stat:.4f}, df={dof}, {p_str}, "
+        f"w={w:.4f} [{w_mag} effect])."
+    )
+
+    freq_table = {
+        "categories": categories,
+        "observed": observed.tolist(),
+        "expected": expected_freq.round(2).tolist(),
+    }
+
+    min_expected = expected_freq.min()
+    if min_expected < 5:
+        warnings_list.append(
+            f"Some expected frequencies are below 5 (min={min_expected:.1f}). "
+            "Chi-square approximation may be unreliable."
+        )
+
+    return {
+        "test_used": "chi_square_goodness_of_fit",
+        "reason": f"Goodness-of-fit test against {dist_type} distribution.",
+        "assumptions": {
+            "min_expected_frequency": round(float(min_expected), 2),
+        },
+        "result": {
+            "statistic": round(float(chi2_stat), 6),
+            "p_value": round(float(p_value), 6),
+            "significant": significant,
+            "alpha": alpha,
+            "degrees_of_freedom": dof,
+        },
+        "effect_size": {
+            "metric": "cohens_w",
+            "value": round(w, 4),
+            "magnitude": w_mag,
+        },
+        "frequency_table": freq_table,
+        "interpretation": interpretation,
+        "warnings": warnings_list,
+    }
+
+
+# =====================================================================
+# Correlation Analysis (Week 7)
+# =====================================================================
+
+CORRELATION_THRESHOLDS = {"small": 0.1, "medium": 0.3, "large": 0.5}
+
+
+def _classify_correlation(r: float) -> str:
+    """Classify correlation magnitude."""
+    abs_r = abs(r)
+    if abs_r >= CORRELATION_THRESHOLDS["large"]:
+        return "large"
+    if abs_r >= CORRELATION_THRESHOLDS["medium"]:
+        return "medium"
+    if abs_r >= CORRELATION_THRESHOLDS["small"]:
+        return "small"
+    return "negligible"
+
+
+def _correlation_ci(r: float, n: int, confidence: float = 0.95) -> Dict[str, float]:
+    """Fisher z-transformation confidence interval for correlation."""
+    if n < 4:
+        return {"lower": None, "upper": None, "confidence": confidence}
+    z = np.arctanh(r)
+    se = 1.0 / math.sqrt(n - 3)
+    z_crit = stats.norm.ppf((1 + confidence) / 2)
+    lower = math.tanh(z - z_crit * se)
+    upper = math.tanh(z + z_crit * se)
+    return {
+        "lower": round(float(lower), 4),
+        "upper": round(float(upper), 4),
+        "confidence": confidence,
+    }
+
+
+def run_pearson_correlation(
+    df: pd.DataFrame,
+    col1: str,
+    col2: str,
+    alpha: float = 0.05,
+) -> Dict[str, Any]:
+    """Pearson product-moment correlation with CI and effect size."""
+    _validate_numeric_col(df, col1)
+    _validate_numeric_col(df, col2)
+
+    clean = df[[col1, col2]].dropna()
+    n = len(clean)
+
+    sdc = check_sdc(n)
+    warnings_list: List[str] = []
+    if sdc["status"] == "suppress":
+        return {
+            "test_used": "suppressed",
+            "reason": sdc["message"],
+            "result": {"statistic": None, "p_value": None, "significant": None, "alpha": alpha},
+            "effect_size": {"metric": None, "value": None, "magnitude": None},
+            "confidence_interval": {},
+            "interpretation": sdc["message"],
+            "warnings": [sdc["message"]],
+        }
+    if sdc["status"] == "warn":
+        warnings_list.append(sdc["message"])
+
+    r, p = stats.pearsonr(clean[col1], clean[col2])
+    ci = _correlation_ci(r, n)
+
+    significant = bool(p <= alpha)
+    p_str = _format_p(p)
+    direction = "positive" if r > 0 else "negative"
+    magnitude = _classify_correlation(r)
+    verdict = (
+        f"There IS a statistically significant {direction} correlation"
+        if significant
+        else f"There is NO statistically significant correlation"
+    )
+    interpretation = (
+        f"{verdict} between '{col1}' and '{col2}' "
+        f"(Pearson r={r:.4f}, {p_str}, [{magnitude} effect], "
+        f"95% CI [{ci['lower']}, {ci['upper']}])."
+    )
+
+    return {
+        "test_used": "pearson",
+        "reason": "Pearson product-moment correlation.",
+        "result": {
+            "statistic": round(float(r), 6),
+            "p_value": round(float(p), 6),
+            "significant": significant,
+            "alpha": alpha,
+        },
+        "effect_size": {
+            "metric": "pearson_r",
+            "value": round(float(r), 4),
+            "magnitude": magnitude,
+        },
+        "confidence_interval": ci,
+        "sample_size": n,
+        "interpretation": interpretation,
+        "warnings": warnings_list,
+    }
+
+
+def run_spearman_correlation(
+    df: pd.DataFrame,
+    col1: str,
+    col2: str,
+    alpha: float = 0.05,
+) -> Dict[str, Any]:
+    """Spearman rank correlation with effect size."""
+    _validate_numeric_col(df, col1)
+    _validate_numeric_col(df, col2)
+
+    clean = df[[col1, col2]].dropna()
+    n = len(clean)
+
+    sdc = check_sdc(n)
+    warnings_list: List[str] = []
+    if sdc["status"] == "suppress":
+        return {
+            "test_used": "suppressed",
+            "reason": sdc["message"],
+            "result": {"statistic": None, "p_value": None, "significant": None, "alpha": alpha},
+            "effect_size": {"metric": None, "value": None, "magnitude": None},
+            "interpretation": sdc["message"],
+            "warnings": [sdc["message"]],
+        }
+    if sdc["status"] == "warn":
+        warnings_list.append(sdc["message"])
+
+    rho, p = stats.spearmanr(clean[col1], clean[col2])
+    ci = _correlation_ci(rho, n)
+
+    significant = bool(p <= alpha)
+    p_str = _format_p(p)
+    direction = "positive" if rho > 0 else "negative"
+    magnitude = _classify_correlation(rho)
+    verdict = (
+        f"There IS a statistically significant {direction} monotonic relationship"
+        if significant
+        else f"There is NO statistically significant monotonic relationship"
+    )
+    interpretation = (
+        f"{verdict} between '{col1}' and '{col2}' "
+        f"(Spearman ρ={rho:.4f}, {p_str}, [{magnitude} effect], "
+        f"95% CI [{ci['lower']}, {ci['upper']}])."
+    )
+
+    return {
+        "test_used": "spearman",
+        "reason": "Spearman rank correlation (non-parametric).",
+        "result": {
+            "statistic": round(float(rho), 6),
+            "p_value": round(float(p), 6),
+            "significant": significant,
+            "alpha": alpha,
+        },
+        "effect_size": {
+            "metric": "spearman_rho",
+            "value": round(float(rho), 4),
+            "magnitude": magnitude,
+        },
+        "confidence_interval": ci,
+        "sample_size": n,
+        "interpretation": interpretation,
+        "warnings": warnings_list,
+    }
+
+
+def run_correlation_analysis(
+    df: pd.DataFrame,
+    col1: str,
+    col2: str,
+    alpha: float = 0.05,
+) -> Dict[str, Any]:
+    """Auto-select Pearson or Spearman based on normality testing.
+
+    Uses Pearson if both columns are normally distributed,
+    otherwise falls back to Spearman.
+    """
+    _validate_numeric_col(df, col1)
+    _validate_numeric_col(df, col2)
+
+    clean = df[[col1, col2]].dropna()
+    norm1 = check_normality(clean[col1].values, alpha)
+    norm2 = check_normality(clean[col2].values, alpha)
+    both_normal = norm1["normal"] and norm2["normal"]
+
+    if both_normal:
+        result = run_pearson_correlation(df, col1, col2, alpha)
+        result["reason"] = (
+            f"Both columns are normally distributed "
+            f"({norm1['test']}: '{col1}' p={norm1['p_value']}, "
+            f"'{col2}' p={norm2['p_value']}). Using Pearson correlation."
+        )
+    else:
+        result = run_spearman_correlation(df, col1, col2, alpha)
+        result["reason"] = (
+            f"Data is NOT normally distributed "
+            f"({norm1['test']}: '{col1}' p={norm1['p_value']}, "
+            f"'{col2}' p={norm2['p_value']}). Using Spearman correlation."
+        )
+
+    result["assumptions"] = {
+        "normality": {
+            "test": norm1["test"],
+            col1: {"p_value": norm1["p_value"], "normal": norm1["normal"]},
+            col2: {"p_value": norm2["p_value"], "normal": norm2["normal"]},
+        },
+        "method_selected": "pearson" if both_normal else "spearman",
+    }
+    return result
+
+
+def run_correlation_matrix(
+    df: pd.DataFrame,
+    columns: Optional[List[str]] = None,
+    method: str = "auto",
+    alpha: float = 0.05,
+) -> Dict[str, Any]:
+    """Pairwise correlation matrix across multiple numeric columns.
+
+    method: 'pearson', 'spearman', or 'auto' (auto-selects per pair).
+    """
+    if columns:
+        for col in columns:
+            _validate_numeric_col(df, col)
+        target_cols = columns
+    else:
+        target_cols = [c for c in df.columns if np.issubdtype(df[c].dtype, np.number)]
+
+    if len(target_cols) < 2:
+        raise ValueError(
+            f"Correlation matrix requires at least 2 numeric columns, "
+            f"found {len(target_cols)}."
+        )
+
+    matrix: Dict[str, Dict[str, Any]] = {}
+    warnings_list: List[str] = []
+
+    for i, c1 in enumerate(target_cols):
+        matrix[c1] = {}
+        for j, c2 in enumerate(target_cols):
+            if i == j:
+                matrix[c1][c2] = {
+                    "r": 1.0, "p_value": 0.0, "method": "identity",
+                    "significant": True, "magnitude": "large",
+                }
+                continue
+
+            if j < i:
+                # Symmetric — copy from the other direction
+                matrix[c1][c2] = matrix[c2][c1].copy()
+                continue
+
+            if method == "pearson":
+                result = run_pearson_correlation(df, c1, c2, alpha)
+            elif method == "spearman":
+                result = run_spearman_correlation(df, c1, c2, alpha)
+            else:
+                result = run_correlation_analysis(df, c1, c2, alpha)
+
+            matrix[c1][c2] = {
+                "r": result["result"]["statistic"],
+                "p_value": result["result"]["p_value"],
+                "method": result["test_used"],
+                "significant": result["result"]["significant"],
+                "magnitude": result["effect_size"]["magnitude"],
+            }
+            if result.get("warnings"):
+                warnings_list.extend(result["warnings"])
+
+    return {
+        "test_used": "correlation_matrix",
+        "reason": f"Pairwise correlation matrix ({method} method) "
+                  f"across {len(target_cols)} columns.",
+        "columns": target_cols,
+        "matrix": matrix,
+        "method": method,
+        "alpha": alpha,
+        "interpretation": (
+            f"Correlation matrix computed for {len(target_cols)} columns "
+            f"with {len(target_cols) * (len(target_cols) - 1) // 2} "
+            f"unique pairs."
+        ),
+        "warnings": list(set(warnings_list)),
+    }

--- a/analytics-service/app/services/inferential.py
+++ b/analytics-service/app/services/inferential.py
@@ -376,6 +376,37 @@ def _build_response(test_result, reason, assumptions, group_stats,
     }
 
 
+def _calc_group_stats(data: np.ndarray) -> Dict[str, Any]:
+    """Summary stats for a single group."""
+    clean = np.asarray(data, dtype=float)
+    clean = clean[~np.isnan(clean)]
+    n = int(len(clean))
+    if n == 0:
+        return {
+            "n": 0, "mean": 0.0, "std": 0.0, "median": 0.0,
+            "se": 0.0, "q1": 0.0, "q3": 0.0, "min": 0.0, "max": 0.0,
+        }
+    mean = round(float(np.mean(clean)), 4)
+    std = round(float(np.std(clean, ddof=1)), 4) if n > 1 else 0.0
+    median = round(float(np.median(clean)), 4)
+    se = round(float(std / np.sqrt(n)), 4) if n > 0 else 0.0
+    q1 = round(float(np.percentile(clean, 25)), 4)
+    q3 = round(float(np.percentile(clean, 75)), 4)
+    min_v = round(float(np.min(clean)), 4)
+    max_v = round(float(np.max(clean)), 4)
+    return {
+        "n": n,
+        "mean": mean,
+        "std": std,
+        "median": median,
+        "se": se,
+        "q1": q1,
+        "q3": q3,
+        "min": min_v,
+        "max": max_v,
+    }
+
+
 # -- Orchestrators --
 
 def _validate_numeric_col(df, col):
@@ -472,18 +503,8 @@ def run_two_group_test(df, numeric_col, group_col, alpha=0.05, alternative="two-
 
 
     group_stats = {
-        str(groups[0]): {
-            "n": int(len(group1)),
-            "mean": round(float(np.mean(group1)), 4),
-            "std": round(float(np.std(group1, ddof=1)), 4),
-            "median": round(float(np.median(group1)), 4),
-        },
-        str(groups[1]): {
-            "n": int(len(group2)),
-            "mean": round(float(np.mean(group2)), 4),
-            "std": round(float(np.std(group2, ddof=1)), 4),
-            "median": round(float(np.median(group2)), 4),
-        },
+        str(groups[0]): _calc_group_stats(group1),
+        str(groups[1]): _calc_group_stats(group2),
     }
 
     return _build_response(test_result, reason, assumptions, group_stats,
@@ -541,16 +562,9 @@ def run_paired_test(df, col1, col2, alpha=0.05, alternative="two-sided"):
         )
 
     group_stats = {
-        col1: {
-            "n": int(len(data1)),
-            "mean": round(float(np.mean(data1)), 4),
-            "std": round(float(np.std(data1, ddof=1)), 4),
-        },
-        col2: {
-            "n": int(len(data2)),
-            "mean": round(float(np.mean(data2)), 4),
-            "std": round(float(np.std(data2, ddof=1)), 4),
-        },
+        col1: _calc_group_stats(data1),
+        col2: _calc_group_stats(data2),
+        "_differences": _calc_group_stats(diffs),
     }
 
     return _build_response(test_result, reason, assumptions, group_stats,
@@ -604,13 +618,8 @@ def run_one_sample_test(df, numeric_col, population_mean, alpha=0.05,
         )
 
     group_stats = {
-        "sample": {
-            "n": int(n),
-            "mean": round(float(np.mean(sample)), 4),
-            "std": round(float(np.std(sample, ddof=1)), 4),
-            "median": round(float(np.median(sample)), 4),
-        },
-        "_reference": {"value": population_mean},
+        "sample": _calc_group_stats(sample),
+        "_reference": {"value": population_mean, "n": len(sample)},
     }
 
     return _build_response(test_result, reason, assumptions, group_stats,
@@ -1063,12 +1072,7 @@ def run_one_way_anova(
 
     group_stats = {}
     for name, gd in zip(group_names, group_data):
-        group_stats[name] = {
-            "n": int(len(gd)),
-            "mean": round(float(np.mean(gd)), 4),
-            "std": round(float(np.std(gd, ddof=1)), 4),
-            "median": round(float(np.median(gd)), 4),
-        }
+        group_stats[name] = _calc_group_stats(gd)
 
     return _build_anova_response(
         test_result, reason, assumptions, group_stats,

--- a/analytics-service/tests/test_chi_square.py
+++ b/analytics-service/tests/test_chi_square.py
@@ -1,0 +1,101 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from app.services.inferential import (
+    run_chi_square_independence,
+    run_chi_square_goodness_of_fit,
+)
+
+
+def _chi_square_independence_df(n_per_cell=50, seed=42):
+    rng = np.random.default_rng(seed)
+    # Generate data with association
+    # Factor A: Treatment (Yes/No), Factor B: Recovery (Yes/No)
+    data = []
+    # Yes Treatment -> 80% Recovery
+    for _ in range(n_per_cell):
+        recovery = "Yes" if rng.random() < 0.8 else "No"
+        data.append({"treatment": "Yes", "recovered": recovery})
+    # No Treatment -> 30% Recovery
+    for _ in range(n_per_cell):
+        recovery = "Yes" if rng.random() < 0.3 else "No"
+        data.append({"treatment": "No", "recovered": recovery})
+    return pd.DataFrame(data)
+
+
+def _goodness_of_fit_df(n=100, p=[0.5, 0.3, 0.2], seed=42):
+    rng = np.random.default_rng(seed)
+    categories = rng.choice(["A", "B", "C"], size=n, p=p)
+    return pd.DataFrame({"category": categories})
+
+
+class TestChiSquareIndependence:
+    def test_independence_significant(self):
+        df = _chi_square_independence_df(n_per_cell=50)
+        result = run_chi_square_independence(df, "treatment", "recovered")
+        assert result["test_used"] == "chi_square_independence"
+        assert result["result"]["significant"] is True
+        assert "contingency_table" in result
+        assert result["effect_size"]["metric"] == "cramers_v"
+        assert result["effect_size"]["value"] > 0.3
+
+    def test_independence_not_significant(self):
+        # Generate independent columns
+        rng = np.random.default_rng(42)
+        treatment = rng.choice(["Yes", "No"], size=100)
+        recovered = rng.choice(["Yes", "No"], size=100)
+        df = pd.DataFrame({"treatment": treatment, "recovered": recovered})
+        result = run_chi_square_independence(df, "treatment", "recovered")
+        assert result["result"]["significant"] is False
+
+    def test_fisher_exact_fallback(self):
+        # 2x2 with extremely small numbers to trigger Fisher's Exact
+        df = pd.DataFrame([
+            {"treatment": "Yes", "recovered": "Yes"},
+            {"treatment": "Yes", "recovered": "No"},
+            {"treatment": "No", "recovered": "Yes"},
+            {"treatment": "No", "recovered": "No"},
+            {"treatment": "Yes", "recovered": "Yes"},
+            {"treatment": "No", "recovered": "No"},
+        ])
+        result = run_chi_square_independence(df, "treatment", "recovered")
+        assert result["test_used"] == "fisher_exact"
+        assert "odds_ratio" in result["reason"].lower() or "fisher" in result["test_used"]
+        assert result["assumptions"]["fisher_fallback"] is True
+
+    def test_sdc_suppression(self):
+        # Sample size < 5
+        df = pd.DataFrame([
+            {"treatment": "Yes", "recovered": "Yes"},
+            {"treatment": "Yes", "recovered": "No"},
+            {"treatment": "No", "recovered": "Yes"},
+        ])
+        result = run_chi_square_independence(df, "treatment", "recovered")
+        assert result["test_used"] == "suppressed"
+
+    def test_column_not_found(self):
+        df = pd.DataFrame({"A": [1, 2], "B": [3, 4]})
+        with pytest.raises(ValueError, match="not found"):
+            run_chi_square_independence(df, "A", "C")
+
+
+class TestChiSquareGoodnessOfFit:
+    def test_goodness_of_fit_uniform(self):
+        df = _goodness_of_fit_df(n=150, p=[0.33, 0.33, 0.34])
+        result = run_chi_square_goodness_of_fit(df, "category")
+        assert result["test_used"] == "chi_square_goodness_of_fit"
+        # Since it's uniform, it should not be significant
+        assert result["result"]["significant"] is False
+
+    def test_goodness_of_fit_non_uniform(self):
+        df = _goodness_of_fit_df(n=150, p=[0.7, 0.2, 0.1])
+        result = run_chi_square_goodness_of_fit(df, "category")
+        assert result["result"]["significant"] is True
+
+    def test_goodness_of_fit_specified_proportions(self):
+        df = _goodness_of_fit_df(n=200, p=[0.6, 0.3, 0.1])
+        expected = {"A": 0.6, "B": 0.3, "C": 0.1}
+        result = run_chi_square_goodness_of_fit(df, "category", expected_proportions=expected)
+        # Should fit the specified proportions, hence not significant difference
+        assert result["result"]["significant"] is False

--- a/analytics-service/tests/test_correlation.py
+++ b/analytics-service/tests/test_correlation.py
@@ -1,0 +1,85 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from app.services.inferential import (
+    run_pearson_correlation,
+    run_spearman_correlation,
+    run_correlation_analysis,
+    run_correlation_matrix,
+)
+
+
+def _correlation_df(n=50, r=0.7, non_normal=False, seed=42):
+    rng = np.random.default_rng(seed)
+    x = rng.normal(100, 15, n) if not non_normal else rng.exponential(scale=5.0, size=n)
+    # Generate correlated y
+    noise_sd = 10 if not non_normal else 1.0
+    noise = rng.normal(0, noise_sd, n)
+    y = r * x + noise
+    return pd.DataFrame({"x": x, "y": y})
+
+
+class TestCorrelationAnalysis:
+    def test_pearson_correlation_significant(self):
+        df = _correlation_df(n=100, r=0.8)
+        result = run_pearson_correlation(df, "x", "y")
+        assert result["test_used"] == "pearson"
+        assert result["result"]["significant"] is True
+        assert result["result"]["statistic"] > 0.5
+        assert "confidence_interval" in result
+        assert result["effect_size"]["magnitude"] == "large"
+
+    def test_spearman_correlation_significant(self):
+        df = _correlation_df(n=100, r=0.8, non_normal=True)
+        result = run_spearman_correlation(df, "x", "y")
+        assert result["test_used"] == "spearman"
+        assert result["result"]["significant"] is True
+        assert result["result"]["statistic"] > 0.5
+        assert result["effect_size"]["magnitude"] == "large"
+
+    def test_correlation_analysis_auto_selects_pearson(self):
+        # Pearson is used when both columns are normal
+        df = _correlation_df(n=100, r=0.6, non_normal=False)
+        result = run_correlation_analysis(df, "x", "y")
+        assert result["assumptions"]["method_selected"] == "pearson"
+
+    def test_correlation_analysis_auto_selects_spearman(self):
+        # Spearman is used when at least one column is non-normal
+        df = _correlation_df(n=100, r=0.6, non_normal=True)
+        result = run_correlation_analysis(df, "x", "y")
+        assert result["assumptions"]["method_selected"] == "spearman"
+
+    def test_correlation_matrix_pearson(self):
+        rng = np.random.default_rng(42)
+        df = pd.DataFrame({
+            "a": rng.normal(10, 2, 50),
+            "b": rng.normal(20, 5, 50),
+            "c": rng.normal(30, 8, 50),
+        })
+        result = run_correlation_matrix(df, method="pearson")
+        assert result["test_used"] == "correlation_matrix"
+        assert "a" in result["matrix"]
+        assert "b" in result["matrix"]["a"]
+        assert result["matrix"]["a"]["a"]["r"] == 1.0
+
+    def test_correlation_matrix_too_few_numeric_columns(self):
+        df = pd.DataFrame({
+            "a": [1, 2, 3],
+            "b": ["x", "y", "z"],
+        })
+        with pytest.raises(ValueError, match="at least 2"):
+            run_correlation_matrix(df)
+
+    def test_sdc_suppression(self):
+        df = pd.DataFrame({
+            "x": [1.0, 2.0, 3.0],
+            "y": [2.0, 4.0, 6.0],
+        })
+        result = run_pearson_correlation(df, "x", "y")
+        assert result["test_used"] == "suppressed"
+
+    def test_column_not_found(self):
+        df = pd.DataFrame({"x": [1, 2], "y": [3, 4]})
+        with pytest.raises(ValueError, match="not found"):
+            run_pearson_correlation(df, "x", "z")

--- a/analytics-service/tests/test_dataset_profiler.py
+++ b/analytics-service/tests/test_dataset_profiler.py
@@ -118,3 +118,20 @@ class TestProfileDataset:
         profile = profile_dataset(clinical_df)
         bp = next(c for c in profile.columns if c.name == "blood_pressure")
         assert bp.normality_hint is not None
+
+    def test_large_sample_normality_hint_appears_normal(self):
+        np.random.seed(42)
+        # 10,000 lines of normal data with two group mixture (Weight vs Sex)
+        weights = np.concatenate([np.random.normal(180, 20, 5000), np.random.normal(140, 15, 5000)])
+        df = pd.DataFrame({"weight": weights})
+        profile = profile_dataset(df)
+        weight_col = next(c for c in profile.columns if c.name == "weight")
+        assert weight_col.normality_hint == "appears_normal"
+
+    def test_large_sample_heavily_skewed_normality_hint_likely_non_normal(self):
+        np.random.seed(42)
+        # 10,000 lines of exponential data (skewness > 1.5)
+        df = pd.DataFrame({"income": np.random.exponential(scale=1000, size=10000)})
+        profile = profile_dataset(df)
+        col = next(c for c in profile.columns if c.name == "income")
+        assert col.normality_hint == "likely_non_normal"

--- a/analytics-service/tests/test_dataset_profiler.py
+++ b/analytics-service/tests/test_dataset_profiler.py
@@ -1,0 +1,120 @@
+"""Tests for the dataset profiler service."""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from app.models.demo_schemas import ColumnType, VariableRole
+from app.services.dataset_profiler import profile_dataset
+
+
+
+
+@pytest.fixture
+def clinical_df():
+    """Simulated clinical trial dataset."""
+    np.random.seed(42)
+    n = 100
+    return pd.DataFrame({
+        "patient_id": [f"P{i:03d}" for i in range(n)],
+        "treatment": np.random.choice(["Drug", "Placebo"], n),
+        "age": np.random.normal(55, 10, n).round(1),
+        "blood_pressure": np.random.normal(130, 15, n).round(1),
+        "cholesterol": np.random.normal(200, 30, n).round(1),
+        "sex": np.random.choice(["M", "F"], n),
+        "visit_date": pd.date_range("2024-01-01", periods=n, freq="D"),
+    })
+
+
+@pytest.fixture
+def minimal_df():
+    """Very small dataset for edge-case testing."""
+    return pd.DataFrame({
+        "x": [1, 2, 3],
+        "group": ["A", "B", "A"],
+    })
+
+
+@pytest.fixture
+def missing_df():
+    """Dataset with heavy missingness."""
+    return pd.DataFrame({
+        "complete": [1, 2, 3, 4, 5],
+        "half_missing": [1, None, None, None, 5],
+        "all_missing": [None, None, None, None, None],
+    })
+
+
+
+
+class TestProfileDataset:
+    def test_correct_column_count(self, clinical_df):
+        profile = profile_dataset(clinical_df)
+        assert profile.column_count == 7
+        assert profile.row_count == 100
+        assert len(profile.columns) == 7
+
+    def test_numeric_columns_have_stats(self, clinical_df):
+        profile = profile_dataset(clinical_df)
+        age_col = next(c for c in profile.columns if c.name == "age")
+        assert age_col.dtype == ColumnType.NUMERIC
+        assert age_col.mean is not None
+        assert age_col.median is not None
+        assert age_col.std is not None
+        assert age_col.min_val is not None
+        assert age_col.max_val is not None
+        assert age_col.skewness is not None
+
+    def test_categorical_columns_detected(self, clinical_df):
+        profile = profile_dataset(clinical_df)
+        treatment = next(c for c in profile.columns if c.name == "treatment")
+        assert treatment.dtype == ColumnType.CATEGORICAL
+        assert treatment.top_values is not None
+        assert treatment.cardinality == 2
+
+    def test_identifier_detected(self, clinical_df):
+        profile = profile_dataset(clinical_df)
+        pid = next(c for c in profile.columns if c.name == "patient_id")
+        assert pid.dtype == ColumnType.IDENTIFIER
+
+    def test_datetime_detected(self, clinical_df):
+        profile = profile_dataset(clinical_df)
+        date_col = next(c for c in profile.columns if c.name == "visit_date")
+        assert date_col.dtype == ColumnType.DATETIME
+
+    def test_role_suggestions_group(self, clinical_df):
+        profile = profile_dataset(clinical_df)
+        assert "treatment" in profile.suggested_group_columns
+        assert "sex" in profile.suggested_group_columns
+
+    def test_role_suggestions_outcome(self, clinical_df):
+        profile = profile_dataset(clinical_df)
+        assert "blood_pressure" in profile.suggested_outcome_columns
+        assert "age" in profile.suggested_outcome_columns
+
+    def test_role_suggestions_subject(self, clinical_df):
+        profile = profile_dataset(clinical_df)
+        assert "patient_id" in profile.suggested_subject_columns
+
+    def test_missing_data_warning(self, missing_df):
+        profile = profile_dataset(missing_df)
+        assert any("half_missing" in w for w in profile.warnings)
+
+    def test_small_dataset_warning(self, minimal_df):
+        profile = profile_dataset(minimal_df)
+        assert any("small dataset" in w.lower() or "Very small" in w for w in profile.warnings)
+
+    def test_constant_column_warning(self):
+        df = pd.DataFrame({"const": [5, 5, 5, 5, 5], "var": [1, 2, 3, 4, 5]})
+        profile = profile_dataset(df)
+        assert any("constant" in w.lower() for w in profile.warnings)
+
+    def test_duplicate_rows_warning(self):
+        df = pd.DataFrame({"a": [1, 1, 2], "b": ["x", "x", "y"]})
+        profile = profile_dataset(df)
+        assert any("duplicate" in w.lower() for w in profile.warnings)
+
+    def test_normality_hint_present(self, clinical_df):
+        profile = profile_dataset(clinical_df)
+        bp = next(c for c in profile.columns if c.name == "blood_pressure")
+        assert bp.normality_hint is not None

--- a/analytics-service/tests/test_demo_router.py
+++ b/analytics-service/tests/test_demo_router.py
@@ -253,3 +253,43 @@ class TestExistingEndpointsUnchanged:
         assert resp.status_code == 200
         data = resp.json()
         assert data["status"] == "healthy"
+
+
+class TestExecuteAnalysisRouting:
+    def test_kruskal_wallis_with_two_groups_routes_to_mann_whitney(self):
+        from app.routers.demo_router import _execute_analysis
+
+        np.random.seed(42)
+        df = pd.DataFrame({
+            "outcome": np.concatenate([np.random.normal(10, 2, 20), np.random.normal(15, 2, 20)]),
+            "group": ["A"] * 20 + ["B"] * 20,
+        })
+        result = _execute_analysis(
+            df=df,
+            test_name="kruskal_wallis",
+            outcome_col="outcome",
+            group_col="group",
+            paired_col=None,
+            predictor_col=None,
+            answers=None,
+        )
+        assert result["test_used"] == "mann_whitney_u"
+
+    def test_one_way_anova_with_two_groups_routes_to_ttest(self):
+        from app.routers.demo_router import _execute_analysis
+
+        np.random.seed(42)
+        df = pd.DataFrame({
+            "outcome": np.concatenate([np.random.normal(10, 2, 20), np.random.normal(15, 2, 20)]),
+            "group": ["A"] * 20 + ["B"] * 20,
+        })
+        result = _execute_analysis(
+            df=df,
+            test_name="one_way_anova",
+            outcome_col="outcome",
+            group_col="group",
+            paired_col=None,
+            predictor_col=None,
+            answers=None,
+        )
+        assert result["test_used"] in ("students_ttest", "welchs_ttest")

--- a/analytics-service/tests/test_demo_router.py
+++ b/analytics-service/tests/test_demo_router.py
@@ -1,0 +1,255 @@
+"""Tests for the demo hypothesis-tree API endpoints."""
+
+import io
+import numpy as np
+import pandas as pd
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+@pytest.fixture
+def csv_file():
+    """Generate a CSV file in memory."""
+    np.random.seed(42)
+    n = 60
+    df = pd.DataFrame({
+        "patient_id": [f"P{i:03d}" for i in range(n)],
+        "treatment": np.random.choice(["Drug", "Placebo"], n),
+        "age": np.random.normal(55, 10, n).round(1),
+        "blood_pressure": np.random.normal(130, 15, n).round(1),
+        "sex": np.random.choice(["M", "F"], n),
+    })
+    buf = io.BytesIO()
+    df.to_csv(buf, index=False)
+    buf.seek(0)
+    return buf
+
+
+class TestCreateSession:
+    def test_upload_creates_session(self, client, csv_file):
+        resp = client.post(
+            "/demo/hypothesis-tree/sessions",
+            files={"file": ("test.csv", csv_file, "text/csv")},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "session_id" in data
+        assert data["profile"]["row_count"] == 60
+        assert data["profile"]["column_count"] == 5
+        assert data["current_question"] is not None
+
+    def test_upload_returns_root_question(self, client, csv_file):
+        resp = client.post(
+            "/demo/hypothesis-tree/sessions",
+            files={"file": ("test.csv", csv_file, "text/csv")},
+        )
+        data = resp.json()
+        q = data["current_question"]
+        assert q["category"] == "start_mode"
+        assert len(q["options"]) == 4
+
+
+class TestGetSession:
+    def test_get_existing_session(self, client, csv_file):
+        create_resp = client.post(
+            "/demo/hypothesis-tree/sessions",
+            files={"file": ("test.csv", csv_file, "text/csv")},
+        )
+        sid = create_resp.json()["session_id"]
+
+        get_resp = client.get(f"/demo/hypothesis-tree/sessions/{sid}")
+        assert get_resp.status_code == 200
+        assert get_resp.json()["session_id"] == sid
+
+    def test_get_invalid_session_returns_404(self, client):
+        resp = client.get("/demo/hypothesis-tree/sessions/nonexistent")
+        assert resp.status_code == 404
+
+    def test_get_session_updates_active_branch(self, client, csv_file):
+        create_resp = client.post(
+            "/demo/hypothesis-tree/sessions",
+            files={"file": ("test.csv", csv_file, "text/csv")},
+        )
+        data = create_resp.json()
+        sid = data["session_id"]
+        
+        # Fork to create another branch
+        fork_resp = client.post(
+            f"/demo/hypothesis-tree/sessions/{sid}/forks",
+            json={"node_id": data["tree"]["root_node_id"]},
+        )
+        new_branch_id = fork_resp.json()["new_branch_id"]
+        
+        # Call GET with active_branch_id parameter
+        get_resp = client.get(f"/demo/hypothesis-tree/sessions/{sid}?active_branch_id={new_branch_id}")
+        assert get_resp.status_code == 200
+        assert get_resp.json()["tree"]["active_branch_id"] == new_branch_id
+
+    def test_get_session_includes_analysis_result(self, client, csv_file):
+        create_resp = client.post(
+            "/demo/hypothesis-tree/sessions",
+            files={"file": ("test.csv", csv_file, "text/csv")},
+        )
+        data = create_resp.json()
+        sid = data["session_id"]
+        branch_id = data["tree"]["active_branch_id"]
+        
+        # 1. Answer start_goal
+        node_id = data["tree"]["root_node_id"]
+        resp = client.post(f"/demo/hypothesis-tree/sessions/{sid}/answers", json={
+            "parent_node_id": node_id, "option_id": "start_goal"
+        })
+        node_id = resp.json()["tree"]["branches"][branch_id]["node_ids"][-1]
+        
+        # 2. Answer goal_compare
+        resp = client.post(f"/demo/hypothesis-tree/sessions/{sid}/answers", json={
+            "parent_node_id": node_id, "option_id": "goal_compare"
+        })
+        node_id = resp.json()["tree"]["branches"][branch_id]["node_ids"][-1]
+        
+        # 3. Answer select_outcome -> col_blood_pressure
+        resp = client.post(f"/demo/hypothesis-tree/sessions/{sid}/answers", json={
+            "parent_node_id": node_id, "option_id": "col_blood_pressure"
+        })
+        node_id = resp.json()["tree"]["branches"][branch_id]["node_ids"][-1]
+        
+        # 4. Answer design_independent
+        resp = client.post(f"/demo/hypothesis-tree/sessions/{sid}/answers", json={
+            "parent_node_id": node_id, "option_id": "design_independent"
+        })
+        node_id = resp.json()["tree"]["branches"][branch_id]["node_ids"][-1]
+        
+        # 5. Answer select_group -> col_treatment
+        resp = client.post(f"/demo/hypothesis-tree/sessions/{sid}/answers", json={
+            "parent_node_id": node_id, "option_id": "col_treatment"
+        })
+        node_id = resp.json()["tree"]["branches"][branch_id]["node_ids"][-1]
+        
+        # 6. Answer group_count -> groups_two
+        resp = client.post(f"/demo/hypothesis-tree/sessions/{sid}/answers", json={
+            "parent_node_id": node_id, "option_id": "groups_two"
+        })
+        resp_data = resp.json()
+        
+        # Check that candidate hypotheses and analyses are returned
+        assert len(resp_data["candidate_hypotheses"]) > 0
+        assert len(resp_data["candidate_analyses"]) > 0
+        
+        hyp_id = resp_data["candidate_hypotheses"][0]["id"]
+        ana_id = resp_data["candidate_analyses"][0]["id"]
+        
+        # Run the analysis
+        run_resp = client.post(f"/demo/hypothesis-tree/sessions/{sid}/analyses", json={
+            "hypothesis_id": hyp_id,
+            "analysis_id": ana_id,
+        })
+        assert run_resp.status_code == 200
+        run_data = run_resp.json()
+        assert run_data["result"] is not None
+        assert run_data["result"]["hypothesis_id"] == hyp_id
+        
+        # Now fetch session via GET and verify analysis_result is present and correct
+        get_resp = client.get(f"/demo/hypothesis-tree/sessions/{sid}")
+        assert get_resp.status_code == 200
+        get_data = get_resp.json()
+        assert get_data["analysis_result"] is not None
+        assert get_data["analysis_result"]["test_used"] == run_data["result"]["test_used"]
+        assert get_data["analysis_result"]["hypothesis_id"] == hyp_id
+
+
+
+class TestAnswerSubmission:
+    def test_answer_advances_tree(self, client, csv_file):
+        # Create session
+        create_resp = client.post(
+            "/demo/hypothesis-tree/sessions",
+            files={"file": ("test.csv", csv_file, "text/csv")},
+        )
+        data = create_resp.json()
+        sid = data["session_id"]
+        root_node = data["tree"]["root_node_id"]
+
+        # Submit answer
+        ans_resp = client.post(
+            f"/demo/hypothesis-tree/sessions/{sid}/answers",
+            json={
+                "parent_node_id": root_node,
+                "option_id": "start_goal",
+            },
+        )
+        assert ans_resp.status_code == 200
+        ans_data = ans_resp.json()
+        # Tree should have more nodes now
+        assert len(ans_data["tree"]["nodes"]) > 1
+
+    def test_answer_to_invalid_session_fails(self, client):
+        resp = client.post(
+            "/demo/hypothesis-tree/sessions/nonexistent/answers",
+            json={"parent_node_id": "x", "option_id": "y"},
+        )
+        assert resp.status_code == 404
+
+
+class TestFork:
+    def test_fork_creates_new_branch(self, client, csv_file):
+        # Create and add an answer
+        create_resp = client.post(
+            "/demo/hypothesis-tree/sessions",
+            files={"file": ("test.csv", csv_file, "text/csv")},
+        )
+        data = create_resp.json()
+        sid = data["session_id"]
+        root_node = data["tree"]["root_node_id"]
+
+        # Add an answer
+        client.post(
+            f"/demo/hypothesis-tree/sessions/{sid}/answers",
+            json={"parent_node_id": root_node, "option_id": "start_goal"},
+        )
+
+        # Fork from root
+        fork_resp = client.post(
+            f"/demo/hypothesis-tree/sessions/{sid}/forks",
+            json={"node_id": root_node},
+        )
+        assert fork_resp.status_code == 200
+        fork_data = fork_resp.json()
+        assert "new_branch_id" in fork_data
+        assert len(fork_data["tree"]["branches"]) == 2
+
+
+class TestDeleteSession:
+    def test_delete_removes_session(self, client, csv_file):
+        create_resp = client.post(
+            "/demo/hypothesis-tree/sessions",
+            files={"file": ("test.csv", csv_file, "text/csv")},
+        )
+        sid = create_resp.json()["session_id"]
+
+        del_resp = client.delete(f"/demo/hypothesis-tree/sessions/{sid}")
+        assert del_resp.status_code == 200
+
+        # Should be gone
+        get_resp = client.get(f"/demo/hypothesis-tree/sessions/{sid}")
+        assert get_resp.status_code == 404
+
+    def test_delete_nonexistent_returns_404(self, client):
+        resp = client.delete("/demo/hypothesis-tree/sessions/nonexistent")
+        assert resp.status_code == 404
+
+
+class TestExistingEndpointsUnchanged:
+    """Verify that existing production endpoints are not broken."""
+
+    def test_health_endpoint_works(self, client):
+        resp = client.get("/health")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "healthy"

--- a/analytics-service/tests/test_demo_sessions.py
+++ b/analytics-service/tests/test_demo_sessions.py
@@ -1,0 +1,92 @@
+"""Tests for the demo session store."""
+
+import time
+import pandas as pd
+import pytest
+
+from app.models.demo_schemas import DatasetProfile, TreeState
+from app.services.demo_sessions import DemoSession, SessionStore
+
+
+@pytest.fixture
+def store():
+    return SessionStore(idle_timeout=2)  # 2-second timeout for fast tests
+
+
+@pytest.fixture
+def sample_df():
+    return pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]})
+
+
+@pytest.fixture
+def sample_profile():
+    return DatasetProfile(row_count=3, column_count=2, columns=[])
+
+
+@pytest.fixture
+def sample_tree():
+    return TreeState()
+
+
+class TestSessionStore:
+    def test_create_and_get(self, store, sample_df, sample_profile, sample_tree):
+        sid = store.create(sample_df, sample_profile, sample_tree)
+        assert sid
+        session = store.get(sid)
+        assert session is not None
+        assert session.session_id == sid
+        assert len(session.df) == 3
+
+    def test_unknown_session_returns_none(self, store):
+        assert store.get("nonexistent") is None
+
+    def test_session_isolation(self, store, sample_df, sample_profile, sample_tree):
+        sid1 = store.create(sample_df, sample_profile, sample_tree)
+        sid2 = store.create(sample_df, sample_profile, sample_tree)
+
+        assert sid1 != sid2
+        s1 = store.get(sid1)
+        s2 = store.get(sid2)
+        assert s1 is not s2
+
+    def test_delete_removes_session(self, store, sample_df, sample_profile, sample_tree):
+        sid = store.create(sample_df, sample_profile, sample_tree)
+        assert store.delete(sid) is True
+        assert store.get(sid) is None
+
+    def test_delete_nonexistent_returns_false(self, store):
+        assert store.delete("nonexistent") is False
+
+    def test_idle_expiry(self, store, sample_df, sample_profile, sample_tree):
+        sid = store.create(sample_df, sample_profile, sample_tree)
+        # Wait for expiry (2 second timeout)
+        time.sleep(2.5)
+        assert store.get(sid) is None
+
+    def test_touch_resets_expiry(self, store, sample_df, sample_profile, sample_tree):
+        sid = store.create(sample_df, sample_profile, sample_tree)
+        time.sleep(1)
+        # Access session to reset timer
+        session = store.get(sid)
+        assert session is not None
+        time.sleep(1)
+        # Should still be valid
+        session = store.get(sid)
+        assert session is not None
+
+    def test_update_tree(self, store, sample_df, sample_profile, sample_tree):
+        sid = store.create(sample_df, sample_profile, sample_tree)
+        new_tree = TreeState(active_branch_id="test_branch")
+        assert store.update_tree(sid, new_tree) is True
+        session = store.get(sid)
+        assert session.tree.active_branch_id == "test_branch"
+
+    def test_update_nonexistent_returns_false(self, store, sample_tree):
+        assert store.update_tree("nonexistent", sample_tree) is False
+
+    def test_list_sessions(self, store, sample_df, sample_profile, sample_tree):
+        sid1 = store.create(sample_df, sample_profile, sample_tree)
+        sid2 = store.create(sample_df, sample_profile, sample_tree)
+        sessions = store.list_sessions()
+        assert sid1 in sessions
+        assert sid2 in sessions

--- a/analytics-service/tests/test_hypothesis_tree.py
+++ b/analytics-service/tests/test_hypothesis_tree.py
@@ -1,0 +1,376 @@
+"""Tests for the hypothesis tree decision engine."""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from app.models.demo_schemas import (
+    ColumnType,
+    CandidateHypothesis,
+    NodeKind,
+    TreeState,
+    VariableRole,
+)
+from app.services.dataset_profiler import profile_dataset
+from app.services.hypothesis_tree import (
+    add_answer_node,
+    create_initial_tree,
+    fork_branch,
+    get_available_starts,
+    get_candidate_analyses,
+    get_candidate_hypotheses,
+    get_next_question,
+    validate_branch,
+)
+
+
+
+
+@pytest.fixture
+def clinical_df():
+    np.random.seed(42)
+    n = 60
+    return pd.DataFrame({
+        "patient_id": [f"P{i:03d}" for i in range(n)],
+        "treatment": np.random.choice(["Drug", "Placebo"], n),
+        "severity": np.random.choice(["Mild", "Moderate", "Severe"], n),
+        "age": np.random.normal(55, 10, n).round(1),
+        "blood_pressure_pre": np.random.normal(140, 15, n).round(1),
+        "blood_pressure_post": np.random.normal(130, 15, n).round(1),
+        "cholesterol": np.random.normal(200, 30, n).round(1),
+        "sex": np.random.choice(["M", "F"], n),
+    })
+
+
+@pytest.fixture
+def profile(clinical_df):
+    return profile_dataset(clinical_df)
+
+
+@pytest.fixture
+def tree():
+    return create_initial_tree()
+
+
+def _answer(tree, profile, branch_id, answer_text, option_id=None, context=None):
+    """Shorthand to add an answer to the tree."""
+    parent_id = tree.branches[branch_id].node_ids[-1]
+    q = get_next_question(profile, tree, branch_id)
+    ctx = context or {}
+    if q and q.category:
+        ctx[q.category] = option_id or answer_text
+    tree, node = add_answer_node(tree, branch_id, parent_id, answer_text, option_id, q, ctx)
+    return tree
+
+
+
+
+class TestQuestionGeneration:
+    def test_first_question_is_start_mode(self, profile, tree):
+        branch_id = tree.active_branch_id
+        q = get_next_question(profile, tree, branch_id)
+        assert q is not None
+        assert q.category == "start_mode"
+        assert len(q.options) == 4
+
+    def test_goal_question_after_start(self, profile, tree):
+        branch_id = tree.active_branch_id
+        tree = _answer(tree, profile, branch_id, "start_goal", "start_goal",
+                       {"start_mode": "start_goal"})
+        q = get_next_question(profile, tree, branch_id)
+        assert q is not None
+        assert q.category == "goal"
+
+    def test_outcome_question_after_compare_goal(self, profile, tree):
+        branch_id = tree.active_branch_id
+        tree = _answer(tree, profile, branch_id, "start_goal", "start_goal",
+                       {"start_mode": "start_goal"})
+        tree = _answer(tree, profile, branch_id, "goal_compare", "goal_compare",
+                       {"goal": "goal_compare"})
+        q = get_next_question(profile, tree, branch_id)
+        assert q is not None
+        assert "outcome" in q.category
+
+    def test_independent_design_asks_for_group(self, profile, tree):
+        branch_id = tree.active_branch_id
+        tree = _answer(tree, profile, branch_id, "start_goal", "start_goal",
+                       {"start_mode": "start_goal"})
+        tree = _answer(tree, profile, branch_id, "goal_compare", "goal_compare",
+                       {"goal": "goal_compare"})
+        tree = _answer(tree, profile, branch_id, "blood_pressure_pre", "col_blood_pressure_pre",
+                       {"select_outcome": "blood_pressure_pre", "outcome": "blood_pressure_pre"})
+        tree = _answer(tree, profile, branch_id, "design_independent", "design_independent",
+                       {"design": "design_independent"})
+        q = get_next_question(profile, tree, branch_id)
+        assert q is not None
+        assert "group" in q.category
+
+    def test_paired_design_asks_for_paired_column(self, profile, tree):
+        branch_id = tree.active_branch_id
+        tree = _answer(tree, profile, branch_id, "start_goal", "start_goal",
+                       {"start_mode": "start_goal"})
+        tree = _answer(tree, profile, branch_id, "goal_compare", "goal_compare",
+                       {"goal": "goal_compare"})
+        tree = _answer(tree, profile, branch_id, "blood_pressure_pre", "col_blood_pressure_pre",
+                       {"select_outcome": "blood_pressure_pre", "outcome": "blood_pressure_pre"})
+        tree = _answer(tree, profile, branch_id, "design_paired", "design_paired",
+                       {"design": "design_paired"})
+        q = get_next_question(profile, tree, branch_id)
+        assert q is not None
+        assert "paired" in q.category
+
+    def test_independent_never_asks_paired_questions(self, profile, tree):
+        """Selecting independent design must never ask paired-only questions."""
+        branch_id = tree.active_branch_id
+        tree = _answer(tree, profile, branch_id, "start_goal", "start_goal",
+                       {"start_mode": "start_goal"})
+        tree = _answer(tree, profile, branch_id, "goal_compare", "goal_compare",
+                       {"goal": "goal_compare"})
+        tree = _answer(tree, profile, branch_id, "blood_pressure_pre", "col_blood_pressure_pre",
+                       {"select_outcome": "blood_pressure_pre", "outcome": "blood_pressure_pre"})
+        tree = _answer(tree, profile, branch_id, "design_independent", "design_independent",
+                       {"design": "design_independent"})
+
+        # Walk remaining questions
+        for _ in range(10):
+            q = get_next_question(profile, tree, branch_id)
+            if q is None:
+                break
+            assert q.category != "select_paired", "Independent design should never ask for paired column"
+            # Auto-answer to progress
+            if q.options:
+                tree = _answer(tree, profile, branch_id, q.options[0].label,
+                               q.options[0].id, {q.category: q.options[0].id})
+            else:
+                break
+
+
+
+
+class TestForkBranch:
+    def test_fork_creates_sibling(self, profile, tree):
+        branch_id = tree.active_branch_id
+        tree = _answer(tree, profile, branch_id, "start_goal", "start_goal",
+                       {"start_mode": "start_goal"})
+        tree = _answer(tree, profile, branch_id, "goal_compare", "goal_compare",
+                       {"goal": "goal_compare"})
+
+        # Fork from the root
+        fork_node = tree.root_node_id
+        tree, new_branch_id = fork_branch(tree, fork_node)
+
+        assert new_branch_id != branch_id
+        assert new_branch_id in tree.branches
+        assert tree.active_branch_id == new_branch_id
+
+    def test_fork_preserves_original(self, profile, tree):
+        branch_id = tree.active_branch_id
+        tree = _answer(tree, profile, branch_id, "start_goal", "start_goal",
+                       {"start_mode": "start_goal"})
+
+        original_nodes = list(tree.branches[branch_id].node_ids)
+        fork_node = tree.root_node_id
+        tree, new_branch_id = fork_branch(tree, fork_node)
+
+        # Original branch still has its nodes
+        assert tree.branches[branch_id].node_ids == original_nodes
+
+    def test_fork_does_not_mutate_original_answers(self, profile, tree):
+        """Changing answers in one branch must not affect another."""
+        branch_id = tree.active_branch_id
+        tree = _answer(tree, profile, branch_id, "start_goal", "start_goal",
+                       {"start_mode": "start_goal"})
+        tree = _answer(tree, profile, branch_id, "goal_compare", "goal_compare",
+                       {"goal": "goal_compare"})
+
+        original_node_count = len(tree.branches[branch_id].node_ids)
+
+        # Fork
+        fork_node = tree.root_node_id
+        tree, new_branch_id = fork_branch(tree, fork_node)
+
+        # Add answer on new branch
+        tree = _answer(tree, profile, new_branch_id, "start_goal", "start_goal",
+                       {"start_mode": "start_goal"})
+        tree = _answer(tree, profile, new_branch_id, "goal_relationship", "goal_relationship",
+                       {"goal": "goal_relationship"})
+
+        # Original branch should NOT have new nodes
+        assert len(tree.branches[branch_id].node_ids) == original_node_count
+
+
+
+
+class TestHypothesisGeneration:
+    def test_two_group_hypothesis_generated(self, profile, tree):
+        branch_id = tree.active_branch_id
+        tree = _answer(tree, profile, branch_id, "start_goal", "start_goal",
+                       {"start_mode": "start_goal"})
+        tree = _answer(tree, profile, branch_id, "goal_compare", "goal_compare",
+                       {"goal": "goal_compare"})
+        tree = _answer(tree, profile, branch_id, "blood_pressure_pre", "col_blood_pressure_pre",
+                       {"select_outcome": "blood_pressure_pre", "outcome": "blood_pressure_pre"})
+        tree = _answer(tree, profile, branch_id, "design_independent", "design_independent",
+                       {"design": "design_independent"})
+        tree = _answer(tree, profile, branch_id, "treatment", "col_treatment",
+                       {"select_group": "treatment", "group": "treatment"})
+        tree = _answer(tree, profile, branch_id, "groups_two", "groups_two",
+                       {"group_count": "groups_two"})
+
+        hyps = get_candidate_hypotheses(profile, tree, branch_id)
+        assert len(hyps) >= 1
+        assert any("blood_pressure_pre" in h.statement for h in hyps)
+        assert any("treatment" in h.statement for h in hyps)
+
+    def test_hypotheses_have_null_and_alternative(self, profile, tree):
+        branch_id = tree.active_branch_id
+        tree = _answer(tree, profile, branch_id, "start_goal", "start_goal",
+                       {"start_mode": "start_goal"})
+        tree = _answer(tree, profile, branch_id, "goal_compare", "goal_compare",
+                       {"goal": "goal_compare"})
+        tree = _answer(tree, profile, branch_id, "blood_pressure_pre", "col_blood_pressure_pre",
+                       {"select_outcome": "blood_pressure_pre", "outcome": "blood_pressure_pre"})
+        tree = _answer(tree, profile, branch_id, "design_independent", "design_independent",
+                       {"design": "design_independent"})
+        tree = _answer(tree, profile, branch_id, "treatment", "col_treatment",
+                       {"select_group": "treatment", "group": "treatment"})
+        tree = _answer(tree, profile, branch_id, "groups_two", "groups_two",
+                       {"group_count": "groups_two"})
+
+        hyps = get_candidate_hypotheses(profile, tree, branch_id)
+        for h in hyps:
+            assert h.null_hypothesis
+            assert h.alternative_hypothesis
+
+
+
+
+class TestAnalysisAlternatives:
+    def _build_two_group_tree(self, profile, tree):
+        branch_id = tree.active_branch_id
+        tree = _answer(tree, profile, branch_id, "start_goal", "start_goal",
+                       {"start_mode": "start_goal"})
+        tree = _answer(tree, profile, branch_id, "goal_compare", "goal_compare",
+                       {"goal": "goal_compare"})
+        tree = _answer(tree, profile, branch_id, "blood_pressure_pre", "col_blood_pressure_pre",
+                       {"select_outcome": "blood_pressure_pre", "outcome": "blood_pressure_pre"})
+        tree = _answer(tree, profile, branch_id, "design_independent", "design_independent",
+                       {"design": "design_independent"})
+        tree = _answer(tree, profile, branch_id, "treatment", "col_treatment",
+                       {"select_group": "treatment", "group": "treatment"})
+        tree = _answer(tree, profile, branch_id, "groups_two", "groups_two",
+                       {"group_count": "groups_two"})
+        return tree
+
+    def test_two_group_offers_parametric_and_nonparametric(self, profile, tree):
+        tree = self._build_two_group_tree(profile, tree)
+        branch_id = tree.active_branch_id
+        hyps = get_candidate_hypotheses(profile, tree, branch_id)
+        assert len(hyps) >= 1
+
+        analyses = get_candidate_analyses(profile, hyps[0], tree, branch_id)
+        test_names = [a.test_name for a in analyses]
+        assert "independent_ttest" in test_names
+        assert "mann_whitney_u" in test_names
+
+    def test_analyses_include_tradeoffs(self, profile, tree):
+        tree = self._build_two_group_tree(profile, tree)
+        branch_id = tree.active_branch_id
+        hyps = get_candidate_hypotheses(profile, tree, branch_id)
+        analyses = get_candidate_analyses(profile, hyps[0], tree, branch_id)
+
+        for a in analyses:
+            assert len(a.tradeoffs) > 0
+
+    def test_one_analysis_is_suggested(self, profile, tree):
+        tree = self._build_two_group_tree(profile, tree)
+        branch_id = tree.active_branch_id
+        hyps = get_candidate_hypotheses(profile, tree, branch_id)
+        analyses = get_candidate_analyses(profile, hyps[0], tree, branch_id)
+
+        suggested = [a for a in analyses if a.is_suggested]
+        assert len(suggested) >= 1
+
+    def test_non_normal_suggests_non_parametric(self, profile, tree):
+        # Set the normality hint to non-normal for the outcome column
+        for col in profile.columns:
+            if col.name == "blood_pressure_pre":
+                col.normality_hint = "likely_non_normal"
+        
+        tree = self._build_two_group_tree(profile, tree)
+        branch_id = tree.active_branch_id
+        hyps = get_candidate_hypotheses(profile, tree, branch_id)
+        analyses = get_candidate_analyses(profile, hyps[0], tree, branch_id)
+
+        t_test = next(a for a in analyses if a.test_name == "independent_ttest")
+        mw_u = next(a for a in analyses if a.test_name == "mann_whitney_u")
+
+        assert mw_u.is_suggested is True
+        assert t_test.is_suggested is False
+        assert mw_u.suggestion_reason is not None
+        assert "non-normally distributed" in mw_u.suggestion_reason
+
+
+
+
+class TestBranchValidation:
+    def test_valid_branch(self, profile, tree):
+        branch_id = tree.active_branch_id
+        validation = validate_branch(profile, tree, branch_id)
+        assert validation.is_valid
+
+    def test_missing_column_contradiction(self, profile, tree):
+        branch_id = tree.active_branch_id
+        tree = _answer(tree, profile, branch_id, "start_goal", "start_goal",
+                       {"start_mode": "start_goal"})
+        tree = _answer(tree, profile, branch_id, "goal_compare", "goal_compare",
+                       {"goal": "goal_compare"})
+        tree = _answer(tree, profile, branch_id, "nonexistent_column", None,
+                       {"outcome": "nonexistent_column"})
+
+        validation = validate_branch(profile, tree, branch_id)
+        assert not validation.is_valid
+        assert len(validation.contradictions) > 0
+
+
+
+
+class TestFollowUpQuestions:
+    def test_followup_covariate_asks_for_covariate_column(self, profile, tree):
+        branch_id = tree.active_branch_id
+        # Build 2-group tree
+        tree = _answer(tree, profile, branch_id, "start_goal", "start_goal", {"start_mode": "start_goal"})
+        tree = _answer(tree, profile, branch_id, "goal_compare", "goal_compare", {"goal": "goal_compare"})
+        tree = _answer(tree, profile, branch_id, "blood_pressure_pre", "col_blood_pressure_pre", {"outcome": "blood_pressure_pre"})
+        tree = _answer(tree, profile, branch_id, "design_independent", "design_independent", {"design": "design_independent"})
+        tree = _answer(tree, profile, branch_id, "treatment", "col_treatment", {"group": "treatment"})
+        tree = _answer(tree, profile, branch_id, "groups_two", "groups_two", {"group_count": "groups_two"})
+        
+        # Add follow-up answer: followup_covariate
+        tree = _answer(tree, profile, branch_id, "Add a covariate and re-analyze", "followup_covariate")
+        
+        q = get_next_question(profile, tree, branch_id)
+        assert q is not None
+        assert q.category == "select_covariate"
+        assert "covariate" in q.prompt.lower()
+
+
+    def test_followup_nonparametric_promotes_mann_whitney(self, profile, tree):
+        branch_id = tree.active_branch_id
+        tree = _answer(tree, profile, branch_id, "start_goal", "start_goal", {"start_mode": "start_goal"})
+        tree = _answer(tree, profile, branch_id, "goal_compare", "goal_compare", {"goal": "goal_compare"})
+        tree = _answer(tree, profile, branch_id, "blood_pressure_pre", "col_blood_pressure_pre", {"outcome": "blood_pressure_pre"})
+        tree = _answer(tree, profile, branch_id, "design_independent", "design_independent", {"design": "design_independent"})
+        tree = _answer(tree, profile, branch_id, "treatment", "col_treatment", {"group": "treatment"})
+        tree = _answer(tree, profile, branch_id, "groups_two", "groups_two", {"group_count": "groups_two"})
+        
+        # Add follow-up answer: followup_nonparametric
+        tree = _answer(tree, profile, branch_id, "Compare with a non-parametric alternative", "followup_nonparametric")
+        
+        hyps = get_candidate_hypotheses(profile, tree, branch_id)
+        analyses = get_candidate_analyses(profile, hyps[0], tree, branch_id)
+        
+        mw_u = next(a for a in analyses if a.test_name == "mann_whitney_u")
+        assert mw_u.is_suggested is True
+        assert "non-parametric alternative requested" in mw_u.suggestion_reason
+

--- a/analytics-service/tests/test_hypothesis_tree.py
+++ b/analytics-service/tests/test_hypothesis_tree.py
@@ -310,6 +310,111 @@ class TestAnalysisAlternatives:
         assert mw_u.suggestion_reason is not None
         assert "non-normally distributed" in mw_u.suggestion_reason
 
+    def test_approx_normal_suggests_parametric_ttest(self, profile, tree):
+        # Even with mild skewness (|skew| <= 1.0) and normality_hint="appears_normal", suggest parametric
+        for col in profile.columns:
+            if col.name == "blood_pressure_pre":
+                col.normality_hint = "appears_normal"
+                col.skewness = 0.6
+                col.kurtosis = 2.2
+
+        tree = self._build_two_group_tree(profile, tree)
+        branch_id = tree.active_branch_id
+        hyps = get_candidate_hypotheses(profile, tree, branch_id)
+        analyses = get_candidate_analyses(profile, hyps[0], tree, branch_id)
+
+        t_test = next(a for a in analyses if a.test_name == "independent_ttest")
+        mw_u = next(a for a in analyses if a.test_name == "mann_whitney_u")
+
+        assert t_test.is_suggested is True
+        assert mw_u.is_suggested is False
+
+    def test_multi_group_normal_suggests_anova(self, profile, tree):
+        for col in profile.columns:
+            if col.name == "blood_pressure_pre":
+                col.normality_hint = "appears_normal"
+                col.skewness = 0.1
+                col.kurtosis = 0.0
+
+        branch_id = tree.active_branch_id
+        tree = _answer(tree, profile, branch_id, "start_goal", "start_goal", {"start_mode": "start_goal"})
+        tree = _answer(tree, profile, branch_id, "goal_compare", "goal_compare", {"goal": "goal_compare"})
+        tree = _answer(tree, profile, branch_id, "blood_pressure_pre", "col_blood_pressure_pre",
+                       {"select_outcome": "blood_pressure_pre", "outcome": "blood_pressure_pre"})
+        tree = _answer(tree, profile, branch_id, "design_independent", "design_independent",
+                       {"design": "design_independent"})
+        tree = _answer(tree, profile, branch_id, "treatment", "col_treatment",
+                       {"select_group": "treatment", "group": "treatment"})
+        tree = _answer(tree, profile, branch_id, "groups_multi", "groups_multi",
+                       {"group_count": "groups_multi"})
+
+        hyps = get_candidate_hypotheses(profile, tree, branch_id)
+        analyses = get_candidate_analyses(profile, hyps[0], tree, branch_id)
+
+        anova = next(a for a in analyses if a.test_name == "one_way_anova")
+        kruskal = next(a for a in analyses if a.test_name == "kruskal_wallis")
+
+        assert anova.is_suggested is True
+        assert kruskal.is_suggested is False
+
+    def test_multi_group_non_normal_suggests_kruskal(self, profile, tree):
+        for col in profile.columns:
+            if col.name == "blood_pressure_pre":
+                col.normality_hint = "likely_non_normal"
+
+        branch_id = tree.active_branch_id
+        tree = _answer(tree, profile, branch_id, "start_goal", "start_goal", {"start_mode": "start_goal"})
+        tree = _answer(tree, profile, branch_id, "goal_compare", "goal_compare", {"goal": "goal_compare"})
+        tree = _answer(tree, profile, branch_id, "blood_pressure_pre", "col_blood_pressure_pre",
+                       {"select_outcome": "blood_pressure_pre", "outcome": "blood_pressure_pre"})
+        tree = _answer(tree, profile, branch_id, "design_independent", "design_independent",
+                       {"design": "design_independent"})
+        tree = _answer(tree, profile, branch_id, "treatment", "col_treatment",
+                       {"select_group": "treatment", "group": "treatment"})
+        tree = _answer(tree, profile, branch_id, "groups_multi", "groups_multi",
+                       {"group_count": "groups_multi"})
+
+        hyps = get_candidate_hypotheses(profile, tree, branch_id)
+        analyses = get_candidate_analyses(profile, hyps[0], tree, branch_id)
+
+        anova = next(a for a in analyses if a.test_name == "one_way_anova")
+        kruskal = next(a for a in analyses if a.test_name == "kruskal_wallis")
+
+        assert anova.is_suggested is False
+        assert kruskal.is_suggested is True
+
+    def test_large_dataset_suggests_independent_ttest(self, tree):
+        np.random.seed(42)
+        n = 10000
+        df = pd.DataFrame({
+            "weight": np.concatenate([np.random.normal(180, 20, 5000), np.random.normal(140, 15, 5000)]),
+            "sex": ["M"] * 5000 + ["F"] * 5000,
+        })
+        large_profile = profile_dataset(df)
+
+        branch_id = tree.active_branch_id
+        tree = _answer(tree, large_profile, branch_id, "start_goal", "start_goal", {"start_mode": "start_goal"})
+        tree = _answer(tree, large_profile, branch_id, "goal_compare", "goal_compare", {"goal": "goal_compare"})
+        tree = _answer(tree, large_profile, branch_id, "weight", "col_weight",
+                       {"select_outcome": "weight", "outcome": "weight"})
+        tree = _answer(tree, large_profile, branch_id, "design_independent", "design_independent",
+                       {"design": "design_independent"})
+        tree = _answer(tree, large_profile, branch_id, "sex", "col_sex",
+                       {"select_group": "sex", "group": "sex"})
+        tree = _answer(tree, large_profile, branch_id, "groups_two", "groups_two",
+                       {"group_count": "groups_two"})
+
+        hyps = get_candidate_hypotheses(large_profile, tree, branch_id)
+        analyses = get_candidate_analyses(large_profile, hyps[0], tree, branch_id)
+
+        t_test = next(a for a in analyses if a.test_name == "independent_ttest")
+        mw_u = next(a for a in analyses if a.test_name == "mann_whitney_u")
+
+        assert t_test.is_suggested is True
+        assert mw_u.is_suggested is False
+        assert "Standard parametric test" in t_test.suggestion_reason
+        assert "Levene's test" in t_test.suggestion_reason
+
 
 
 

--- a/analytics-service/tests/test_infer_endpoint.py
+++ b/analytics-service/tests/test_infer_endpoint.py
@@ -64,6 +64,16 @@ def _one_sample_csv(n=50, mean=110, std=10, seed=42):
     return buf.getvalue()
 
 
+def _chi_square_csv():
+    df = pd.DataFrame({
+        "treatment": ["Yes", "Yes", "No", "No"] * 25,
+        "recovered": ["Yes", "No", "Yes", "No"] * 25
+    })
+    buf = io.BytesIO()
+    df.to_csv(buf, index=False)
+    return buf.getvalue()
+
+
 @pytest_asyncio.fixture
 async def client():
     transport = ASGITransport(app=app)
@@ -421,31 +431,40 @@ class TestValidation:
         assert resp.status_code == 200
 
     @pytest.mark.asyncio
-    async def test_unsupported_test_type_chi_square(self, client):
+    async def test_chi_square_endpoint(self, client):
         resp = await client.post(
             "/analytics/infer",
             data={
                 **_auth_form(nonce=31),
                 "test_type": "chi_square",
-                "numeric_column": "score",
+                "test_subtype": "independence",
+                "column_1": "treatment",
+                "column_2": "recovered",
             },
-            files={"file": ("data.csv", _two_group_csv(), "text/csv")},
+            files={"file": ("data.csv", _chi_square_csv(), "text/csv")},
         )
-        assert resp.status_code == 400
-        assert "not yet implemented" in resp.json()["detail"].lower()
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["test_used"] == "chi_square_independence"
+        assert "contingency_table" in body
 
     @pytest.mark.asyncio
-    async def test_unsupported_test_type_correlation(self, client):
+    async def test_correlation_endpoint(self, client):
         resp = await client.post(
             "/analytics/infer",
             data={
                 **_auth_form(nonce=32),
                 "test_type": "correlation",
-                "numeric_column": "score",
+                "test_subtype": "pearson",
+                "column_1": "before",
+                "column_2": "after",
             },
-            files={"file": ("data.csv", _two_group_csv(), "text/csv")},
+            files={"file": ("data.csv", _paired_csv(), "text/csv")},
         )
-        assert resp.status_code == 400
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["test_used"] == "pearson"
+        assert "confidence_interval" in body
 
     @pytest.mark.asyncio
     async def test_invalid_subtype(self, client):


### PR DESCRIPTION
## Week 8b — Dataset Profiler, ANCOVA & Follow-up Enhancements

### Summary

Adds the dataset profiler, ANCOVA support, and subgroup analysis to the inferential engine. Stacks on top of Week 8a (Hypothesis Tree core engine).

### What's New

**Dataset Profiler** (`dataset_profiler.py`)
- Auto-detects column types (numeric, categorical, datetime, identifier)
- Computes distribution stats (mean, median, skewness, kurtosis, normality hints)
- Suggests variable roles (outcome, group, subject, time) from column names
- Flags data issues (missingness, small samples, constant columns, duplicates)

**Inferential Enhancements** (`inferential.py`)
- `force_test` param on `run_two_group_test` — lets the tree engine force Mann-Whitney after non-parametric follow-up
- `run_ancova` — group comparison controlling for a numeric covariate (OLS-based)
- `run_subgroup_analysis` — 2-way ANOVA for interaction effects

### Tests
- 13 profiler tests covering type detection, role suggestions, and data warnings
- All 321 tests pass


