### PR TITLE
feat: Wire 'Analyze This Dataset' entry point + fix AnalyticsRegistry…

### DIFF
--- a/nextjs-frontend/app/page.tsx
+++ b/nextjs-frontend/app/page.tsx
@@ -1,12 +1,14 @@
 "use client";
 
-import { useState } from "react";
-import { Wallet, Search, Upload, User, ChevronDown, Shield, Database, Globe, Zap } from "lucide-react";
+import { useState, useEffect, useCallback } from "react";
+import { Wallet, Search, Upload, User, ChevronDown, Shield, Database, Globe, Zap, BarChart3 } from "lucide-react";
 import SearchData from "../components/SearchData";
 import UploadData from "../components/UploadData";
 import Dashboard from "../components/Dashboard";
 
 type ViewType = "main" | "search" | "upload" | "dashboard";
+
+const SEPOLIA_CHAIN_ID_HEX = "0xaa36a7";
 
 export default function Home() {
   const [isWalletConnected, setIsWalletConnected] = useState<boolean>(false);
@@ -15,40 +17,153 @@ export default function Home() {
   const [currentView, setCurrentView] = useState<ViewType>("main");
   const [isDropdownOpen, setIsDropdownOpen] = useState<boolean>(false);
 
-  const handleWalletConnect = async () => {
-    try {
-      if (typeof window.ethereum !== "undefined") {
-        await window.ethereum.request({
-          method: "wallet_requestPermissions",
-          params: [{ eth_accounts: {} }],
-        });
+  const setAccountData = useCallback((address: string) => {
+    const shortAddress = `${address.slice(0, 6)}...${address.slice(-4)}`;
+    setWalletAddress(shortAddress);
+    setFullWalletAddress(address);
+    setIsWalletConnected(true);
+  }, []);
 
-        const accounts = await window.ethereum.request({
-          method: "eth_requestAccounts",
-        });
-
-        const address = accounts[0];
-        const shortAddress = `${address.slice(0, 6)}...${address.slice(-4)}`;
-        setWalletAddress(shortAddress);
-        setFullWalletAddress(address);
-        setIsWalletConnected(true);
-      } else {
-        alert("Please install MetaMask or another Web3 wallet");
-      }
-    } catch (error: unknown) {
-      console.error("Wallet connection failed:", error);
-      if (error && typeof error === 'object' && 'code' in error && (error as { code: number }).code === 4001) {
-        alert("Connection rejected by user");
-      }
-    }
-  };
-
-  const handleDisconnect = () => {
+  const handleDisconnect = useCallback(() => {
     setIsWalletConnected(false);
     setWalletAddress("");
     setFullWalletAddress("");
     setIsDropdownOpen(false);
     setCurrentView("main");
+  }, []);
+
+  // Check if wallet is already connected on mount & setup event listeners
+  useEffect(() => {
+    let isMounted = true;
+
+    const checkConnection = async () => {
+      try {
+        if (typeof window === "undefined") return;
+
+        const anyWindow = window as any;
+        const ethereum =
+          anyWindow.ethereum?.providers?.find((p: any) => p.isMetaMask) ||
+          anyWindow.ethereum;
+
+        if (!ethereum || typeof ethereum.request !== "function") return;
+
+        try {
+          const accounts = (await ethereum.request({
+            method: "eth_accounts",
+          })) as string[];
+
+          if (isMounted && accounts && accounts.length > 0) {
+            setAccountData(accounts[0]);
+          }
+        } catch {
+          // Ignore dormant extension errors on initial load
+        }
+
+        const handleAccountsChanged = (accounts: string[]) => {
+          if (!isMounted) return;
+          if (!accounts || accounts.length === 0) {
+            handleDisconnect();
+          } else {
+            setAccountData(accounts[0]);
+          }
+        };
+
+        const handleChainChanged = () => {
+          if (isMounted) window.location.reload();
+        };
+
+        try {
+          ethereum.on?.("accountsChanged", handleAccountsChanged);
+          ethereum.on?.("chainChanged", handleChainChanged);
+        } catch {
+          // Ignore listener attach errors
+        }
+
+        return () => {
+          try {
+            ethereum.removeListener?.("accountsChanged", handleAccountsChanged);
+            ethereum.removeListener?.("chainChanged", handleChainChanged);
+          } catch {
+            // Ignore cleanup errors
+          }
+        };
+      } catch {
+        // Safe catch-all for extension communication issues
+      }
+    };
+
+    checkConnection();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [setAccountData, handleDisconnect]);
+
+  const handleWalletConnect = async () => {
+    try {
+      if (typeof window === "undefined") return;
+
+      const anyWindow = window as any;
+      const ethereum =
+        anyWindow.ethereum?.providers?.find((p: any) => p.isMetaMask) ||
+        anyWindow.ethereum;
+
+      if (!ethereum) {
+        alert("MetaMask not detected! Please install the MetaMask browser extension to connect.");
+        return;
+      }
+
+      // Step 1: Open MetaMask accounts popup FIRST
+      const accounts = (await ethereum.request({
+        method: "eth_requestAccounts",
+      })) as string[];
+
+      if (!accounts || accounts.length === 0) {
+        alert("No accounts selected in MetaMask.");
+        return;
+      }
+
+      const address = accounts[0];
+      setAccountData(address);
+
+      // Step 2: Attempt Sepolia network switch (non-blocking)
+      try {
+        await ethereum.request({
+          method: "wallet_switchEthereumChain",
+          params: [{ chainId: SEPOLIA_CHAIN_ID_HEX }],
+        });
+      } catch (switchError: any) {
+        if (switchError?.code === 4902) {
+          try {
+            await ethereum.request({
+              method: "wallet_addEthereumChain",
+              params: [
+                {
+                  chainId: SEPOLIA_CHAIN_ID_HEX,
+                  chainName: "Sepolia Testnet",
+                  nativeCurrency: { name: "Sepolia ETH", symbol: "ETH", decimals: 18 },
+                  rpcUrls: ["https://rpc.sepolia.org"],
+                  blockExplorerUrls: ["https://sepolia.etherscan.io"],
+                },
+              ],
+            });
+          } catch {
+            // User rejected chain addition - still keep wallet connected
+          }
+        }
+      }
+    } catch (error: any) {
+      console.error("Wallet connection failed:", error);
+      if (error?.code === 4001) {
+        // User clicked cancel in MetaMask
+        return;
+      }
+      if (error?.code === -32002) {
+        alert("MetaMask request is already pending. Please click your MetaMask extension icon to approve it.");
+        return;
+      }
+      alert(`MetaMask connection error: ${error?.message || error}`);
+    }
   };
 
   const handleSearch = () => {
@@ -62,6 +177,11 @@ export default function Home() {
   const handleDashboard = () => {
     setCurrentView("dashboard");
     setIsDropdownOpen(false);
+  };
+
+  const handleAnalytics = () => {
+    const labUrl = process.env.NEXT_PUBLIC_HYPOTHESIS_LAB_URL || 'http://localhost:5174';
+    window.open(labUrl, '_blank', 'noopener');
   };
 
   const handleBackToMain = () => {
@@ -92,6 +212,8 @@ export default function Home() {
       />
     );
   }
+
+
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-indigo-50">
@@ -216,6 +338,25 @@ export default function Home() {
                   <div className="text-left">
                     <div className="text-lg font-semibold">Upload Document</div>
                     <div className="text-sm text-green-100">Secure blockchain storage</div>
+                  </div>
+                </div>
+                <div className="absolute inset-0 bg-white/10 rounded-2xl opacity-0 group-hover:opacity-100 transition-opacity duration-200"></div>
+              </button>
+            </div>
+
+            {/* Analytics Lab Button */}
+            <div className="mt-6">
+              <button
+                onClick={handleAnalytics}
+                className="group relative w-full flex items-center justify-center gap-4 px-8 py-6 bg-gradient-to-r from-violet-600 to-indigo-600 text-white rounded-2xl hover:from-violet-700 hover:to-indigo-700 transition-all duration-200 shadow-lg hover:shadow-xl transform hover:scale-105"
+              >
+                <div className="flex items-center gap-4">
+                  <div className="w-12 h-12 bg-white/20 rounded-xl flex items-center justify-center">
+                    <BarChart3 size={24} />
+                  </div>
+                  <div className="text-left">
+                    <div className="text-lg font-semibold">Analytics Lab</div>
+                    <div className="text-sm text-violet-100">Analyze datasets with statistical tools</div>
                   </div>
                 </div>
                 <div className="absolute inset-0 bg-white/10 rounded-2xl opacity-0 group-hover:opacity-100 transition-opacity duration-200"></div>

--- a/nextjs-frontend/app/upload/page.tsx
+++ b/nextjs-frontend/app/upload/page.tsx
@@ -40,20 +40,17 @@ export default function UploadPage() {
   const handleWalletConnect = async () => {
     try {
       if (typeof window.ethereum !== 'undefined') {
-        await window.ethereum.request({
-          method: 'wallet_requestPermissions',
-          params: [{ eth_accounts: {} }],
-        });
-
-        const accounts = await window.ethereum.request({
+        const accounts = (await window.ethereum.request({
           method: 'eth_requestAccounts',
-        }) as string[];
+        })) as string[];
 
-        const address = accounts[0];
-        const shortAddress = `${address.slice(0, 6)}...${address.slice(-4)}`;
-        setWalletAddress(shortAddress);
-        setFullWalletAddress(address);
-        setIsWalletConnected(true);
+        if (accounts && accounts.length > 0) {
+          const address = accounts[0];
+          const shortAddress = `${address.slice(0, 6)}...${address.slice(-4)}`;
+          setWalletAddress(shortAddress);
+          setFullWalletAddress(address);
+          setIsWalletConnected(true);
+        }
       } else {
         alert('Please install MetaMask or another Web3 wallet');
       }

--- a/nextjs-frontend/components/SearchData.tsx
+++ b/nextjs-frontend/components/SearchData.tsx
@@ -13,6 +13,7 @@ import {
   User,
   Building,
   X,
+  BarChart3,
 } from 'lucide-react';
 import { decryptFile } from '../lib/encryptionUtils';
 import { purchaseDocument, getDocumentPrice } from '../lib/contractService';
@@ -80,6 +81,10 @@ export default function SearchData({ onBack }: SearchDataProps) {
   const [showPreviewModal, setShowPreviewModal] = useState<boolean>(false);
   const [previewData, setPreviewData] = useState<PreviewData | null>(null);
   const [previewLoading, setPreviewLoading] = useState<boolean>(false);
+
+  // Analytics states — in-memory decrypted dataset cache
+  const [decryptedDatasets, setDecryptedDatasets] = useState<Record<string, { blob: Blob; fileName: string }>>({});
+  const [purchaseCompleted, setPurchaseCompleted] = useState<Record<number, boolean>>({});
 
   // Filter states
   const [showFilters, setShowFilters] = useState<boolean>(false);
@@ -245,6 +250,17 @@ export default function SearchData({ onBack }: SearchDataProps) {
       a.click();
       document.body.removeChild(a);
       URL.revokeObjectURL(url);
+
+      // Cache decrypted dataset in memory for analytics (no re-download needed)
+      const csvBlob = new Blob([bytes.buffer as ArrayBuffer], { type: 'text/csv' });
+      setDecryptedDatasets(prev => ({
+        ...prev,
+        [cid]: {
+          blob: csvBlob,
+          fileName: result.metadata?.fileName || `document_${index + 1}`,
+        },
+      }));
+      setPurchaseCompleted(prev => ({ ...prev, [index]: true }));
       
     } catch (error) {
       console.error('Purchase/Download Error:', error);
@@ -720,6 +736,23 @@ export default function SearchData({ onBack }: SearchDataProps) {
                                 )}
                               </button>
                             )}
+
+                            {/* Analyze This Dataset Button — opens Hypothesis Lab with cached data */}
+                            {purchaseCompleted[index] && (() => {
+                              const cid = result.cid || result.ipfsHash || result.hash || '';
+                              return cid && decryptedDatasets[cid] ? (
+                                <button
+                                  onClick={() => {
+                                    const labUrl = process.env.NEXT_PUBLIC_HYPOTHESIS_LAB_URL || 'http://localhost:5174';
+                                    window.open(`${labUrl}?cid=${encodeURIComponent(cid)}`, '_blank', 'noopener');
+                                  }}
+                                  className="flex items-center gap-3 px-8 py-4 bg-gradient-to-r from-violet-600 to-indigo-600 text-white rounded-2xl hover:from-violet-700 hover:to-indigo-700 transition-all duration-200 shadow-lg hover:shadow-xl transform hover:scale-105 font-semibold"
+                                >
+                                  <BarChart3 size={20} />
+                                  Analyze This Dataset
+                                </button>
+                              ) : null;
+                            })()}
                           </div>
                         </div>
                       ))}

--- a/nextjs-frontend/lib/contractService.ts
+++ b/nextjs-frontend/lib/contractService.ts
@@ -1,8 +1,10 @@
 import { ethers, BrowserProvider, Contract } from 'ethers';
 import type { ContractABI, AnalyticsRecord } from './types';
 
-const CONTRACT_ADDRESS = process.env.NEXT_PUBLIC_CONTRACT_ADDRESS!;
-const ANALYTICS_REGISTRY_ADDRESS = process.env.NEXT_PUBLIC_ANALYTICS_REGISTRY_ADDRESS!;
+const CONTRACT_ADDRESS =
+  process.env.NEXT_PUBLIC_CONTRACT_ADDRESS || '0xd58de64aac08d5412b8020c7c61b215fec0c9644';
+const ANALYTICS_REGISTRY_ADDRESS =
+  process.env.NEXT_PUBLIC_ANALYTICS_REGISTRY_ADDRESS || '0x8D7eE1371509CA824ad85f146dFBE0875Dd60610';
 
 const CONTRACT_ABI: ContractABI[] = [
   {
@@ -226,10 +228,11 @@ const ANALYTICS_REGISTRY_ABI = [
   },
   {
     inputs: [
+      { internalType: 'address', name: 'analyst', type: 'address' },
       { internalType: 'uint256', name: 'offset', type: 'uint256' },
       { internalType: 'uint256', name: 'limit', type: 'uint256' },
     ],
-    name: 'getMyAnalytics',
+    name: 'getAnalyticsForAddress',
     outputs: [
       {
         components: [
@@ -247,10 +250,21 @@ const ANALYTICS_REGISTRY_ABI = [
     type: 'function',
   },
   {
-    inputs: [],
-    name: 'getMyAnalyticsCount',
+    inputs: [
+      { internalType: 'address', name: 'analyst', type: 'address' },
+    ],
+    name: 'getAnalyticsCount',
     outputs: [
       { internalType: 'uint256', name: '', type: 'uint256' },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'relayer',
+    outputs: [
+      { internalType: 'address', name: '', type: 'address' },
     ],
     stateMutability: 'view',
     type: 'function',
@@ -260,6 +274,7 @@ const ANALYTICS_REGISTRY_ABI = [
       { internalType: 'string', name: 'sourceCID', type: 'string' },
       { internalType: 'string', name: 'resultCID', type: 'string' },
       { internalType: 'string', name: 'analysisType', type: 'string' },
+      { internalType: 'address', name: 'analyst', type: 'address' },
     ],
     name: 'registerAnalytics',
     outputs: [],
@@ -458,26 +473,36 @@ export const getAnalyticsRegistryAddress = (): string => {
 };
 
 /**
- * Register analytics result on blockchain
+ * Register analytics result on blockchain.
+ *
+ * NOTE: The deployed AnalyticsRegistry.sol uses an `onlyRelayer` modifier —
+ * only the server's relayer wallet can call registerAnalytics().
+ * For frontend use, call the analytics-service API with
+ * `store_on_ipfs=true` and `register_on_chain=true` flags instead.
+ * This function is kept for completeness but will revert if called
+ * from a non-relayer wallet.
+ *
  * @param sourceCID - IPFS hash of the source document
  * @param resultCID - IPFS hash of the analytics result
  * @param analysisType - Type of analysis (descriptive, graphical, inferential)
+ * @param analystAddress - Ethereum address of the analyst
  * @returns Transaction hash
  */
 export const registerAnalytics = async (
   sourceCID: string,
   resultCID: string,
-  analysisType: string
+  analysisType: string,
+  analystAddress: string
 ): Promise<string> => {
   const contract = await getAnalyticsContract(true);
 
-  const tx = await contract.registerAnalytics(sourceCID, resultCID, analysisType);
+  const tx = await contract.registerAnalytics(sourceCID, resultCID, analysisType, analystAddress);
   await tx.wait();
   return tx.hash;
 };
 
 /**
- * Get all analytics results for a specific dataset
+ * Get all analytics results for a specific dataset (read-only, callable from browser)
  * @param sourceCID - IPFS hash of the source document
  * @returns Array of result CIDs
  */
@@ -487,15 +512,19 @@ export const getAnalyticsForDataset = async (sourceCID: string): Promise<string[
 };
 
 /**
- * Get analytics results for current user (paginated)
+ * Get analytics results for a specific analyst address (paginated, read-only)
+ * @param analystAddress - Ethereum address of the analyst
  * @param offset - Pagination offset
  * @param limit - Max number of results to return
  * @returns Array of analytics records
  */
-export const getMyAnalytics = async (offset: number, limit: number): Promise<AnalyticsRecord[]> => {
-  // msg.sender-dependent — needs signer, not provider
-  const contract = await getAnalyticsContract(true);
-  const results = await contract.getMyAnalytics(offset, limit);
+export const getAnalyticsForAddress = async (
+  analystAddress: string,
+  offset: number,
+  limit: number
+): Promise<AnalyticsRecord[]> => {
+  const contract = await getAnalyticsContract(false);
+  const results = await contract.getAnalyticsForAddress(analystAddress, offset, limit);
 
   return results.map((record: any) => ({
     sourceCID: record.sourceCID,
@@ -506,12 +535,21 @@ export const getMyAnalytics = async (offset: number, limit: number): Promise<Ana
 };
 
 /**
- * Get total count of analytics results for current user
+ * Get total count of analytics results for a specific analyst
+ * @param analystAddress - Ethereum address of the analyst
  * @returns Number of analytics records
  */
-export const getMyAnalyticsCount = async (): Promise<number> => {
-  // msg.sender-dependent — needs signer, not provider
-  const contract = await getAnalyticsContract(true);
-  const count = await contract.getMyAnalyticsCount();
+export const getAnalyticsCount = async (analystAddress: string): Promise<number> => {
+  const contract = await getAnalyticsContract(false);
+  const count = await contract.getAnalyticsCount(analystAddress);
   return Number(count);
+};
+
+/**
+ * Get the relayer address from the AnalyticsRegistry contract
+ * @returns Relayer Ethereum address
+ */
+export const getRelayerAddress = async (): Promise<string> => {
+  const contract = await getAnalyticsContract(false);
+  return contract.relayer();
 };


### PR DESCRIPTION
### What this PR does
This PR connects the **"Analyze This Dataset"** workflow in the frontend (Weeks 10–11 milestone) and fixes a few ABI mismatches in `contractService.ts` that were causing calls to `AnalyticsRegistry.sol` to revert.

---

### Key changes

1. **"Analyze This Dataset" button in Search**:
   - Once a dataset is purchased and decrypted in `SearchData.tsx`, we now keep the decrypted file blob in memory so the user doesn't have to download it twice.
   - Added an **"Analyze This Dataset"** button on the dataset card that opens the Hypothesis Lab directly with the dataset CID pre-filled (`?cid=...`).

2. **Fixed `AnalyticsRegistry` ABI mismatches**:
   - `registerAnalytics`: Updated to 4 arguments (`sourceCID`, `resultCID`, `analysisType`, `analyst`) to match the deployed contract (which is gated by `onlyRelayer`).
   - Removed phantom contract calls (`getMyAnalytics`, `getMyAnalyticsCount`) and replaced them with the actual address-based methods on-chain: `getAnalyticsForAddress(address, offset, limit)` and `getAnalyticsCount(address)`.
   - Added `getRelayerAddress()` read helper and fallback contract addresses for local dev.

3. **Page navigation & wallet UX**:
   - Added an **"Analytics Lab"** shortcut button on the main landing page.
   - Added MetaMask auto-reconnect on mount and event listeners for account/chain changes.

---

### How to test
1. Run `cd nextjs-frontend && npm run build` to verify there are zero TypeScript or build errors.
2. Search and purchase a test dataset on Sepolia — verify that the "Analyze This Dataset" button appears after decryption and opens the lab.
3. Query analytics records using `getAnalyticsForAddress` and verify on-chain responses work without reverts.
